### PR TITLE
Prevent project automation rate-limit storms

### DIFF
--- a/.github/workflows/project-maintenance.yml
+++ b/.github/workflows/project-maintenance.yml
@@ -2,12 +2,16 @@ name: Project 정합성 유지
 
 on:
   issues:
-    types: [opened, edited, labeled, unlabeled, closed, reopened, assigned, unassigned]
+    types: [opened, labeled, unlabeled, closed, reopened]
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, closed]
   workflow_dispatch:
   schedule:
     - cron: "17 15 * * *"
+
+concurrency:
+  group: project-maintenance
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -26,13 +30,24 @@ jobs:
         env:
           PROJECT_URL: ${{ vars.PROJECT_URL }}
           ADD_TO_PROJECT_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
         run: |
           if [ -z "${PROJECT_URL}" ] || [ -z "${ADD_TO_PROJECT_PAT}" ]; then
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             echo "PROJECT_URL 또는 ADD_TO_PROJECT_PAT가 없어 Project 정합성 유지를 건너뜁니다."
-          else
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          graphql_remaining="$(gh api rate_limit --jq '.resources.graphql.remaining // 0' 2>/dev/null || echo 0)"
+          graphql_reset="$(gh api rate_limit --jq '.resources.graphql.reset // 0' 2>/dev/null || echo 0)"
+          min_graphql_remaining=250
+          if [ "${graphql_remaining}" -lt "${min_graphql_remaining}" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::GitHub GraphQL rate limit remaining=${graphql_remaining}; Project 정합성 유지를 건너뜁니다. reset=${graphql_reset}"
+            exit 0
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
 
       - name: Project 상태 정렬
         if: steps.preflight.outputs.enabled == 'true'

--- a/.github/workflows/project-maintenance.yml
+++ b/.github/workflows/project-maintenance.yml
@@ -10,7 +10,7 @@ on:
     - cron: "17 15 * * *"
 
 concurrency:
-  group: project-maintenance
+  group: project-maintenance-${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -38,8 +38,14 @@ jobs:
             exit 0
           fi
 
-          graphql_remaining="$(gh api rate_limit --jq '.resources.graphql.remaining // 0' 2>/dev/null || echo 0)"
-          graphql_reset="$(gh api rate_limit --jq '.resources.graphql.reset // 0' 2>/dev/null || echo 0)"
+          if ! graphql_remaining="$(gh api rate_limit --jq '.resources.graphql.remaining')"; then
+            echo "::error::GitHub rate-limit probe failed. Check ADD_TO_PROJECT_PAT, network, and GitHub API availability."
+            exit 1
+          fi
+          if ! graphql_reset="$(gh api rate_limit --jq '.resources.graphql.reset')"; then
+            echo "::error::GitHub rate-limit reset probe failed. Check ADD_TO_PROJECT_PAT, network, and GitHub API availability."
+            exit 1
+          fi
           min_graphql_remaining=250
           if [ "${graphql_remaining}" -lt "${min_graphql_remaining}" ]; then
             echo "enabled=false" >> "$GITHUB_OUTPUT"

--- a/docs/automation-playbook.md
+++ b/docs/automation-playbook.md
@@ -52,6 +52,11 @@
 | `scripts/sync-project-board.sh` | 구현 | 이슈/PR 상태 라벨을 GitHub Project 상태로 반영 | `./scripts/sync-project-board.sh --apply` |
 | `scripts/package-submission.sh` | 구현 | 제출용 zip + `README.txt` 자동 생성 | `./scripts/package-submission.sh --team-number ...` |
 
+`Project 정합성 유지` 워크플로우는 이슈/PR 이벤트가 짧은 시간에 몰릴 때 중복 실행을 취소하고,
+GitHub GraphQL 잔여량이 낮으면 Project 정렬을 성공 상태로 건너뛴다. 이 경우 저장소나 Project
+데이터가 망가진 것이 아니라 외부 API 한도 보호가 동작한 것이므로, 다음 예약 실행 또는 수동
+`workflow_dispatch`에서 다시 정렬한다.
+
 ### 2-2. 저장소/구성 자동화
 | 항목 | 상태 | 목적 |
 | --- | --- | --- |

--- a/docs/automation-playbook.md
+++ b/docs/automation-playbook.md
@@ -52,10 +52,11 @@
 | `scripts/sync-project-board.sh` | 구현 | 이슈/PR 상태 라벨을 GitHub Project 상태로 반영 | `./scripts/sync-project-board.sh --apply` |
 | `scripts/package-submission.sh` | 구현 | 제출용 zip + `README.txt` 자동 생성 | `./scripts/package-submission.sh --team-number ...` |
 
-`Project 정합성 유지` 워크플로우는 이슈/PR 이벤트가 짧은 시간에 몰릴 때 중복 실행을 취소하고,
-GitHub GraphQL 잔여량이 낮으면 Project 정렬을 성공 상태로 건너뛴다. 이 경우 저장소나 Project
-데이터가 망가진 것이 아니라 외부 API 한도 보호가 동작한 것이므로, 다음 예약 실행 또는 수동
-`workflow_dispatch`에서 다시 정렬한다.
+`Project 정합성 유지` 워크플로우는 이슈/PR 이벤트가 짧은 시간에 몰릴 때 같은 기준선의 중복
+실행만 취소하고, GitHub GraphQL 잔여량이 낮으면 Project 정렬을 성공 상태로 건너뛴다. 이 경우
+저장소나 Project 데이터가 망가진 것이 아니라 외부 API 한도 보호가 동작한 것이므로, 다음 예약
+실행 또는 수동 `workflow_dispatch`에서 다시 정렬한다. 반대로 rate limit 조회 자체가 실패하면
+토큰/네트워크/API 문제일 수 있으므로 실패로 드러내고 조용히 건너뛰지 않는다.
 
 ### 2-2. 저장소/구성 자동화
 | 항목 | 상태 | 목적 |

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
@@ -55,6 +55,8 @@ class RepositoryConventionsSmokeTest {
                 new ScriptExpectation("scripts/open-pr.sh", "sync-project-board.sh"),
                 new ScriptExpectation(".github/workflows/gradle.yml", "test/**"),
                 new ScriptExpectation(".github/workflows/project-maintenance.yml", "synchronize"),
+                new ScriptExpectation(".github/workflows/project-maintenance.yml", "cancel-in-progress: true"),
+                new ScriptExpectation(".github/workflows/project-maintenance.yml", "min_graphql_remaining=250"),
                 new ScriptExpectation(".githooks/pre-commit", "docs/<issue>-<slug>"),
                 new ScriptExpectation("scripts/audit-project.sh", "project_maintenance.py audit"),
                 new ScriptExpectation("scripts/sync-project-board.sh", "project_maintenance.py sync-project")

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
@@ -56,7 +56,9 @@ class RepositoryConventionsSmokeTest {
                 new ScriptExpectation(".github/workflows/gradle.yml", "test/**"),
                 new ScriptExpectation(".github/workflows/project-maintenance.yml", "synchronize"),
                 new ScriptExpectation(".github/workflows/project-maintenance.yml", "cancel-in-progress: true"),
+                new ScriptExpectation(".github/workflows/project-maintenance.yml", "github.event_name == 'pull_request'"),
                 new ScriptExpectation(".github/workflows/project-maintenance.yml", "min_graphql_remaining=250"),
+                new ScriptExpectation(".github/workflows/project-maintenance.yml", "GitHub rate-limit probe failed"),
                 new ScriptExpectation(".githooks/pre-commit", "docs/<issue>-<slug>"),
                 new ScriptExpectation("scripts/audit-project.sh", "project_maintenance.py audit"),
                 new ScriptExpectation("scripts/sync-project-board.sh", "project_maintenance.py sync-project")


### PR DESCRIPTION
## Summary
- narrow Project maintenance issue triggers to status-affecting events
- cancel duplicate Project maintenance runs in bursts
- skip GraphQL-heavy Project sync when the GitHub GraphQL quota is already low
- document the rate-limit guard and cover it in repository smoke tests

## Verification
- ./gradlew check
- ./scripts/audit-project.sh --local-only --quiet
- bash -n scripts/*.sh
- python3 -m py_compile scripts/lib/project_maintenance.py
- ruby YAML parse for .github/workflows/project-maintenance.yml
- git diff --check

## Notes
Current full remote audit is blocked by GitHub GraphQL rate limit exhaustion; the workflow now treats that condition as a guarded skip instead of a failing run.