### PR TITLE
docs: 도메인 모델, SSD, Operation Contract 초안 작성

### DIFF
--- a/docs/requirements-traceability.md
+++ b/docs/requirements-traceability.md
@@ -65,6 +65,6 @@
 - Reporter는 assigned 전까지만 자신이 등록한 이슈의 title/description을 수정할 수 있고, assigned 이후 정정은 comment로 남깁니다.
 - Priority는 PL만 변경할 수 있으며, assigned 상태와 무관하게 변경 가능합니다.
 - Dev가 fixed 처리한 이슈를 Tester가 검증 실패하면 `fixed -> assigned`로 되돌릴 수 있습니다.
-- Reopen은 PL만 수행하며, reopen 전이 시 마지막 fixer, resolver값을 기준으로 assignee와 verifier에 각각 재할당합니다. 이후 PL이 필요하면 assignee/verifier를 재지정해 assigned 상태부터 재작업을 시작합니다.
+- Reopen은 PL만 수행하며, reopen 전이 시 마지막 fixer, resolver값을 기준으로 assignee와 verifier에 재지정할 수도 있습니다. 이후 PL이 필요하면 assignee/verifier를 재지정해 assigned 상태부터 재작업을 시작합니다.
 - 불필요한 이슈는 `deleted` 상태로 soft-delete하고, deleted 이슈가 30개를 초과하면 deleted 전이 시각 기준 FIFO로 오래된 이슈부터 물리 삭제합니다.
 - 이슈 dependency 관계는 구조화된 기능으로 추가합니다.

--- a/docs/requirements-traceability.md
+++ b/docs/requirements-traceability.md
@@ -65,6 +65,6 @@
 - Reporter는 assigned 전까지만 자신이 등록한 이슈의 title/description을 수정할 수 있고, assigned 이후 정정은 comment로 남깁니다.
 - Priority는 PL만 변경할 수 있으며, assigned 상태와 무관하게 변경 가능합니다.
 - Dev가 fixed 처리한 이슈를 Tester가 검증 실패하면 `fixed -> assigned`로 되돌릴 수 있습니다.
-- Reopen은 PL만 수행하며, reopen 전이 시 마지막 fixer, resolver값을 기준으로 assignee와 verifier를 복원합니다. 이후 PL이 필요하면 assignee/verifier를 재지정해 assigned 상태부터 재작업을 시작합니다.
+- Reopen은 PL만 수행하며, reopen 전이 시 마지막 fixer, resolver값을 기준으로 assignee와 verifier에 각각 재할당합니다. 이후 PL이 필요하면 assignee/verifier를 재지정해 assigned 상태부터 재작업을 시작합니다.
 - 불필요한 이슈는 `deleted` 상태로 soft-delete하고, deleted 이슈가 30개를 초과하면 deleted 전이 시각 기준 FIFO로 오래된 이슈부터 물리 삭제합니다.
 - 이슈 dependency 관계는 구조화된 기능으로 추가합니다.

--- a/docs/uml/sd/SD_README.md
+++ b/docs/uml/sd/SD_README.md
@@ -1,0 +1,82 @@
+# Detailed Sequence Diagram 작성 기준
+
+이 폴더의 SD는 Larman 스타일의 Detailed Sequence Diagram을 기준으로 작성한다.
+
+## 기본 방향
+
+- UC1 Register Issue Detailed SD를 작성 기준선으로 삼는다.
+- SSD의 system operation을 첫 메시지로 삼는다.
+- 첫 non-UI 수신 객체는 logical architecture의 Use Case Controller를 사용한다.
+  - 예: `:IssueController`, `:AssignmentController`, `:IssueStateController`, `:DeletedIssueController`
+- SD의 중심은 UI/DB 호출 흐름이 아니라 도메인 객체 사이의 책임 협력이다.
+- UI, 권한 정책, 인증, 현재 시각, repository, persistence는 핵심 책임이 아닌 경우 lifeline으로 펼치지 않고 note 또는 guard로만 표현한다.
+- Operation Contract의 postcondition은 도메인 객체 메시지로 실현한다.
+- Domain Model의 association과 enum/value type을 객체 책임 배정의 근거로 사용한다.
+- GRASP 패턴은 객체 선택의 근거로 둔다.
+- SD가 너무 구현 흐름 위주로 복잡해지거나, 반대로 OC 사후조건을 확인하기 어려울 만큼 단순해지지 않도록 조정한다.
+- 제출용 가독성을 위해 핵심 객체 책임, 생성, association 형성, 상태/속성 변경만 선명하게 남기고 보조 서비스는 필요한 경우 note로 축약한다.
+
+## 산출물 우선순위
+
+SD 작성 시 다음 artifact를 최우선 근거로 사용한다.
+
+1. UC 명세: actor, precondition, main flow, alternative flow, postcondition, include/extend 확인
+2. SSD: system operation, actor-system 메시지, 응답 메시지 확인
+3. Operation Contract: instance 생성/삭제, association 형성/붕괴, 속성값 변경 확인
+4. 기본 가정사항: 상태 전이, 권한, 자동 필드, 삭제/복구/reopen 정책 확인
+5. Domain Model: 책임을 맡을 도메인 객체, association, enum/value type 확인
+6. Logical Architecture: system operation을 받을 controller와 MVC/Application Layer 경계 확인
+
+## GRASP 적용 기준
+
+- Controller: SSD system operation을 받는 non-UI 객체.
+- Creator: 새 객체를 포함하거나 밀접하게 사용하는 도메인 객체가 생성 책임을 가진다.
+- Information Expert: 상태, association, 이력 기록에 필요한 정보를 가진 객체가 해당 책임을 가진다.
+- Low Coupling / High Cohesion: Controller가 도메인 속성을 직접 조작하지 않고 도메인 객체에 의도를 전달한다.
+- Pure Fabrication / Indirection: repository, policy, clock 같은 기술/정책 객체는 설계 설명에는 남기되, 제출용 SD에서는 필요할 때만 note로 축약한다.
+
+## 작성 순서
+
+1. SSD에서 system operation과 actor 응답을 확인한다.
+2. Operation Contract에서 instance 생성/삭제, association 형성/붕괴, 속성 변경을 확인한다.
+3. Domain Model에서 책임을 맡을 객체와 association을 확인한다.
+4. Logical Architecture에서 어떤 Controller가 system operation을 받을지 확인한다.
+5. SD에서는 Controller가 흐름을 시작하고, 실제 postcondition은 도메인 객체 메시지로 표현한다.
+6. UC의 optional/alternative 흐름은 `alt`, `opt`, `ref` frame으로 표현한다.
+
+## 표기 규칙
+
+- lifeline 이름은 가능하면 `objectName:ClassName` 또는 `:ClassName` 형식을 사용한다.
+- 상호작용 파트너는 사각형 머리의 `participant`로 표현한다. `control`, `entity` 아이콘 표기는 사용하지 않는다.
+- lifeline head 안에는 roleName을 반드시 적는다. Class가 명확하면 `roleName:ClassName`으로 적고, 명확하지 않으면 roleName만 적는다.
+- `Controller`, `Issue Controller`처럼 일반 역할명만 적는 표현은 피한다.
+- 현재 logical architecture에 있는 컨트롤러를 사용할 때는 `issueController:IssueController`, `assignmentController:AssignmentController`, `issueStateController:IssueStateController`, `deletedIssueController:DeletedIssueController`처럼 repo의 클래스명과 연결되는 이름을 사용한다.
+- PlantUML의 `control`, `entity` 키워드는 UML 역할을 직관적으로 보여주지만 아이콘 lifeline을 만들 수 있으므로, 강의자료 notation을 맞출 때는 `participant`로 작성하고 roleName/ClassName 및 note로 의미를 드러낸다.
+- 동기 메시지는 `->`로 표현한다. 렌더링 결과가 속이 찬 검은 화살표로 보여야 한다.
+- 비동기 메시지는 `->>`로 표현한다. 렌더링 결과가 꺾쇠 모양 화살표로 보여야 한다.
+- 응답 메시지는 `-->`로 표현한다. 렌더링 결과가 점선 꺾쇠 모양 화살표로 보여야 한다.
+- 새로 생성되는 객체는 `create "roleName:ClassName" as Alias` 다음에 `creator --> Alias : new`를 사용한다. 생성 메시지는 생성될 객체의 lifeline head를 향하는 점선 `new` 화살표로 보여야 한다.
+- 다른 UC로 이어지는 선택 흐름은 `ref` frame으로 표현한다.
+- 도메인 책임의 근거가 중요한 경우 note에 GRASP 근거 또는 OC postcondition을 짧게 적는다.
+
+## 작성된 SD 목록
+
+파일은 세부 폴더에 나누어 둔다.
+
+- PUML: `sd_puml/`
+- PNG: `sd_img/`
+- GRASP 설명: `sd_grasp/`
+
+| SD | PUML | PNG | GRASP 설명 |
+| --- | --- | --- | --- |
+| UC1 Register Issue | `sd_puml/sd-01-register-issue-detailed.puml` | `sd_img/sd-01-register-issue-detailed.png` | `sd_grasp/sd-01-register-issue-grasp.txt` |
+| UC5 Assign Issue | `sd_puml/sd-05-assign-issue-detailed.puml` | `sd_img/sd-05-assign-issue-detailed.png` | `sd_grasp/sd-05-assign-issue-grasp.txt` |
+| UC6 Mark Fixed | `sd_puml/sd-06-mark-fixed-detailed.puml` | `sd_img/sd-06-mark-fixed-detailed.png` | `sd_grasp/sd-06-mark-fixed-grasp.txt` |
+| UC6 Resolve Fixed Issue | `sd_puml/sd-07-resolve-fixed-issue-detailed.puml` | `sd_img/sd-07-resolve-fixed-issue-detailed.png` | `sd_grasp/sd-07-resolve-fixed-issue-grasp.txt` |
+| UC6 Reject Fix | `sd_puml/sd-08-reject-fix-detailed.puml` | `sd_img/sd-08-reject-fix-detailed.png` | `sd_grasp/sd-08-reject-fix-grasp.txt` |
+| UC6 Close Issue | `sd_puml/sd-09-close-issue-detailed.puml` | `sd_img/sd-09-close-issue-detailed.png` | `sd_grasp/sd-09-close-issue-grasp.txt` |
+| UC6 Reopen Issue | `sd_puml/sd-10-reopen-issue-detailed.puml` | `sd_img/sd-10-reopen-issue-detailed.png` | `sd_grasp/sd-10-reopen-issue-grasp.txt` |
+| UC9 Delete Issue | `sd_puml/sd-12-delete-issue-detailed.puml` | `sd_img/sd-12-delete-issue-detailed.png` | `sd_grasp/sd-12-delete-issue-grasp.txt` |
+| UC7 Add Dependency | `sd_puml/sd-24-add-dependency-detailed.puml` | `sd_img/sd-24-add-dependency-detailed.png` | `sd_grasp/sd-24-add-dependency-grasp.txt` |
+| UC9 Restore Deleted Issue | `sd_puml/sd-26-restore-deleted-issue-detailed.puml` | `sd_img/sd-26-restore-deleted-issue-detailed.png` | `sd_grasp/sd-26-restore-deleted-issue-grasp.txt` |
+| UC16 Change Priority | `sd_puml/sd-27-change-priority-detailed.puml` | `sd_img/sd-27-change-priority-detailed.png` | `sd_grasp/sd-27-change-priority-grasp.txt` |

--- a/docs/uml/sd/_shared/its-uml-style.puml
+++ b/docs/uml/sd/_shared/its-uml-style.puml
@@ -1,0 +1,58 @@
+' Shared visual language for ITS SD artifacts.
+' Keep diagram-specific PUML files focused on interaction content.
+
+skinparam shadowing false
+skinparam backgroundColor #FFFFFF
+skinparam dpi 170
+skinparam defaultFontName "Noto Sans CJK KR"
+skinparam defaultFontSize 14
+skinparam defaultFontColor #263238
+
+skinparam TitleFontName "Noto Sans CJK KR"
+skinparam TitleFontSize 24
+skinparam TitleFontStyle bold
+skinparam TitleFontColor #1F2937
+
+skinparam linetype polyline
+skinparam nodesep 45
+skinparam ranksep 50
+skinparam ArrowColor #263238
+skinparam ArrowThickness 1.2
+
+skinparam sequence {
+  ArrowColor #000000
+  ArrowThickness 1.4
+  LifeLineBorderColor #7E57C2
+  LifeLineBackgroundColor #FFFFFF
+  ParticipantBorderColor #B39DDB
+  ParticipantBackgroundColor #F3E5F5
+  ActorBorderColor #7E57C2
+  ActorBackgroundColor #FFFFFF
+}
+
+skinparam packageStyle rectangle
+skinparam rectangle {
+  BorderColor #90A4AE
+  BackgroundColor #F8FAFC
+  FontColor #263238
+  FontStyle bold
+}
+
+skinparam package {
+  BorderColor #90A4AE
+  BackgroundColor #F8FAFC
+  FontColor #263238
+  FontStyle bold
+}
+
+skinparam note {
+  BackgroundColor #FFF8E1
+  BorderColor #8D6E63
+  FontColor #263238
+}
+
+skinparam legend {
+  BackgroundColor #F8FAFC
+  BorderColor #90A4AE
+  FontColor #263238
+}

--- a/docs/uml/sd/sd_grasp/sd-01-register-issue-grasp.txt
+++ b/docs/uml/sd/sd_grasp/sd-01-register-issue-grasp.txt
@@ -16,7 +16,7 @@ issueController:IssueController가 SSD의 system operation registerIssue(...)를
 currentProject:Project가 newIssue:Issue를 생성한다. Domain Model에서 Project가 Issue를 contains 하므로, Project.registerIssue 내부에서 새 Issue 생성, Project-Issue contains 등록, 초기 생성 이력 기록 흐름을 하나의 원자적 도메인 작업으로 묶는 것이 자연스럽다.
 
 3. Information Expert
-currentProject:Project는 자신이 포함할 Issue 목록을 알고 있으므로 등록 책임을 맡는다. newIssue:Issue는 자신의 status, priority, reportedDate, reporter, history 목록을 관리하므로 Project.registerIssue 내부에서 recordCreation(...) 요청을 받아 IssueHistory(CREATED)를 생성하고 addHistory를 수행한다.
+currentProject:Project는 자신이 포함할 Issue 목록을 알고 있으므로 등록 책임을 맡는다. newIssue:Issue는 자신의 status, priority, reportedDate, reporter, history 목록을 관리하므로 createWithDefaultPriority(...)에서 누락된 priority를 MAJOR로 해석하고, Project.registerIssue 내부에서 recordCreation(...) 요청을 받아 IssueHistory(CREATED)를 생성하고 addHistory를 수행한다.
 
 4. Low Coupling / High Cohesion
 issueController가 Issue의 내부 필드를 직접 설정하지 않고 Project.registerIssue(...)에 의도를 전달한다. priority 기본값 결정과 초기 history 기록이 Controller 밖으로 이동했기 때문에 Controller와 도메인 모델 사이의 결합도가 낮아지고, 이슈 등록 불변식이 도메인 작업 안에 응집된다.

--- a/docs/uml/sd/sd_grasp/sd-05-assign-issue-grasp.txt
+++ b/docs/uml/sd/sd_grasp/sd-05-assign-issue-grasp.txt
@@ -1,0 +1,50 @@
+SD 05 Assign / Update Issue Assignment - GRASP 적용 설명
+
+관련 산출물:
+- UC5 Assign / Update Issue Assignment: PL이 상태별로 이슈 배정 정보를 생성하거나 갱신
+- SSD 05: startAssignment(issueId), assignIssue(issueId, assigneeId, verifierId), reassignIssue(issueId, assigneeId), changeVerifier(issueId, verifierId)
+- OC-03: NEW -> ASSIGNED, assignee/verifier 설정, ASSIGNMENT_CHANGED 및 STATUS_CHANGED 기록
+- OC-04: ASSIGNED -> ASSIGNED, assignee만 변경, status 유지, ASSIGNMENT_CHANGED만 기록
+- OC-05: FIXED -> FIXED, verifier만 변경, status 유지, ASSIGNMENT_CHANGED만 기록
+- OC-12: REOPENED -> ASSIGNED, assignee/verifier 재설정, fixer/resolver 보존, ASSIGNMENT_CHANGED 및 STATUS_CHANGED 기록
+- UC2 Add Comment: UC5에서 배정 관련 comment를 선택적으로 추가할 수 있음
+- Logical Architecture: AssignmentController, AssignmentRecommendationService
+
+적용 GRASP:
+
+1. Controller
+assignmentController:AssignmentController가 UC5의 system operation을 수신한다. startAssignment, assignIssue, reassignIssue, changeVerifier 흐름을 조정하지만 assignee/verifier/status를 직접 조작하지 않는다. 권한 또는 상태가 유효하지 않은 경우에는 후보 추천으로 내려가지 않고 먼저 assignmentRejected(reason)을 반환한다.
+
+2. Information Expert
+targetIssue:Issue는 현재 status, assignee, verifier, fixer, resolver, history를 알고 있으므로 상태별 배정 변경 책임을 맡는다. NEW/REOPENED 배정, ASSIGNED 재배정, FIXED verifier 변경은 모두 Issue의 role relation과 상태 불변식을 사용한다.
+
+3. Creator
+assignmentHistory와 statusHistory는 targetIssue에 종속되어 logs association으로 연결된다. 따라서 targetIssue가 IssueHistory를 생성하고 자신의 history 목록에 추가한다.
+
+4. Low Coupling / High Cohesion
+AssignmentController는 상태별 의도 메시지(assignFromNew, assignReopened, reassignAssignee, changeVerifier)를 전달한다. 실제 association 형성/제거, status 변경 또는 유지, history 기록은 targetIssue 안에 응집된다.
+
+5. Pure Fabrication
+AssignmentRecommendationService는 후보 추천 규칙을 모으는 서비스 객체이다. 다만 SD-05에서는 네 branch가 한 PNG에서 보이도록 UC8 후보 추천 상세를 ref frame으로 접었다. UC8 후보 추천은 권한/상태 rejection 이후 각 valid status branch 내부에서만 수행된다. 상태별 후보 반환도 branch 내부에서 분리해 표현한다. NEW/REOPENED는 Dev assignee 후보와 Tester verifier 후보를 모두 반환하고, ASSIGNED는 Dev assignee 후보만, FIXED는 Tester verifier 후보만 반환한다.
+
+6. Protected Variations
+UC8 후보 추천 규칙과 상태별 배정 정책은 서로 다른 변경 축이다. 추천은 AssignmentRecommendationService 뒤에 숨기고, 상태별 사후조건은 Issue의 메서드로 분기하여 정책 변경 영향을 줄인다.
+
+7. Information Expert - 상태별 불변식
+OC-04는 verifier/fixer/resolver 유지, OC-05는 assignee/fixer/resolver 유지, OC-12는 fixer/resolver 보존을 명시한다. 이 association들의 현재 값을 알고 있는 객체가 Issue이므로, 변경하지 않아야 하는 책임도 Issue에 둔다.
+
+8. Artifact 정합성
+SD-05는 UC5 대표 SD이므로 SSD 05의 네 branch와 OC-03/04/05/12를 모두 반영한다.
+반영된 branch는 다음과 같다.
+- ASSIGNED -> ASSIGNED: reassignIssue(issueId, assigneeId), status 유지, ASSIGNMENT_CHANGED only, verifier/fixer/resolver 변경 없음
+- FIXED -> FIXED: changeVerifier(issueId, verifierId), status 유지, ASSIGNMENT_CHANGED only, assignee/fixer/resolver 변경 없음
+- NEW -> ASSIGNED: assignIssue(issueId, assigneeId, verifierId), ASSIGNMENT_CHANGED + STATUS_CHANGED
+- REOPENED -> ASSIGNED: assignIssue(issueId, assigneeId, verifierId), ASSIGNMENT_CHANGED + STATUS_CHANGED, fixer/resolver 보존
+
+주의:
+ASSIGNED -> ASSIGNED와 FIXED -> FIXED는 상태 전이가 아니므로 STATUS_CHANGED history를 만들지 않는다.
+기존 status는 각각 ASSIGNED, FIXED로 유지되며, 변경된 배정 정보만 IssueHistory(actionType=ASSIGNMENT_CHANGED)에 기록한다.
+모든 UC5 IssueHistory 생성 메시지는 changedDate=now를 포함한다.
+UC2 Add Comment는 UC5의 선택적 extension 흐름이므로 opt/ref fragment로 별도 표시한다.
+권한/상태 rejection은 후보 추천보다 먼저 처리한다.
+PNG 가독성을 위해 네 branch의 내부 메시지를 압축하고, branch summary note를 상단에 배치했다.

--- a/docs/uml/sd/sd_grasp/sd-06-mark-fixed-grasp.txt
+++ b/docs/uml/sd/sd_grasp/sd-06-mark-fixed-grasp.txt
@@ -1,0 +1,25 @@
+SD 06 Mark Issue as Fixed - GRASP 적용 설명
+
+관련 산출물:
+- UC6 Change Issue State: DEV assignee가 ASSIGNED -> FIXED 전이를 수행하고 사유 comment를 필수 입력
+- SSD 06: changeStatus(issueId, targetStatus=FIXED, comment)
+- OC-06: Comment 생성, COMMENTED history 생성, fixer=current DEV, status=FIXED, STATUS_CHANGED history 생성
+- 기본 가정사항: ASSIGNED -> FIXED에서 fixer가 설정되고 상태 변경 이력과 의미상 일치해야 함
+- Logical Architecture: IssueStateController.changeStatus()
+
+적용 GRASP:
+
+1. Controller
+issueStateController:IssueStateController가 상태 변경 system operation을 수신한다. 상태 전이 흐름을 조정하지만 Issue의 필드를 직접 set하지 않는다.
+
+2. Information Expert
+targetIssue:Issue가 현재 status, assignee, fixer, comment 목록, history 목록을 알고 있으므로 markFixed(...) 메시지를 통해 상태 변경과 이력 기록을 수행한다.
+
+3. Creator
+Comment와 IssueHistory는 모두 특정 Issue에 소속된다. 따라서 targetIssue가 fixComment, commentHistory, statusHistory를 생성하고 자신의 collection에 추가한다.
+
+4. Low Coupling / High Cohesion
+Controller는 markFixed(currentDev, comment, now)라는 의도 중심 메시지만 보낸다. Comment 생성, fixer 기록, status 변경, history 기록이 Issue 내부 책임으로 모여 cohesion을 유지한다.
+
+5. Information Expert 보강
+currentDev가 fixer라는 사실은 Issue의 상태 전이 규칙과 assignee 관계에 의존한다. Issue가 해당 정보를 검증하고 fixer association을 갱신하는 것이 적절하다.

--- a/docs/uml/sd/sd_grasp/sd-07-resolve-fixed-issue-grasp.txt
+++ b/docs/uml/sd/sd_grasp/sd-07-resolve-fixed-issue-grasp.txt
@@ -1,0 +1,29 @@
+SD 07 Resolve Fixed Issue - GRASP 적용 설명
+
+관련 산출물:
+- UC6 Change Issue State: Tester verifier가 FIXED -> RESOLVED 전이를 수행하고 사유 comment를 필수 입력
+- SSD 07: changeStatus(issueId, targetStatus=RESOLVED, comment)
+- OC-07: resolver=currentTester, assignee/verifier/fixer 유지, Comment/COMMENTED history, STATUS_CHANGED history
+- 기본 가정사항: 모든 blocking issue가 RESOLVED 또는 CLOSED일 때만 resolve 허용, BLOCK/BLOCKED 상태는 도입하지 않음
+- Domain Model: IssueDependency는 blockingIssue/blockedIssue association으로 방향을 표현
+
+적용 GRASP:
+
+1. Controller
+issueStateController:IssueStateController가 changeStatus(...RESOLVED...)를 수신하고 전이 흐름을 시작한다.
+
+2. Information Expert
+targetIssue:Issue는 자신의 status, verifier, resolver, dependency, history를 알고 있으므로 checkResolvePreconditions와 resolve 책임을 맡는다.
+
+3. Information Expert - dependency guard
+FIXED -> RESOLVED 가능 여부는 targetIssue와 연결된 blockingIssue들의 상태에 달려 있다. 따라서 targetIssue가 blockingIssue에게 isResolvedOrClosed()를 물어 guard를 평가한다.
+Issue가 checkResolvePreconditions(currentTester, comment)를 통해 not verifier, status is not FIXED, comment is empty를 먼저 검사하고 resolveAllowed or reason을 Controller에 반환한다. 이 검증을 통과한 경우에만 unresolved blocking issue guard를 평가한다.
+
+4. Creator
+resolveComment, commentHistory, statusHistory는 targetIssue에 기록되는 객체들이므로 targetIssue가 생성한다.
+
+5. Low Coupling / High Cohesion
+Controller가 dependency 목록이나 status enum의 세부 규칙을 직접 순회하지 않고 targetIssue에 전이 가능성 확인을 위임한다. 이로써 상태 전이 규칙이 Issue에 응집된다.
+
+6. Protected Variations
+dependency 정책은 이후 확장될 수 있으므로 SD에서는 별도 IssueStatus를 만들지 않고 FIXED -> RESOLVED guard로 표현한다. 이는 기본 가정사항과 OC-07 정책을 안정적으로 반영한다.

--- a/docs/uml/sd/sd_grasp/sd-08-reject-fix-grasp.txt
+++ b/docs/uml/sd/sd_grasp/sd-08-reject-fix-grasp.txt
@@ -1,0 +1,28 @@
+SD 08 Reject Fix - GRASP 적용 설명
+
+관련 산출물:
+- UC6 Change Issue State: Tester verifier가 FIXED -> ASSIGNED 전이를 수행하고 거절 사유 comment를 필수 입력
+- SSD 08: changeStatus(issueId, targetStatus=ASSIGNED, comment)
+- OC-13: Comment 생성, COMMENTED history 생성, STATUS_CHANGED history 생성, status=ASSIGNED, 기존 assignee/verifier/fixer 유지
+- 기본 가정사항: 새 DEV로 교체하려면 PL이 UC5 reassignIssue를 별도로 수행
+- Logical Architecture: IssueStateController.changeStatus()
+
+적용 GRASP:
+
+1. Controller
+issueStateController:IssueStateController가 상태 변경 system operation을 수신한다. Controller는 흐름을 조정하되 Issue의 상태와 association을 직접 변경하지 않는다.
+
+2. Information Expert
+targetIssue:Issue는 현재 status, verifier, assignee, fixer, comment 목록, history 목록을 알고 있으므로 rejectFix(...)와 precondition 확인 책임을 맡는다.
+
+3. Creator
+rejectComment, commentHistory, statusHistory는 모두 targetIssue에 소속되어 기록되는 객체다. 따라서 targetIssue가 생성하고 자신의 collection에 추가한다.
+
+4. Low Coupling / High Cohesion
+Controller는 rejectFix(currentTester, comment, now)라는 의도 중심 메시지를 보낸다. Comment 생성, 이력 기록, 기존 assignee/verifier/fixer 유지, status 변경은 Issue 내부 책임으로 응집된다.
+
+5. Protected Variations
+FIXED -> ASSIGNED 이후 새 DEV 교체 여부는 UC5 reassignIssue 정책에 맡긴다. SD에서는 기존 association 유지와 상태 rollback만 표현해 상태 전이 정책 변경의 영향을 줄인다.
+
+6. Information Expert 보강
+IssueHistory.changedBy=currentTester가 Tester와 history의 changes association을 함께 의미하므로, 별도의 currentTester:User lifeline을 만들지 않고 생성 파라미터로 표현한다.

--- a/docs/uml/sd/sd_grasp/sd-09-close-issue-grasp.txt
+++ b/docs/uml/sd/sd_grasp/sd-09-close-issue-grasp.txt
@@ -1,0 +1,28 @@
+SD 09 Close Issue - GRASP 적용 설명
+
+관련 산출물:
+- UC6 Change Issue State: PL이 RESOLVED -> CLOSED 전이를 수행하고 종료 사유 comment를 필수 입력
+- SSD 09: changeStatus(issueId, targetStatus=CLOSED, comment)
+- OC-08: Comment 생성, COMMENTED history 생성, STATUS_CHANGED history 생성, status=CLOSED, assignee/verifier 제거, fixer/resolver 보존
+- 기본 가정사항: CLOSED는 최종 종료 상태이며 assignee와 verifier는 null로 제거
+- Logical Architecture: IssueStateController.changeStatus()
+
+적용 GRASP:
+
+1. Controller
+issueStateController:IssueStateController가 changeStatus(...CLOSED...)를 수신하고 close 흐름을 시작한다.
+
+2. Information Expert
+targetIssue:Issue는 자신의 현재 status, assignee, verifier, fixer, resolver, comment 목록, history 목록을 알고 있으므로 close(...) 책임을 맡는다.
+
+3. Creator
+closeComment, commentHistory, statusHistory는 targetIssue에 연결되어야 하는 객체들이므로 targetIssue가 생성하고 logs/has association을 형성한다.
+
+4. Low Coupling / High Cohesion
+Controller가 assignee/verifier 필드를 직접 null로 만들지 않고 targetIssue.close(...)에 위임한다. 최종 종료 전이, association 제거, 이력 기록이 Issue 내부에 응집된다.
+
+5. Information Expert - association management
+assignee/verifier 제거와 fixer/resolver 보존은 Issue가 보유한 role relation에 대한 변경이다. 따라서 Issue가 clearAssignee, clearVerifier, preserveFixerAndResolver 책임을 가진다.
+
+6. Information Expert 보강
+IssueHistory.changedBy=currentPL이 PL과 history의 changes association을 함께 의미하므로, 별도의 currentPL:User lifeline 없이 생성 메시지의 파라미터로 표현한다.

--- a/docs/uml/sd/sd_grasp/sd-10-reopen-issue-grasp.txt
+++ b/docs/uml/sd/sd_grasp/sd-10-reopen-issue-grasp.txt
@@ -1,0 +1,27 @@
+SD 10 Reopen Issue - GRASP 적용 설명
+
+관련 산출물:
+- UC6 Change Issue State: PL이 RESOLVED/CLOSED 이슈를 REOPENED로 전이
+- SSD 10: changeStatus(issueId, targetStatus=REOPENED, comment)
+- OC-09: Comment/COMMENTED history, STATUS_CHANGED history, fixer/resolver 보존, assignee/verifier 자동복원 없음
+- 기본 가정사항: reopen 후 PL이 필요하면 UC5로 assignee/verifier를 다시 결정
+
+적용 GRASP:
+
+1. Controller
+issueStateController:IssueStateController가 reopen system operation을 수신한다. UC6 상태 전이의 진입점으로서 권한/상태 전이 흐름을 조정한다.
+
+2. Information Expert
+targetIssue:Issue는 현재 status, assignee, verifier, fixer, resolver, comments, history를 알고 있으므로 verifyReopenPreconditions(...)와 reopen(...) 책임을 맡는다. Issue가 status, PL role, comment 필수 여부를 검증하고 reopenAllowed or reason을 Controller에 반환한 뒤, Controller는 그 결과로 alt 분기만 수행한다.
+
+3. Creator
+reopenComment, commentHistory, statusHistory는 targetIssue의 comment/history로 기록되므로 targetIssue가 생성한다.
+
+4. Low Coupling / High Cohesion
+Controller가 assignee/verifier/fixer/resolver 필드를 직접 조작하지 않고 reopen 메시지 하나로 의도를 전달한다. Issue는 assignee/verifier 제거와 fixer/resolver 보존 정책을 내부에서 처리한다.
+
+5. Protected Variations
+reopen 정책은 이전 문서에서 충돌이 있었던 변경 가능성이 큰 정책이다. SD는 "assignee/verifier 자동복원 없음, fixer/resolver 보존, 재배정은 UC5"를 note와 ref로 분리해 정책 변화를 명확히 격리한다.
+
+6. Indirection
+재작업 담당자 지정은 reopen SD 안에 섞지 않고 UC5 Assign Issue ref로 연결한다. 이렇게 하면 reopen 책임과 assignment 책임이 분리된다.

--- a/docs/uml/sd/sd_grasp/sd-12-delete-issue-grasp.txt
+++ b/docs/uml/sd/sd_grasp/sd-12-delete-issue-grasp.txt
@@ -1,0 +1,28 @@
+SD 12 Delete Issue - GRASP 적용 설명
+
+관련 산출물:
+- UC9 Manage Deleted Issue: PL이 NEW/CLOSED 이슈를 DELETED로 soft-delete
+- SSD 12: deleteIssue(issueId)
+- OC-10: status=DELETED, 관련 IssueDependency 제거, STATUS_CHANGED history, FIFO 30개 보관 정책
+- 기본 가정사항: deleted transition time은 IssueHistory.changedDate에서 결정, 삭제 dependency는 restore 시 자동 복원하지 않음
+- Logical Architecture: DeletedIssueController.deleteIssue()
+
+적용 GRASP:
+
+1. Controller
+deletedIssueController:DeletedIssueController가 UC9 deleteIssue system operation을 수신한다. 삭제/복구는 UC6 상태 변경과 구분되는 별도 PL 관리 목표이므로 전용 controller가 적절하다.
+
+2. Information Expert
+targetIssue:Issue는 자신의 status와 관련 dependency, history를 알고 있으므로 softDelete(...) 책임을 맡는다.
+
+3. Creator
+statusHistory는 targetIssue의 상태 변경 이력이므로 targetIssue가 생성하고 addHistory로 기록한다.
+
+4. Low Coupling / High Cohesion
+Controller가 dependency 제거, status 변경, history 생성의 세부 순서를 직접 수행하지 않고 targetIssue에 위임한다. 삭제 정책의 핵심 변경 책임이 Issue에 응집된다.
+
+5. 다이어그램 추상화 수준
+DELETED 이슈 30개 초과 FIFO 보관 정책은 Logical Architecture에서 별도 policy/service로 상세화할 수 있지만, 이 SD에서는 Larman식 주요 도메인 협력을 선명하게 유지하기 위해 lifeline으로 펼치지 않는다. 대신 deleted issue count가 30개를 초과하는 경우 DeletedIssueController 내부의 enforceDeletedLimit(max=30) 처리로 축약한다.
+
+6. Protected Variations
+FIFO 보관 한도나 물리 삭제 기준은 변경될 수 있으므로 삭제 상태 전이와 분리해 표현한다. SD 본문에서는 보관 한도 적용을 opt fragment로 분리하여, 삭제 도메인 작업과 보관 정책 변경 가능성이 과하게 결합하지 않도록 한다.

--- a/docs/uml/sd/sd_grasp/sd-24-add-dependency-grasp.txt
+++ b/docs/uml/sd/sd_grasp/sd-24-add-dependency-grasp.txt
@@ -1,0 +1,32 @@
+SD 24 Add Dependency - GRASP 적용 설명
+
+관련 산출물:
+- UC7 Manage Dependency: PL이 blocking issue와 blocked issue 사이의 구조화된 dependency를 추가
+- SSD 24: addDependency(blockingIssueId, blockedIssueId)
+- UC14 Check Permission: dependency 추가 전에 PL 권한을 검사
+- OC-14: IssueDependency 생성, blockingIssue/blockedIssue association 형성, DEPENDENCY_CHANGED history, Issue.status 변경 없음
+- 기본 가정사항: dependency는 FIXED -> RESOLVED guard로만 작동하고 BLOCK/BLOCKED 상태는 도입하지 않음
+- Domain Model: IssueDependency는 blocking Issue 1개와 blocked Issue 1개를 연결
+
+적용 GRASP:
+
+1. Controller
+issueController:IssueController가 addDependency system operation을 수신한다. Logical Architecture에서 dependency 관련 operation이 IssueController에 배치되어 있으므로 이 controller를 사용한다. UC14 권한 검사는 dependency 후보 검증보다 먼저 수행되며, not PL 또는 permission denied이면 도메인 검증으로 내려가지 않는다.
+
+2. Information Expert
+blockedIssue:Issue는 자신이 해결되기 전에 어떤 blockingIssue가 먼저 해결되어야 하는지를 기록해야 한다. 따라서 dependency 후보 검증과 addDependency 책임을 blockedIssue에 둔다.
+
+3. Information Expert - cycle guard
+순환 dependency 여부는 새 관계 blockingIssue -> blockedIssue를 추가했을 때 dependency graph에 cycle이 생기는지의 문제이다. 구현 의미로는 blockedIssue에서 blockingIssue로 이미 도달 가능한 경로가 있는지 확인하는 검사에 해당한다. 의미상 blockingIssue가 먼저 해결되어야 blockedIssue가 RESOLVED 될 수 있으므로, 검증 책임은 영향을 받는 blockedIssue에 둔다. SD에서는 방향이 모호한 경로 탐색 메시지 대신 blockedIssue가 rejectIfCycleWouldBeCreated(blockingIssue)를 수행하는 의미 중심 책임으로 표현한다.
+
+4. Creator
+IssueDependency는 blockedIssue와 blockingIssue를 연결하지만, 이 dependency의 효과는 blockedIssue의 resolve guard에 직접 작동한다. 따라서 blockedIssue가 newDependency를 생성하고 자신의 dependency 목록에 추가한다.
+
+5. Creator - history
+dependencyHistory는 blockedIssue에 기록되는 DEPENDENCY_CHANGED 이력이므로 blockedIssue가 생성한다.
+
+6. Low Coupling / High Cohesion
+Controller가 자기참조/중복/순환 검사 세부 로직과 history 생성을 직접 수행하지 않고 blockedIssue에 위임한다. dependency 규칙이 Issue 쪽에 응집된다.
+
+7. Protected Variations
+dependencyName/type을 두지 않고 association 방향으로 의미를 표현한다. dependency 정책이 확장되더라도 SD의 핵심 책임은 blockingIssue/blockedIssue/IssueDependency 협력 안에 유지된다.

--- a/docs/uml/sd/sd_grasp/sd-26-restore-deleted-issue-grasp.txt
+++ b/docs/uml/sd/sd_grasp/sd-26-restore-deleted-issue-grasp.txt
@@ -1,0 +1,28 @@
+SD 26 Restore Deleted Issue - GRASP 적용 설명
+
+관련 산출물:
+- UC9 Manage Deleted Issue: PL이 DELETED 이슈를 삭제 직전 상태 NEW 또는 CLOSED로 복구
+- SSD 26: viewDeletedIssues(projectId), restoreIssue(issueId)
+- OC-11: 기존 Issue를 복구, restoreTargetStatus는 delete history.previousValue에서 결정, assignee/verifier null 유지, dependency 자동 복원 없음
+- 기본 가정사항: 복구 대상 상태는 별도 Issue 속성이 아니라 delete history.previousValue에서 읽으며, 미존재/영구 삭제된 이슈는 복구할 수 없음
+- Logical Architecture: DeletedIssueController.restoreIssue()
+
+적용 GRASP:
+
+1. Controller
+deletedIssueController:DeletedIssueController가 deleted issue 목록 조회와 복구 system operation을 수신한다. 삭제/복구 관리 유스케이스의 조정자 역할을 맡는다. not PL, permission denied, issue not found, permanently deleted, Issue is not DELETED는 복구 대상 검증 단계에서 거부한다.
+
+2. Information Expert
+targetIssue:Issue는 자신의 history 목록을 알고 있으므로 findDeleteStatusHistory()를 통해 삭제 직전 상태를 찾는다.
+
+3. Information Expert - history
+deleteHistory:IssueHistory는 previousValue를 알고 있으므로 restoreTargetStatus를 제공한다. 이 값이 복구 대상 상태의 근거가 된다.
+
+4. Creator
+restoreHistory는 targetIssue의 상태 변경 이력이므로 targetIssue가 생성하고 addHistory로 기록한다.
+
+5. Low Coupling / High Cohesion
+Controller가 별도 복구용 상태 필드를 관리하지 않고 targetIssue와 deleteHistory에 책임을 위임한다. deleteHistory.previousValue에서 읽은 previousStatusFromDeleteHistory를 restoreTargetStatus라는 지역 값으로 표현해, history 기반 복구 정책이 도메인 객체 협력으로 드러난다.
+
+6. Protected Variations
+복구 정책에서 dependency 자동 복원 없음, assignee/verifier null 유지, reporter/fixer/resolver 보존을 note로 명확히 분리한다. 이후 정책 변경 시 restore(...) 내부 책임만 조정하면 된다.

--- a/docs/uml/sd/sd_grasp/sd-27-change-priority-grasp.txt
+++ b/docs/uml/sd/sd_grasp/sd-27-change-priority-grasp.txt
@@ -1,0 +1,28 @@
+SD 27 Change Priority - GRASP 적용 설명
+
+관련 산출물:
+- UC16 Change Priority: PL이 이슈 우선순위를 변경하며 UC14 권한 검사를 포함
+- SSD 27: changePriority(issueId, newPriority)
+- OC-16: Issue.priority 변경, PRIORITY_CHANGED history 생성, status 및 assignment 관련 association 유지
+- Domain Model: Issue는 Priority 값을 가지고 IssueHistory를 logs association으로 보유
+- Logical Architecture: IssueController.changePriority()
+
+적용 GRASP:
+
+1. Controller
+issueController:IssueController가 changePriority(issueId, newPriority)를 수신한다. 이는 Logical Architecture에서 changePriority가 IssueController 책임으로 배치되어 있기 때문이다. UC14 권한 검사는 도메인 priority 검증보다 먼저 수행되며, not PL 또는 permission denied이면 Issue 검증으로 내려가지 않는다.
+
+2. Information Expert
+targetIssue:Issue는 현재 priority와 status, role association, history 목록을 알고 있으므로 authorized PL 요청에 대해 priority 변경 가능 여부 확인과 changePriority(...) 책임을 맡는다.
+
+3. Creator
+priorityHistory:IssueHistory는 targetIssue의 priority 변경을 기록하고 targetIssue에 logs association으로 연결된다. 따라서 targetIssue가 생성 책임을 갖는다.
+
+4. Low Coupling / High Cohesion
+Controller는 priority 값을 직접 비교하거나 history를 직접 만들지 않고 targetIssue에 의도 중심 메시지를 보낸다. priority 변경과 이력 기록이 Issue 내부 책임으로 응집된다.
+
+5. Information Expert - invariant 유지
+OC-16은 status 및 assigned to/verifies/fixes/resolves association이 변경되지 않는다고 명시한다. Issue가 자신의 상태와 role relation을 알고 있으므로 변경하지 않는 책임도 Issue가 가진다.
+
+6. Information Expert 보강
+IssueHistory.changedBy=currentPL이 PL과 history의 changes association을 함께 의미하므로, 별도 currentPL:User lifeline 없이 생성 파라미터로 표현한다.

--- a/docs/uml/sd/sd_puml/sd-01-register-issue-detailed.puml
+++ b/docs/uml/sd/sd_puml/sd-01-register-issue-detailed.puml
@@ -4,17 +4,6 @@
 title Detailed SD 01 - Register Issue
 hide footbox
 
-skinparam sequence {
-  ArrowColor #000000
-  ArrowThickness 1.4
-  LifeLineBorderColor #7E57C2
-  LifeLineBackgroundColor #FFFFFF
-  ParticipantBorderColor #B39DDB
-  ParticipantBackgroundColor #F3E5F5
-  ActorBorderColor #7E57C2
-  ActorBackgroundColor #FFFFFF
-}
-
 actor "Auth User" as User
 participant "issueController:IssueController" as IC
 participant "currentProject:Project" as Project
@@ -35,15 +24,14 @@ else valid and authorized
 
   IC -> Project : registerIssue(title, description, priority,\ncurrentUser, now)
   activate Project
-  Project -> Project : priorityOrMajor := defaultIfMissing(priority, MAJOR)
 
   create "newIssue:Issue" as Issue
-  Project -> Issue : new(title, description, priorityOrMajor,\nstatus=NEW, reporter=currentUser,\nreportedDate=now)
+  Project --> Issue : createWithDefaultPriority(title, description, priority,\nstatus=NEW, reporter=currentUser,\nreportedDate=now)
   activate Issue
 
   Project -> Issue : recordCreation(currentUser, now)
   create "createdHistory:IssueHistory" as CreatedHistory
-  Issue -> CreatedHistory : new(action=CREATED,\npreviousValue=null,\nnewValue=NEW,\nchangedBy=currentUser,\nchangedDate=now)
+  Issue --> CreatedHistory : new(action=CREATED,\npreviousValue=null,\nnewValue=NEW,\nchangedBy=currentUser,\nchangedDate=now)
   Issue -> Issue : addHistory(createdHistory)
 
   note right of Issue
@@ -66,8 +54,8 @@ else valid and authorized
 
   note over Project
   Creator / Information Expert:
-  Project.registerIssue는 priority 기본값 결정,
-  Issue 생성, CREATED history 기록, contains 등록을
+  Project.registerIssue는 Issue 생성,
+  priority 기본값 적용, CREATED history 기록, contains 등록을
   하나의 원자적 도메인 작업으로 캡슐화한다.
   end note
 

--- a/docs/uml/sd/sd_puml/sd-05-assign-issue-detailed.puml
+++ b/docs/uml/sd/sd_puml/sd-05-assign-issue-detailed.puml
@@ -1,0 +1,132 @@
+@startuml sd-05-assign-issue-detailed
+!include ../_shared/its-uml-style.puml
+
+title Detailed SD 05 - Assign / Update Issue Assignment
+scale 0.58
+hide footbox
+
+actor "PL" as PL
+participant "assignmentController:AssignmentController" as AC
+participant "targetIssue:Issue" as Issue
+
+PL -> AC : startAssignment(issueId)
+AC -> Issue : getAssignmentContext()
+Issue --> AC : status, currentAssignee,\ncurrentVerifier, fixer, resolver
+
+note over AC, Issue
+UC5 branch summary:
+NEW -> ASSIGNED: assignIssue + ASSIGNMENT_CHANGED + STATUS_CHANGED
+REOPENED -> ASSIGNED: assignIssue + ASSIGNMENT_CHANGED + STATUS_CHANGED
+ASSIGNED -> ASSIGNED: reassignIssue + ASSIGNMENT_CHANGED only
+FIXED -> FIXED: changeVerifier + ASSIGNMENT_CHANGED only
+end note
+
+alt invalid status or permission denied
+  AC --> PL : assignmentRejected(reason)
+else Issue.status == NEW
+  ref over PL, AC
+  UC8 Recommend Assignment Candidates
+  recommendAssignmentCandidates(issueId, status=NEW)
+  end ref
+
+  AC --> PL : assignmentOptions(devList, testerList,\nassigneeCandidates, verifierCandidates)
+  PL -> AC : assignIssue(issueId, assigneeId, verifierId)
+  AC -> Issue : assignFromNew(assigneeId, verifierId,\nchangedBy=currentPL, now)
+  activate Issue
+  Issue -> Issue : setAssigneeAndVerifier();\nchangeStatus(ASSIGNED)
+
+  create "assignmentHistory:IssueHistory" as NewAH
+  Issue -> NewAH : new(action=ASSIGNMENT_CHANGED,\nnewValue=assigneeId/verifierId,\nchangedBy=currentPL,\nchangedDate=now)
+  create "statusHistory:IssueHistory" as NewSH
+  Issue -> NewSH : new(action=STATUS_CHANGED,\npreviousValue=NEW,\nnewValue=ASSIGNED,\nchangedBy=currentPL,\nchangedDate=now)
+  Issue -> Issue : addHistory(assignmentHistory)
+  Issue -> Issue : addHistory(statusHistory)
+
+  Issue --> AC : assignmentResult(status=ASSIGNED)
+  deactivate Issue
+  AC --> PL : issueAssigned(issueId, status=ASSIGNED)
+else Issue.status == REOPENED
+  ref over PL, AC
+  UC8 Recommend Assignment Candidates
+  recommendAssignmentCandidates(issueId, status=REOPENED)
+  end ref
+
+  AC --> PL : assignmentOptions(devList, testerList,\nassigneeCandidates, verifierCandidates)
+  PL -> AC : assignIssue(issueId, assigneeId, verifierId)
+  AC -> Issue : assignReopened(assigneeId, verifierId,\nchangedBy=currentPL, now)
+  activate Issue
+  Issue -> Issue : replaceAssigneeAndVerifier();\npreserveFixerAndResolver();\nchangeStatus(ASSIGNED)
+
+  create "assignmentHistory:IssueHistory" as ReopenedAH
+  Issue -> ReopenedAH : new(action=ASSIGNMENT_CHANGED,\nnewValue=assigneeId/verifierId,\nchangedBy=currentPL,\nchangedDate=now)
+  create "statusHistory:IssueHistory" as ReopenedSH
+  Issue -> ReopenedSH : new(action=STATUS_CHANGED,\npreviousValue=REOPENED,\nnewValue=ASSIGNED,\nchangedBy=currentPL,\nchangedDate=now)
+  Issue -> Issue : addHistory(assignmentHistory)
+  Issue -> Issue : addHistory(statusHistory)
+
+  Issue --> AC : assignmentResult(status=ASSIGNED,\nfixer/resolver=retained)
+  deactivate Issue
+  AC --> PL : issueAssigned(issueId, status=ASSIGNED)
+else Issue.status == ASSIGNED
+  ref over PL, AC
+  UC8 Recommend Assignment Candidates
+  recommendAssignmentCandidates(issueId, status=ASSIGNED)
+  end ref
+
+  AC --> PL : reassignmentOptions(devList,\ncurrentAssignee, assigneeCandidates)
+  PL -> AC : reassignIssue(issueId, assigneeId)
+  AC -> Issue : reassignAssignee(assigneeId,\nchangedBy=currentPL, now)
+  activate Issue
+  Issue -> Issue : oldAssignee := currentAssignee()
+  Issue -> Issue : replaceAssignee(assigneeId);\nkeepStatus(ASSIGNED);\nkeepVerifierFixerResolver()
+
+  create "assignmentHistory:IssueHistory" as ReassignAH
+  Issue -> ReassignAH : new(action=ASSIGNMENT_CHANGED,\npreviousValue=oldAssignee,\nnewValue=assigneeId,\nchangedBy=currentPL,\nchangedDate=now)
+  Issue -> Issue : addHistory(assignmentHistory)
+
+  note right of Issue
+  ASSIGNED -> ASSIGNED:
+  status remains ASSIGNED.
+  STATUS_CHANGED is not created.
+  end note
+
+  Issue --> AC : reassignmentResult(status=ASSIGNED)
+  deactivate Issue
+  AC --> PL : issueReassigned(issueId, status=ASSIGNED)
+else Issue.status == FIXED
+  ref over PL, AC
+  UC8 Recommend Assignment Candidates
+  recommendAssignmentCandidates(issueId, status=FIXED)
+  end ref
+
+  AC --> PL : verifierChangeOptions(testerList,\ncurrentVerifier, verifierCandidates)
+  PL -> AC : changeVerifier(issueId, verifierId)
+  AC -> Issue : changeVerifier(verifierId,\nchangedBy=currentPL, now)
+  activate Issue
+  Issue -> Issue : oldVerifier := currentVerifier()
+  Issue -> Issue : replaceVerifier(verifierId);\nkeepStatus(FIXED);\nkeepAssigneeFixerResolver()
+
+  create "assignmentHistory:IssueHistory" as VerifierAH
+  Issue -> VerifierAH : new(action=ASSIGNMENT_CHANGED,\npreviousValue=oldVerifier,\nnewValue=verifierId,\nchangedBy=currentPL,\nchangedDate=now)
+  Issue -> Issue : addHistory(assignmentHistory)
+
+  note right of Issue
+  FIXED -> FIXED:
+  verifier is changed.
+  status remains FIXED.
+  STATUS_CHANGED is not created.
+  end note
+
+  Issue --> AC : verifierChangeResult(status=FIXED)
+  deactivate Issue
+  AC --> PL : verifierChanged(issueId, status=FIXED)
+end
+
+opt PL wants to add an optional assignment comment
+  ref over PL, AC
+  UC2 Add Comment
+  addComment(issueId, content)
+  end ref
+end
+
+@enduml

--- a/docs/uml/sd/sd_puml/sd-06-mark-fixed-detailed.puml
+++ b/docs/uml/sd/sd_puml/sd-06-mark-fixed-detailed.puml
@@ -1,0 +1,54 @@
+@startuml sd-06-mark-fixed-detailed
+!include ../_shared/its-uml-style.puml
+
+title Detailed SD 06 - Mark Issue as Fixed
+hide footbox
+
+actor "DEV" as Dev
+participant "issueStateController:IssueStateController" as ISC
+participant "targetIssue:Issue" as Issue
+
+Dev -> ISC : changeStatus(issueId,\ntargetStatus=FIXED, comment)
+
+alt not assignee or status is not ASSIGNED or comment is empty
+  ISC --> Dev : statusChangeRejected(reason)
+else valid ASSIGNED -> FIXED transition
+  note right of ISC
+  UC6은 UC2 Add Comment를 include하므로
+  상태 변경 사유 comment는 필수이다.
+  권한/현재 사용자/now 조회는 contextual service로 둔다.
+  end note
+
+  ISC -> Issue : markFixed(currentDev, comment, now)
+  activate Issue
+
+  create "fixComment:Comment" as Comment
+  Issue --> Comment : new(content=comment,\nwriter=currentDev,\ncreatedDate=now)
+  Issue -> Issue : addComment(fixComment)
+
+  create "commentHistory:IssueHistory" as CommentHistory
+  Issue --> CommentHistory : new(action=COMMENTED,\nmessage=comment,\nchangedBy=currentDev,\nchangedDate=now)
+  Issue -> Issue : addHistory(commentHistory)
+
+  Issue -> Issue : setFixer(currentDev)
+  Issue -> Issue : changeStatus(FIXED)
+
+  create "statusHistory:IssueHistory" as StatusHistory
+  Issue --> StatusHistory : new(action=STATUS_CHANGED,\npreviousValue=ASSIGNED,\nnewValue=FIXED,\nchangedBy=currentDev,\nchangedDate=now)
+  Issue -> Issue : addHistory(statusHistory)
+
+  note right of Issue
+  OC-06 사후조건:
+  - Comment 생성 및 Issue에 추가
+  - IssueHistory(COMMENTED) 기록
+  - fixer = currentDev
+  - Issue.status = FIXED
+  - IssueHistory(STATUS_CHANGED) 기록
+  end note
+
+  Issue --> ISC : updatedIssue(status=FIXED)
+  deactivate Issue
+  ISC --> Dev : updatedIssue(issueId,\nstatus=FIXED)
+end
+
+@enduml

--- a/docs/uml/sd/sd_puml/sd-07-resolve-fixed-issue-detailed.puml
+++ b/docs/uml/sd/sd_puml/sd-07-resolve-fixed-issue-detailed.puml
@@ -1,0 +1,71 @@
+@startuml sd-07-resolve-fixed-issue-detailed
+!include ../_shared/its-uml-style.puml
+
+title Detailed SD 07 - Resolve Fixed Issue
+hide footbox
+
+actor "Tester" as Tester
+participant "issueStateController:IssueStateController" as ISC
+participant "targetIssue:Issue" as Issue
+participant "blockingIssue:Issue" as BlockingIssue
+
+Tester -> ISC : changeStatus(issueId,\ntargetStatus=RESOLVED, comment)
+
+ISC -> Issue : checkResolvePreconditions(currentTester, comment)
+Issue -> Issue : verifyStatus(FIXED)
+Issue -> Issue : verifyVerifier(currentTester)
+Issue -> Issue : verifyComment(comment)
+Issue --> ISC : resolveAllowed or reason
+
+alt precondition failed (not verifier or status is not FIXED or comment is empty)
+  ISC --> Tester : statusChangeRejected(reason)
+else preconditions valid
+  loop each blocking IssueDependency
+    Issue -> BlockingIssue : isResolvedOrClosed()
+    BlockingIssue --> Issue : true or false
+  end
+
+  alt unresolved blocking issue exists
+    Issue --> ISC : resolveBlocked(blockingIssueId)
+    ISC --> Tester : statusChangeRejected(blockingIssueId)
+  else all blocking issues are RESOLVED or CLOSED
+  note right of Issue
+  dependency는 별도 IssueStatus가 아니라
+  FIXED -> RESOLVED 전이에 대한 guard이다.
+  end note
+
+  ISC -> Issue : resolve(currentTester, comment, now)
+  activate Issue
+
+  create "resolveComment:Comment" as Comment
+  Issue --> Comment : new(content=comment,\nwriter=currentTester,\ncreatedDate=now)
+  Issue -> Issue : addComment(resolveComment)
+
+  create "commentHistory:IssueHistory" as CommentHistory
+  Issue --> CommentHistory : new(action=COMMENTED,\nmessage=comment,\nchangedBy=currentTester,\nchangedDate=now)
+  Issue -> Issue : addHistory(commentHistory)
+
+  Issue -> Issue : setResolver(currentTester)
+  Issue -> Issue : changeStatus(RESOLVED)
+
+  create "statusHistory:IssueHistory" as StatusHistory
+  Issue --> StatusHistory : new(action=STATUS_CHANGED,\npreviousValue=FIXED,\nnewValue=RESOLVED,\nchangedBy=currentTester,\nchangedDate=now)
+  Issue -> Issue : addHistory(statusHistory)
+
+  note right of Issue
+  OC-07 사후조건:
+  - Comment 생성 및 Issue에 추가
+  - resolver = currentTester
+  - Issue.status = RESOLVED
+  - assignee/verifier/fixer 유지
+  - IssueHistory(COMMENTED) 기록
+  - IssueHistory(STATUS_CHANGED) 기록
+  end note
+
+  Issue --> ISC : updatedIssue(status=RESOLVED,\nresolver=currentTester)
+  deactivate Issue
+  ISC --> Tester : updatedIssue(issueId,\nstatus=RESOLVED,\nresolver=currentTester)
+  end
+end
+
+@enduml

--- a/docs/uml/sd/sd_puml/sd-08-reject-fix-detailed.puml
+++ b/docs/uml/sd/sd_puml/sd-08-reject-fix-detailed.puml
@@ -1,0 +1,61 @@
+@startuml sd-08-reject-fix-detailed
+!include ../_shared/its-uml-style.puml
+
+title Detailed SD 08 - Reject Fix
+hide footbox
+
+actor "Tester" as Tester
+participant "issueStateController:IssueStateController" as ISC
+participant "targetIssue:Issue" as Issue
+
+Tester -> ISC : changeStatus(issueId,\ntargetStatus=ASSIGNED, comment)
+
+ISC -> Issue : verifyRejectFixPreconditions(currentTester, comment)
+Issue -> Issue : verifyStatus(FIXED)
+Issue -> Issue : verifyVerifier(currentTester)
+Issue --> ISC : rejectAllowed or reason
+
+alt not verifier or status is not FIXED or comment is empty
+  ISC --> Tester : statusChangeRejected(reason)
+else valid FIXED -> ASSIGNED transition
+  note right of ISC
+  UC6은 상태 변경 사유 comment를 필수로 요구한다.
+  권한/인증/현재 시각 조회는 보조 책임이므로
+  이 SD에서는 guard와 파라미터로 축약한다.
+  end note
+
+  ISC -> Issue : rejectFix(currentTester, comment, now)
+  activate Issue
+
+  create "rejectComment:Comment" as Comment
+  Issue --> Comment : new(content=comment,\nwriter=currentTester,\ncreatedDate=now)
+  Issue -> Issue : addComment(rejectComment)
+
+  create "commentHistory:IssueHistory" as CommentHistory
+  Issue --> CommentHistory : new(action=COMMENTED,\nmessage=comment,\nchangedBy=currentTester,\nchangedDate=now)
+  Issue -> Issue : addHistory(commentHistory)
+
+  Issue -> Issue : keepAssigneeVerifierFixer()
+  Issue -> Issue : changeStatus(ASSIGNED)
+
+  create "statusHistory:IssueHistory" as StatusHistory
+  Issue --> StatusHistory : new(action=STATUS_CHANGED,\npreviousValue=FIXED,\nnewValue=ASSIGNED,\nchangedBy=currentTester,\nchangedDate=now)
+  Issue -> Issue : addHistory(statusHistory)
+
+  note right of Issue
+  OC-13 사후조건:
+  - Issue.status = ASSIGNED
+  - 기존 assignee/verifier/fixer 유지
+  - 새 DEV 교체는 UC5 reassignIssue에서 수행
+  - Comment와 COMMENTED history 기록
+  - STATUS_CHANGED history 기록
+  - IssueHistory.changedBy=currentTester가
+    Tester와 history의 changes association을 의미
+  end note
+
+  Issue --> ISC : updatedIssue(status=ASSIGNED,\nassignee=retained,\nverifier=retained,\nfixer=retained)
+  deactivate Issue
+  ISC --> Tester : updatedIssue(issueId,\nstatus=ASSIGNED,\nfixer=retained)
+end
+
+@enduml

--- a/docs/uml/sd/sd_puml/sd-09-close-issue-detailed.puml
+++ b/docs/uml/sd/sd_puml/sd-09-close-issue-detailed.puml
@@ -1,0 +1,63 @@
+@startuml sd-09-close-issue-detailed
+!include ../_shared/its-uml-style.puml
+
+title Detailed SD 09 - Close Issue
+hide footbox
+
+actor "PL" as PL
+participant "issueStateController:IssueStateController" as ISC
+participant "targetIssue:Issue" as Issue
+
+PL -> ISC : changeStatus(issueId,\ntargetStatus=CLOSED, comment)
+
+ISC -> Issue : verifyClosePreconditions(currentPL, comment)
+Issue -> Issue : verifyStatus(RESOLVED)
+Issue --> ISC : closeAllowed or reason
+
+alt not PL or status is not RESOLVED or comment is empty
+  ISC --> PL : statusChangeRejected(reason)
+else valid RESOLVED -> CLOSED transition
+  note right of ISC
+  UC6 close는 PL 전용 최종 종료 전이이다.
+  UC2 include로 comment가 필수이며,
+  권한 확인은 guard로 축약한다.
+  end note
+
+  ISC -> Issue : close(currentPL, comment, now)
+  activate Issue
+
+  create "closeComment:Comment" as Comment
+  Issue --> Comment : new(content=comment,\nwriter=currentPL,\ncreatedDate=now)
+  Issue -> Issue : addComment(closeComment)
+
+  create "commentHistory:IssueHistory" as CommentHistory
+  Issue --> CommentHistory : new(action=COMMENTED,\nmessage=comment,\nchangedBy=currentPL,\nchangedDate=now)
+  Issue -> Issue : addHistory(commentHistory)
+
+  Issue -> Issue : clearAssignee()
+  Issue -> Issue : clearVerifier()
+  Issue -> Issue : preserveFixerAndResolver()
+  Issue -> Issue : changeStatus(CLOSED)
+
+  create "statusHistory:IssueHistory" as StatusHistory
+  Issue --> StatusHistory : new(action=STATUS_CHANGED,\npreviousValue=RESOLVED,\nnewValue=CLOSED,\nchangedBy=currentPL,\nchangedDate=now)
+  Issue -> Issue : addHistory(statusHistory)
+
+  note right of Issue
+  OC-08 사후조건:
+  - Issue.status = CLOSED
+  - assignee DEV association 제거
+  - verifier TESTER association 제거
+  - fixer/resolver association 보존
+  - Comment와 COMMENTED history 기록
+  - STATUS_CHANGED history 기록
+  - IssueHistory.changedBy=currentPL이
+    PL과 history의 changes association을 의미
+  end note
+
+  Issue --> ISC : updatedIssue(status=CLOSED,\nassignee=null,\nverifier=null,\nfixer=retained,\nresolver=retained)
+  deactivate Issue
+  ISC --> PL : updatedIssue(issueId,\nstatus=CLOSED,\nassignee=null,\nverifier=null)
+end
+
+@enduml

--- a/docs/uml/sd/sd_puml/sd-10-reopen-issue-detailed.puml
+++ b/docs/uml/sd/sd_puml/sd-10-reopen-issue-detailed.puml
@@ -1,0 +1,69 @@
+@startuml sd-10-reopen-issue-detailed
+!include ../_shared/its-uml-style.puml
+
+title Detailed SD 10 - Reopen Issue
+hide footbox
+
+actor "PL" as PL
+participant "issueStateController:IssueStateController" as ISC
+participant "targetIssue:Issue" as Issue
+
+PL -> ISC : changeStatus(issueId,\ntargetStatus=REOPENED, comment)
+
+ISC -> Issue : verifyReopenPreconditions(currentPL, comment)
+Issue -> Issue : verifyStatus(RESOLVED or CLOSED)
+Issue -> Issue : verifyRole(PL)
+Issue -> Issue : verifyComment(comment)
+Issue --> ISC : reopenAllowed or reason
+
+alt not PL or status is not RESOLVED/CLOSED or comment is empty
+  ISC --> PL : statusChangeRejected(reason)
+else preconditions valid
+  note right of ISC
+  UC6 reopen은 PL 전용 상태 전이이다.
+  재작업 담당자 배정은 이 operation에서 자동 수행하지 않고,
+  필요 시 UC5 Assign Issue를 별도로 수행한다.
+  end note
+
+  ISC -> Issue : reopen(currentPL, comment, now)
+  activate Issue
+
+  create "reopenComment:Comment" as Comment
+  Issue --> Comment : new(content=comment,\nwriter=currentPL,\ncreatedDate=now)
+  Issue -> Issue : addComment(reopenComment)
+
+  create "commentHistory:IssueHistory" as CommentHistory
+  Issue --> CommentHistory : new(action=COMMENTED,\nmessage=comment,\nchangedBy=currentPL,\nchangedDate=now)
+  Issue -> Issue : addHistory(commentHistory)
+
+  Issue -> Issue : clearAssignee()
+  Issue -> Issue : clearVerifier()
+  Issue -> Issue : preserveFixerAndResolver()
+  Issue -> Issue : changeStatus(REOPENED)
+
+  create "statusHistory:IssueHistory" as StatusHistory
+  Issue --> StatusHistory : new(action=STATUS_CHANGED,\npreviousValue=RESOLVED or CLOSED,\nnewValue=REOPENED,\nchangedBy=currentPL,\nchangedDate=now)
+  Issue -> Issue : addHistory(statusHistory)
+
+  note right of Issue
+  OC-09 사후조건:
+  - Issue.status = REOPENED
+  - assignee/verifier 자동복원 없음
+  - fixer/resolver 보존
+  - Comment와 COMMENTED history 기록
+  - STATUS_CHANGED history 기록
+  end note
+
+  Issue --> ISC : updatedIssue(status=REOPENED,\nfixer=preserved,\nresolver=preserved)
+  deactivate Issue
+  ISC --> PL : updatedIssue(issueId,\nstatus=REOPENED,\nfixer=preserved,\nresolver=preserved)
+end
+
+opt PL decides assignee/verifier for rework
+  ref over PL, ISC
+  UC5 Assign Issue
+  assignIssue(issueId, assigneeId, verifierId)
+  end ref
+end
+
+@enduml

--- a/docs/uml/sd/sd_puml/sd-12-delete-issue-detailed.puml
+++ b/docs/uml/sd/sd_puml/sd-12-delete-issue-detailed.puml
@@ -1,0 +1,61 @@
+@startuml sd-12-delete-issue-detailed
+!include ../_shared/its-uml-style.puml
+
+title Detailed SD 12 - Delete Issue
+hide footbox
+
+actor "PL" as PL
+participant "deletedIssueController:DeletedIssueController" as DIC
+participant "targetIssue:Issue" as Issue
+participant "relatedDependency:IssueDependency" as Dependency
+
+PL -> DIC : deleteIssue(issueId)
+
+alt not PL or status is not NEW/CLOSED
+  DIC --> PL : deleteRejected(reason)
+else valid soft delete target
+  note right of DIC
+  UC9 delete는 UC6 상태 변경에 편입하지 않는다.
+  삭제/복구는 별도 PL 관리 목표이며,
+  삭제 사유 comment는 필수로 두지 않는다.
+  end note
+
+  DIC -> Issue : softDelete(currentPL, now)
+  activate Issue
+
+  loop each related IssueDependency
+    Issue -> Dependency : removeBlockingAndBlockedAssociations()
+    Issue -> Issue : removeDependency(relatedDependency)
+    note right of Dependency
+    blockingIssue / blockedIssue association을 제거한다.
+    제거된 dependency는 restoreIssue에서 자동 복원하지 않는다.
+    end note
+    destroy Dependency
+  end
+
+  Issue -> Issue : changeStatus(DELETED)
+
+  create "statusHistory:IssueHistory" as StatusHistory
+  Issue -> StatusHistory : new(action=STATUS_CHANGED,\npreviousValue=NEW or CLOSED,\nnewValue=DELETED,\nchangedBy=currentPL,\nchangedDate=now)
+  Issue -> Issue : addHistory(statusHistory)
+
+  note right of Issue
+  OC-10 사후조건:
+  - Issue.status = DELETED
+  - 관련 IssueDependency 제거
+  - STATUS_CHANGED history 기록
+  - deleted transition time은 history.changedDate
+  - 제거된 dependency는 restore 시 자동 복원하지 않음
+  end note
+
+  Issue --> DIC : deletedIssue(status=DELETED,\ndeletedTransitionTime=statusHistory.changedDate)
+  deactivate Issue
+
+  opt deleted issue count exceeds 30
+    DIC -> DIC : enforceDeletedLimit(max=30)
+  end
+
+  DIC --> PL : issueDeleted(issueId,\nstatus=DELETED)
+end
+
+@enduml

--- a/docs/uml/sd/sd_puml/sd-24-add-dependency-detailed.puml
+++ b/docs/uml/sd/sd_puml/sd-24-add-dependency-detailed.puml
@@ -1,0 +1,65 @@
+@startuml sd-24-add-dependency-detailed
+!include ../_shared/its-uml-style.puml
+
+title Detailed SD 24 - Add Dependency
+hide footbox
+
+actor "PL" as PL
+participant "issueController:IssueController" as IC
+participant "blockingIssue:Issue" as BlockingIssue
+participant "blockedIssue:Issue" as BlockedIssue
+
+PL -> IC : addDependency(blockingIssueId, blockedIssueId)
+
+alt not PL or permission denied
+  IC --> PL : dependencyRejected(reason)
+else authorized PL
+  IC -> BlockedIssue : validateDependencyCandidate(blockingIssue)
+  BlockedIssue -> BlockedIssue : rejectIfSameIssue(blockingIssue)
+  BlockedIssue -> BlockedIssue : rejectIfDuplicate(blockingIssue)
+  BlockedIssue -> BlockedIssue : rejectIfCycleWouldBeCreated(blockingIssue)
+  BlockedIssue --> IC : dependencyCandidateValid or reason
+
+  alt self reference, duplicate, or cycle detected
+    IC --> PL : dependencyRejected(reason)
+  else valid dependency
+    note right of BlockedIssue
+    순환 검사:
+    새 관계 blockingIssue -> blockedIssue를 추가했을 때
+    순환 dependency가 생기면 거부한다.
+    구현 의미는 blockedIssue에서 blockingIssue로
+    이미 도달 가능한 경로가 있는지 확인하는 것이다.
+
+    의미상 blockingIssue가 먼저 해결되어야
+    blockedIssue가 RESOLVED 될 수 있다.
+    dependency는 별도 IssueStatus가 아니라
+    UC6 FIXED -> RESOLVED guard에서 사용된다.
+    end note
+
+    IC -> BlockedIssue : addDependency(blockingIssue,\nchangedBy=currentPL, now)
+    activate BlockedIssue
+
+    create "newDependency:IssueDependency" as Dependency
+    BlockedIssue -> Dependency : new(dependencyId,\nblockingIssue=blockingIssue,\nblockedIssue=blockedIssue,\ndiscoveredDate=now)
+    BlockedIssue -> BlockedIssue : addBlockingDependency(newDependency)
+
+    create "dependencyHistory:IssueHistory" as History
+    BlockedIssue -> History : new(action=DEPENDENCY_CHANGED,\npreviousValue=null,\nnewValue=dependencyId,\nchangedBy=currentPL,\nchangedDate=now)
+    BlockedIssue -> BlockedIssue : addHistory(dependencyHistory)
+
+    note right of BlockedIssue
+    OC-14 사후조건:
+    - IssueDependency 생성
+    - blockingIssue association 형성
+    - blockedIssue association 형성
+    - blockedIssue에 DEPENDENCY_CHANGED history 기록
+    - Issue.status는 변경하지 않음
+    end note
+
+    BlockedIssue --> IC : dependencyAdded(dependencyId)
+    deactivate BlockedIssue
+    IC --> PL : dependencyAdded(dependencyId)
+  end
+end
+
+@enduml

--- a/docs/uml/sd/sd_puml/sd-26-restore-deleted-issue-detailed.puml
+++ b/docs/uml/sd/sd_puml/sd-26-restore-deleted-issue-detailed.puml
@@ -1,0 +1,60 @@
+@startuml sd-26-restore-deleted-issue-detailed
+!include ../_shared/its-uml-style.puml
+
+title Detailed SD 26 - Restore Deleted Issue
+hide footbox
+
+actor "PL" as PL
+participant "deletedIssueController:DeletedIssueController" as DIC
+participant "targetIssue:Issue" as Issue
+participant "deleteHistory:IssueHistory" as DeleteHistory
+
+PL -> DIC : viewDeletedIssues(projectId)
+DIC --> PL : deletedIssueList(issues)
+
+PL -> DIC : restoreIssue(issueId)
+
+alt not PL or permission denied
+  DIC --> PL : restoreRejected(reason)
+else issue not found or permanently deleted
+  DIC --> PL : restoreRejected(reason)
+else Issue is not DELETED
+  DIC --> PL : restoreRejected(reason)
+else valid restore target
+  note right of DIC
+  previousStatusFromDeleteHistory는
+  NEW/CLOSED -> DELETED 전이 때의
+  IssueHistory.previousValue에서 읽는다.
+  이 값이 restoreTargetStatus가 된다.
+  end note
+
+  DIC -> Issue : restore(currentPL, now)
+  activate Issue
+  Issue -> Issue : findDeleteStatusHistory()
+  Issue -> DeleteHistory : previousValue()
+  DeleteHistory --> Issue : previousStatusFromDeleteHistory(NEW or CLOSED)
+  Issue -> Issue : restoreTargetStatus := previousStatusFromDeleteHistory
+
+  Issue -> Issue : changeStatus(restoreTargetStatus)
+  Issue -> Issue : keepReporterFixerResolverCommentsHistory()
+  Issue -> Issue : keepAssigneeVerifierNull()
+
+  create "restoreHistory:IssueHistory" as RestoreHistory
+  Issue -> RestoreHistory : new(action=STATUS_CHANGED,\npreviousValue=DELETED,\nnewValue=restoreTargetStatus,\nchangedBy=currentPL,\nchangedDate=now)
+  Issue -> Issue : addHistory(restoreHistory)
+
+  note right of Issue
+  OC-11 사후조건:
+  - 새 Issue를 만들지 않고 기존 Issue 복구
+  - status = NEW 또는 CLOSED
+  - reporter/fixer/resolver/comments/history 유지
+  - assignee/verifier는 null 유지
+  - 삭제 때 제거된 dependency는 자동 복원하지 않음
+  end note
+
+  Issue --> DIC : restoredIssue(status=restoreTargetStatus)
+  deactivate Issue
+  DIC --> PL : issueRestored(issueId,\nstatus=restoreTargetStatus)
+end
+
+@enduml

--- a/docs/uml/sd/sd_puml/sd-27-change-priority-detailed.puml
+++ b/docs/uml/sd/sd_puml/sd-27-change-priority-detailed.puml
@@ -1,0 +1,57 @@
+@startuml sd-27-change-priority-detailed
+!include ../_shared/its-uml-style.puml
+
+title Detailed SD 27 - Change Priority
+hide footbox
+
+actor "PL" as PL
+participant "issueController:IssueController" as IC
+participant "targetIssue:Issue" as Issue
+
+PL -> IC : changePriority(issueId, newPriority)
+
+alt not PL or permission denied
+  IC --> PL : priorityChangeRejected(reason)
+else authorized PL
+  IC -> Issue : verifyPriorityChange(newPriority)
+  Issue -> Issue : validatePriority(newPriority)
+  Issue -> Issue : compareCurrentPriority(newPriority)
+  Issue --> IC : priorityChangeAllowed or reason
+
+  alt invalid priority or same as current priority
+    IC --> PL : priorityChangeRejected(reason)
+  else valid priority change
+  note right of IC
+  UC16은 IssueController가 수신한다.
+  권한 확인과 이슈 조회는 보조 흐름이므로
+  이 SD에서는 guard로 축약한다.
+  end note
+
+  IC -> Issue : changePriority(newPriority, currentPL, now)
+  activate Issue
+
+  Issue -> Issue : oldPriority := currentPriority()
+  Issue -> Issue : setPriority(newPriority)
+
+  create "priorityHistory:IssueHistory" as PriorityHistory
+  Issue --> PriorityHistory : new(action=PRIORITY_CHANGED,\npreviousValue=oldPriority,\nnewValue=newPriority,\nchangedBy=currentPL,\nchangedDate=now)
+  Issue -> Issue : addHistory(priorityHistory)
+
+  note right of Issue
+  OC-16 사후조건:
+  - Issue.priority = newPriority
+  - PRIORITY_CHANGED history 기록
+  - Issue.status 변경 없음
+  - assigned to/verifies/fixes/resolves
+    association 변경 없음
+  - IssueHistory.changedBy=currentPL이
+    PL과 history의 changes association을 의미
+  end note
+
+  Issue --> IC : updatedIssue(priority=newPriority,\nstatus=unchanged)
+  deactivate Issue
+  IC --> PL : priorityChanged(issueId,\npriority=newPriority)
+  end
+end
+
+@enduml


### PR DESCRIPTION
## 요약
- 작업 브랜치: `feat/15-detailed-sd-added`
- 관련 이슈: #15

## 변경 의도

도메인 주도 설계(DDD)와 Larman 스타일의 상세 시퀀스 다이어그램 작성 기준을 정립하고, 이슈 추적 시스템의 주요 유스케이스에 대한 설계 문서(SSD, Operation Contract, GRASP 적용 설명)를 작성했습니다.

## 주요 변경 사항

### 설계 기준 문서
- **SD_README.md** (+82줄): Detailed Sequence Diagram 작성 기준 및 GRASP 적용 방법, 표기 규칙, 산출물 우선순위 등을 문서화하고 SSD 목록을 관리하는 인덱스로 기능

### 시퀀스 다이어그램 및 GRASP 설명 (총 11개 SSD)

**이슈 생명주기 관련:**
- **SD-01**: 이슈 등록 (GRASP 설명 문서 갱신, PlantUML 미소 개선)
- **SD-05**: 이슈 배정/갱신 (상태별 4개 분기, 이력 생성)
- **SD-06**: 이슈 고정(FIXED)으로 표시 (담당자/상태 검증, 댓글/이력 생성)
- **SD-07**: 고정된 이슈 해결(RESOLVED) (의존성 검증, 해결자 지정)
- **SD-08**: 수정 거절 (검증자가 FIXED→ASSIGNED 전이, 거절 사유 댓글 필수)
- **SD-09**: 이슈 종료(CLOSED) (담당자/검증자 제거, 수정자/해결자 보존)
- **SD-10**: 이슈 재오픈(REOPENED) (할당자 자동 복원 없음, UC5로 재할당 분리)

**이슈 관리 관련:**
- **SD-12**: 이슈 삭제 (소프트 삭제, 의존성 제거, 30개 보관 정책)
- **SD-24**: 의존성 추가 (사이클 검증, 권한 검사)
- **SD-26**: 삭제된 이슈 복구 (이전 상태 복원, 의존성 자동 복원 없음)
- **SD-27**: 우선순위 변경

각 시퀀스 다이어그램마다:
- PlantUML 상세 다이어그램 파일 (+64~141줄)
- GRASP 적용 설명 문서 (+25~50줄): Controller, Information Expert, Creator, Low Coupling/High Cohesion, Protected Variations 등 패턴 적용 근거 기술

## 검증
- `./gradlew check`

## 주요 설계 원칙 기록

- 상태 전이 규칙 및 불변식 문서화 (NEW → ASSIGNED → FIXED → RESOLVED → CLOSED/REOPENED)
- 도메인 객체(Issue, IssueHistory, IssueDependency) 간 책임 분배 및 GRASP 원칙 적용
- Operation Contract와 SSD의 연계 관계 명시
- 향후 구현 단계에서 참조 가능한 설계 기선 확립

## 관련 이슈
- Closes #15