### PR TITLE
chore: Route Dependabot updates through dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,13 +2,19 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     labels:
       - "type:chore"
       - "area:automation"
+    ignore:
+      - dependency-name: "actions/add-to-project"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: "gradle"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
## Summary
- Add target-branch: dev to the default-branch Dependabot config
- Carry over the actions/add-to-project major-update ignore so Dependabot does not open guarded workflow major bumps

## Why
Dependabot reads .github/dependabot.yml from the repository default branch. main did not have target-branch configured, so version-update PRs were opened against main and failed the workflow guard.

## Verification
- git diff --check -- .github/dependabot.yml
- Local workflow guard simulation for a marcellokim-authored main-target PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 의도
Dependabot이 기본 브랜치의 설정을 읽기 때문에, main 브랜치의 `.github/dependabot.yml`에 `target-branch: dev` 설정을 추가하여 Dependabot 버전 업데이트 PR이 main이 아닌 dev로 라우팅되도록 함. 이를 통해 워크플로우 가드 실패를 방지.

## 주요 파일
- `.github/dependabot.yml`
  - GitHub Actions 업데이트 항목에 `target-branch: "dev"` 추가
  - `actions/add-to-project` 메이저 버전 업데이트 무시 규칙 추가
  - Gradle 업데이트 항목에 `target-branch: "dev"` 추가

## 검증 상태
- ✓ `git diff --check -- .github/dependabot.yml` 실행 완료
- ✓ 로컬 워크플로우 가드 시뮬레이션 수행 완료
- ✗ 실제 Dependabot 재실행은 미테스트

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcellokim/se-issue-tracker/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->