### PR TITLE
feat: 이슈, 댓글, 우선순위, 상태 전이 모델 구현

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/domain/ActionType.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/ActionType.java
@@ -1,0 +1,11 @@
+package com.github.marcellokim.issuetracker.domain;
+
+public enum ActionType {
+    CREATED,
+    TITLE_DESCRIPTION_UPDATED,
+    PRIORITY_CHANGED,
+    STATUS_CHANGED,
+    ASSIGNMENT_CHANGED,
+    DEPENDENCY_CHANGED,
+    COMMENTED
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Comment.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Comment.java
@@ -1,0 +1,46 @@
+package com.github.marcellokim.issuetracker.domain;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public final class Comment {
+
+    private final String commentId;
+    private final String content;
+    private final LocalDateTime createdDate;
+    private final User writer;
+
+    private Comment(String commentId, String content, User writer, LocalDateTime createdDate) {
+        this.commentId = requireText(commentId, "commentId");
+        this.content = requireText(content, "content");
+        this.writer = Objects.requireNonNull(writer, "writer must not be null");
+        this.createdDate = Objects.requireNonNull(createdDate, "createdDate must not be null");
+    }
+
+    public static Comment create(String commentId, String content, User writer, LocalDateTime createdDate) {
+        return new Comment(commentId, content, writer, createdDate);
+    }
+
+    public String getCommentId() {
+        return commentId;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public User getWriter() {
+        return writer;
+    }
+
+    private static String requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Issue.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Issue.java
@@ -1,0 +1,313 @@
+package com.github.marcellokim.issuetracker.domain;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class Issue {
+
+    private static final String CREATED_PREVIOUS_VALUE = null;
+    private static final String COMMENT_FIELD = "comment";
+    private static final String CHANGED_BY_REQUIRED = "changedBy must not be null";
+    private static final String CHANGED_DATE_REQUIRED = "changedDate must not be null";
+
+    private final String issueId;
+    private String title;
+    private String description;
+    private final LocalDateTime reportedDate;
+    private Priority priority = Priority.MAJOR;
+    private IssueStatus status = IssueStatus.NEW;
+    private final User reporter;
+    private User assignee;
+    private User verifier;
+    private User fixer;
+    private User resolver;
+    private final List<Comment> comments = new ArrayList<>();
+    private final List<IssueHistory> histories = new ArrayList<>();
+    private final List<IssueDependency> blockingDependencies = new ArrayList<>();
+    private final List<IssueDependency> blockedByDependencies = new ArrayList<>();
+
+    private Issue(
+            String issueId,
+            String title,
+            String description,
+            Priority priority,
+            User reporter,
+            LocalDateTime reportedDate
+    ) {
+        this.issueId = requireText(issueId, "issueId");
+        this.title = requireText(title, "title");
+        this.description = requireText(description, "description");
+        this.priority = priority == null ? Priority.MAJOR : priority;
+        this.reporter = Objects.requireNonNull(reporter, "reporter must not be null");
+        this.reportedDate = Objects.requireNonNull(reportedDate, "reportedDate must not be null");
+        recordHistory(ActionType.CREATED, CREATED_PREVIOUS_VALUE, IssueStatus.NEW.name(), "Issue created", reporter, reportedDate);
+    }
+
+    public static Issue create(
+            String issueId,
+            String title,
+            String description,
+            Priority priority,
+            User reporter,
+            LocalDateTime reportedDate
+    ) {
+        return new Issue(issueId, title, description, priority, reporter, reportedDate);
+    }
+
+    public String getIssueId() {
+        return issueId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public LocalDateTime getReportedDate() {
+        return reportedDate;
+    }
+
+    public Priority getPriority() {
+        return priority;
+    }
+
+    public IssueStatus getStatus() {
+        return status;
+    }
+
+    public User getReporter() {
+        return reporter;
+    }
+
+    public User getAssignee() {
+        return assignee;
+    }
+
+    public User getVerifier() {
+        return verifier;
+    }
+
+    public User getFixer() {
+        return fixer;
+    }
+
+    public User getResolver() {
+        return resolver;
+    }
+
+    public List<Comment> getComments() {
+        return Collections.unmodifiableList(comments);
+    }
+
+    public List<IssueHistory> getHistories() {
+        return Collections.unmodifiableList(histories);
+    }
+
+    public List<IssueDependency> getBlockingDependencies() {
+        return Collections.unmodifiableList(blockingDependencies);
+    }
+
+    public List<IssueDependency> getBlockedByDependencies() {
+        return Collections.unmodifiableList(blockedByDependencies);
+    }
+
+    public void assignFromNew(User assignee, User verifier, User changedBy, LocalDateTime changedDate) {
+        requireStatus(IssueStatus.NEW);
+        assign(assignee, verifier, changedBy, changedDate, "Issue assigned from NEW");
+    }
+
+    public void assignReopened(User assignee, User verifier, User changedBy, LocalDateTime changedDate) {
+        requireStatus(IssueStatus.REOPENED);
+        assign(assignee, verifier, changedBy, changedDate, "Issue assigned from REOPENED");
+    }
+
+    public void markFixed(User fixer, String comment, LocalDateTime changedDate) {
+        requireStatus(IssueStatus.ASSIGNED);
+        requireRole(fixer, Role.DEV, "fixer");
+        var requiredComment = requireText(comment, COMMENT_FIELD);
+
+        this.fixer = fixer;
+        changeStatusTo(IssueStatus.FIXED, requiredComment, fixer, changedDate);
+    }
+
+    public void resolve(User resolver, String comment, LocalDateTime changedDate) {
+        requireStatus(IssueStatus.FIXED);
+        requireRole(resolver, Role.TESTER, "resolver");
+        var requiredComment = requireText(comment, COMMENT_FIELD);
+
+        this.resolver = resolver;
+        changeStatusTo(IssueStatus.RESOLVED, requiredComment, resolver, changedDate);
+    }
+
+    public void reopen(User changedBy, String comment, LocalDateTime changedDate) {
+        if (status != IssueStatus.RESOLVED && status != IssueStatus.CLOSED) {
+            throw new IllegalStateException("Issue status must be RESOLVED or CLOSED");
+        }
+        requireRole(changedBy, Role.PL, "changedBy");
+        var requiredComment = requireText(comment, COMMENT_FIELD);
+
+        assignee = null;
+        verifier = null;
+        changeStatusTo(IssueStatus.REOPENED, requiredComment, changedBy, changedDate);
+    }
+
+    public IssueDependency addDependency(
+            String dependencyId,
+            Issue blockingIssue,
+            User changedBy,
+            LocalDateTime discoveredDate
+    ) {
+        Objects.requireNonNull(changedBy, CHANGED_BY_REQUIRED);
+        Objects.requireNonNull(blockingIssue, "blockingIssue must not be null");
+        rejectDuplicateDependency(blockingIssue);
+        var dependency = IssueDependency.create(dependencyId, blockingIssue, this, discoveredDate);
+        blockedByDependencies.add(dependency);
+        blockingIssue.blockingDependencies.add(dependency);
+        recordHistory(
+                ActionType.DEPENDENCY_CHANGED,
+                null,
+                dependencyId,
+                "Dependency added",
+                changedBy,
+                discoveredDate
+        );
+        return dependency;
+    }
+
+    public Comment addComment(String commentId, String content, User writer, LocalDateTime createdDate) {
+        var comment = Comment.create(commentId, content, writer, createdDate);
+        comments.add(comment);
+        recordHistory(ActionType.COMMENTED, null, commentId, content, writer, createdDate);
+        return comment;
+    }
+
+    public void changePriority(Priority newPriority, User changedBy, LocalDateTime changedDate) {
+        Objects.requireNonNull(newPriority, "newPriority must not be null");
+        Objects.requireNonNull(changedBy, CHANGED_BY_REQUIRED);
+        Objects.requireNonNull(changedDate, CHANGED_DATE_REQUIRED);
+        if (priority == newPriority) {
+            throw new IllegalArgumentException("newPriority must be different from current priority");
+        }
+
+        var previousPriority = priority;
+        priority = newPriority;
+        recordHistory(
+                ActionType.PRIORITY_CHANGED,
+                previousPriority.name(),
+                newPriority.name(),
+                "Priority changed",
+                changedBy,
+                changedDate
+        );
+    }
+
+    private void changeStatusTo(IssueStatus targetStatus, String message, User changedBy, LocalDateTime changedDate) {
+        Objects.requireNonNull(targetStatus, "targetStatus must not be null");
+        Objects.requireNonNull(changedBy, CHANGED_BY_REQUIRED);
+        Objects.requireNonNull(changedDate, CHANGED_DATE_REQUIRED);
+        if (status == targetStatus) {
+            throw new IllegalArgumentException("targetStatus must be different from current status");
+        }
+
+        var previousStatus = status;
+        status = targetStatus;
+        recordHistory(
+                ActionType.STATUS_CHANGED,
+                previousStatus.name(),
+                targetStatus.name(),
+                message,
+                changedBy,
+                changedDate
+        );
+    }
+
+    private void recordHistory(
+            ActionType action,
+            String previousValue,
+            String newValue,
+            String message,
+            User changedBy,
+            LocalDateTime changedDate
+    ) {
+        histories.add(IssueHistory.create(
+                nextHistoryId(),
+                action,
+                previousValue,
+                newValue,
+                message,
+                changedBy,
+                changedDate
+        ));
+    }
+
+    private String nextHistoryId() {
+        return issueId + "-H" + (histories.size() + 1);
+    }
+
+    private void assign(User assignee, User verifier, User changedBy, LocalDateTime changedDate, String message) {
+        requireRole(assignee, Role.DEV, "assignee");
+        requireRole(verifier, Role.TESTER, "verifier");
+        Objects.requireNonNull(changedBy, CHANGED_BY_REQUIRED);
+        Objects.requireNonNull(changedDate, CHANGED_DATE_REQUIRED);
+
+        this.assignee = assignee;
+        this.verifier = verifier;
+        recordHistory(
+                ActionType.ASSIGNMENT_CHANGED,
+                null,
+                assignee.getUserId() + "/" + verifier.getUserId(),
+                message,
+                changedBy,
+                changedDate
+        );
+
+        var previousStatus = status;
+        status = IssueStatus.ASSIGNED;
+        recordHistory(
+                ActionType.STATUS_CHANGED,
+                previousStatus.name(),
+                IssueStatus.ASSIGNED.name(),
+                message,
+                changedBy,
+                changedDate
+        );
+    }
+
+    private void requireStatus(IssueStatus expectedStatus) {
+        if (status != expectedStatus) {
+            throw new IllegalStateException("Issue status must be " + expectedStatus);
+        }
+    }
+
+    private static void requireRole(User user, Role expectedRole, String fieldName) {
+        Objects.requireNonNull(user, fieldName + " must not be null");
+        if (!user.isActive()) {
+            throw new IllegalArgumentException(fieldName + " must be active");
+        }
+        if (!user.hasRole(expectedRole)) {
+            throw new IllegalArgumentException(fieldName + " must have role " + expectedRole);
+        }
+    }
+
+    private void rejectDuplicateDependency(Issue blockingIssue) {
+        var blockingIssueId = blockingIssue.getIssueId();
+        for (var dependency : blockedByDependencies) {
+            if (Objects.equals(dependency.getBlockingIssue().getIssueId(), blockingIssueId)) {
+                throw new IllegalArgumentException("Dependency already exists");
+            }
+        }
+    }
+
+    private static String requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/IssueDependency.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/IssueDependency.java
@@ -1,0 +1,54 @@
+package com.github.marcellokim.issuetracker.domain;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public final class IssueDependency {
+
+    private final String dependencyId;
+    private final LocalDateTime discoveredDate;
+    private final Issue blockingIssue;
+    private final Issue blockedIssue;
+
+    private IssueDependency(String dependencyId, Issue blockingIssue, Issue blockedIssue, LocalDateTime discoveredDate) {
+        this.dependencyId = requireText(dependencyId, "dependencyId");
+        this.blockingIssue = Objects.requireNonNull(blockingIssue, "blockingIssue must not be null");
+        this.blockedIssue = Objects.requireNonNull(blockedIssue, "blockedIssue must not be null");
+        if (Objects.equals(blockingIssue.getIssueId(), blockedIssue.getIssueId())) {
+            throw new IllegalArgumentException("An issue cannot depend on itself");
+        }
+        this.discoveredDate = Objects.requireNonNull(discoveredDate, "discoveredDate must not be null");
+    }
+
+    public static IssueDependency create(
+            String dependencyId,
+            Issue blockingIssue,
+            Issue blockedIssue,
+            LocalDateTime discoveredDate
+    ) {
+        return new IssueDependency(dependencyId, blockingIssue, blockedIssue, discoveredDate);
+    }
+
+    public String getDependencyId() {
+        return dependencyId;
+    }
+
+    public LocalDateTime getDiscoveredDate() {
+        return discoveredDate;
+    }
+
+    public Issue getBlockingIssue() {
+        return blockingIssue;
+    }
+
+    public Issue getBlockedIssue() {
+        return blockedIssue;
+    }
+
+    private static String requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/IssueHistory.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/IssueHistory.java
@@ -1,0 +1,80 @@
+package com.github.marcellokim.issuetracker.domain;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public final class IssueHistory {
+
+    private final String historyId;
+    private final ActionType action;
+    private final String previousValue;
+    private final String newValue;
+    private final LocalDateTime changedDate;
+    private final String message;
+    private final User changedBy;
+
+    private IssueHistory(
+            String historyId,
+            ActionType action,
+            String previousValue,
+            String newValue,
+            String message,
+            User changedBy,
+            LocalDateTime changedDate
+    ) {
+        this.historyId = requireText(historyId, "historyId");
+        this.action = Objects.requireNonNull(action, "action must not be null");
+        this.previousValue = previousValue;
+        this.newValue = newValue;
+        this.message = message;
+        this.changedBy = Objects.requireNonNull(changedBy, "changedBy must not be null");
+        this.changedDate = Objects.requireNonNull(changedDate, "changedDate must not be null");
+    }
+
+    public static IssueHistory create(
+            String historyId,
+            ActionType action,
+            String previousValue,
+            String newValue,
+            String message,
+            User changedBy,
+            LocalDateTime changedDate
+    ) {
+        return new IssueHistory(historyId, action, previousValue, newValue, message, changedBy, changedDate);
+    }
+
+    public String getHistoryId() {
+        return historyId;
+    }
+
+    public ActionType getAction() {
+        return action;
+    }
+
+    public String getPreviousValue() {
+        return previousValue;
+    }
+
+    public String getNewValue() {
+        return newValue;
+    }
+
+    public LocalDateTime getChangedDate() {
+        return changedDate;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public User getChangedBy() {
+        return changedBy;
+    }
+
+    private static String requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/IssueStatus.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/IssueStatus.java
@@ -1,0 +1,11 @@
+package com.github.marcellokim.issuetracker.domain;
+
+public enum IssueStatus {
+    NEW,
+    ASSIGNED,
+    FIXED,
+    RESOLVED,
+    CLOSED,
+    REOPENED,
+    DELETED
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Priority.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Priority.java
@@ -1,0 +1,9 @@
+package com.github.marcellokim.issuetracker.domain;
+
+public enum Priority {
+    BLOCKER,
+    CRITICAL,
+    MAJOR,
+    MINOR,
+    TRIVIAL
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Role.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Role.java
@@ -1,0 +1,8 @@
+package com.github.marcellokim.issuetracker.domain;
+
+public enum Role {
+    ADMIN,
+    PL,
+    DEV,
+    TESTER
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/User.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/User.java
@@ -1,0 +1,61 @@
+package com.github.marcellokim.issuetracker.domain;
+
+import java.util.Objects;
+
+public final class User {
+
+    private final String userId;
+    private final String loginId;
+    private final String name;
+    private final String passwordHash;
+    private final Role role;
+    private boolean active;
+
+    public User(String userId, String loginId, String name, String passwordHash, Role role) {
+        this.userId = requireText(userId, "userId");
+        this.loginId = requireText(loginId, "loginId");
+        this.name = requireText(name, "name");
+        this.passwordHash = requireText(passwordHash, "passwordHash");
+        this.role = Objects.requireNonNull(role, "role must not be null");
+        this.active = true;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getLoginId() {
+        return loginId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public boolean hasRole(Role role) {
+        return this.role == role;
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+
+    private static String requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueAssignmentRoleTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueAssignmentRoleTest.java
@@ -1,0 +1,107 @@
+package com.github.marcellokim.issuetracker.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("이슈 배정 역할")
+class IssueAssignmentRoleTest {
+
+    private final User reporter = new User("U-1", "tester1", "Tester One", "hash", Role.TESTER);
+    private final User assignee = new User("U-2", "dev1", "Dev One", "hash", Role.DEV);
+    private final User verifier = new User("U-3", "tester2", "Tester Two", "hash", Role.TESTER);
+    private final User pl = new User("U-4", "pl1", "PL One", "hash", Role.PL);
+    private final LocalDateTime createdAt = LocalDateTime.of(2026, 5, 18, 10, 0);
+
+    @Test
+    @DisplayName("NEW 이슈를 배정하면 assignee/verifier가 설정되고 ASSIGNED 상태가 된다")
+    void assignFromNewIssue() {
+        var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+        var assignedAt = createdAt.plusMinutes(10);
+
+        issue.assignFromNew(assignee, verifier, pl, assignedAt);
+
+        assertSame(assignee, issue.getAssignee());
+        assertSame(verifier, issue.getVerifier());
+        assertEquals(IssueStatus.ASSIGNED, issue.getStatus());
+        assertEquals(3, issue.getHistories().size());
+
+        var assignmentHistory = findHistory(issue, ActionType.ASSIGNMENT_CHANGED);
+        assertEquals(ActionType.ASSIGNMENT_CHANGED, assignmentHistory.getAction());
+
+        var statusHistory = findHistory(issue, ActionType.STATUS_CHANGED);
+        assertEquals(IssueStatus.NEW.name(), statusHistory.getPreviousValue());
+        assertEquals(IssueStatus.ASSIGNED.name(), statusHistory.getNewValue());
+    }
+
+    @Test
+    @DisplayName("REOPENED 이슈도 재배정하면 ASSIGNED 상태가 된다")
+    void assignReopenedIssue() {
+        var issue = reopenedIssue();
+
+        issue.assignReopened(assignee, verifier, pl, createdAt.plusMinutes(40));
+
+        assertSame(assignee, issue.getAssignee());
+        assertSame(verifier, issue.getVerifier());
+        assertEquals(IssueStatus.ASSIGNED, issue.getStatus());
+    }
+
+    @Test
+    @DisplayName("assignee는 DEV, verifier는 TESTER여야 한다")
+    void rejectInvalidAssignmentRoles() {
+        var invalidAssigneeIssue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+        var invalidVerifierIssue = Issue.create("ISSUE-2", "Signup fails", "Cannot sign up", null, reporter, createdAt);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> invalidAssigneeIssue.assignFromNew(verifier, verifier, pl, createdAt));
+        assertThrows(IllegalArgumentException.class,
+                () -> invalidVerifierIssue.assignFromNew(assignee, assignee, pl, createdAt));
+    }
+
+    @Test
+    @DisplayName("비활성 사용자는 assignee 또는 verifier가 될 수 없다")
+    void rejectInactiveAssignmentParticipants() {
+        var inactiveAssignee = new User("U-5", "dev2", "Dev Two", "hash", Role.DEV);
+        var inactiveVerifier = new User("U-6", "tester3", "Tester Three", "hash", Role.TESTER);
+        inactiveAssignee.deactivate();
+        inactiveVerifier.deactivate();
+
+        var issueForAssignee = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+        assertThrows(IllegalArgumentException.class,
+                () -> issueForAssignee.assignFromNew(inactiveAssignee, verifier, pl, createdAt.plusMinutes(10)));
+
+        var issueForVerifier = Issue.create("ISSUE-2", "Signup fails", "Cannot sign up", null, reporter, createdAt);
+        assertThrows(IllegalArgumentException.class,
+                () -> issueForVerifier.assignFromNew(assignee, inactiveVerifier, pl, createdAt.plusMinutes(10)));
+    }
+
+    @Test
+    @DisplayName("NEW가 아닌 이슈는 assignFromNew로 배정할 수 없다")
+    void rejectAssignFromNewWhenStatusIsNotNew() {
+        var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+        issue.assignFromNew(assignee, verifier, pl, createdAt.plusMinutes(10));
+
+        assertThrows(IllegalStateException.class,
+                () -> issue.assignFromNew(assignee, verifier, pl, createdAt.plusMinutes(20)));
+    }
+
+    private Issue reopenedIssue() {
+        var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+        issue.assignFromNew(assignee, verifier, pl, createdAt.plusMinutes(10));
+        issue.markFixed(assignee, "Fix completed", createdAt.plusMinutes(20));
+        issue.resolve(verifier, "Verified", createdAt.plusMinutes(30));
+        issue.reopen(pl, "Needs more work", createdAt.plusMinutes(35));
+        return issue;
+    }
+
+    private static IssueHistory findHistory(Issue issue, ActionType action) {
+        return issue.getHistories().stream()
+                .filter(history -> history.getAction() == action)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("History not found for action " + action));
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueChangeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueChangeTest.java
@@ -1,0 +1,73 @@
+package com.github.marcellokim.issuetracker.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("이슈 변경")
+class IssueChangeTest {
+
+    private final User reporter = new User("U-1", "tester1", "Tester One", "hash", Role.TESTER);
+    private final User pl = new User("U-2", "pl1", "PL One", "hash", Role.PL);
+    private final LocalDateTime createdAt = LocalDateTime.of(2026, 5, 18, 10, 0);
+
+    @Test
+    @DisplayName("우선순위를 변경하면 PRIORITY_CHANGED 이력이 기록된다")
+    void changePriorityAndRecordHistory() {
+        var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+        var changedAt = createdAt.plusMinutes(10);
+
+        issue.changePriority(Priority.CRITICAL, pl, changedAt);
+
+        assertEquals(Priority.CRITICAL, issue.getPriority());
+        assertEquals(2, issue.getHistories().size());
+        var history = issue.getHistories().get(1);
+        assertEquals(ActionType.PRIORITY_CHANGED, history.getAction());
+        assertEquals(Priority.MAJOR.name(), history.getPreviousValue());
+        assertEquals(Priority.CRITICAL.name(), history.getNewValue());
+        assertEquals(changedAt, history.getChangedDate());
+    }
+
+    @Test
+    @DisplayName("resolved 이슈를 reopen하면 assignment가 비워지고 STATUS_CHANGED 이력이 기록된다")
+    void reopenResolvedIssueAndRecordHistory() {
+        var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+        var assignee = new User("U-3", "dev1", "Dev One", "hash", Role.DEV);
+        var verifier = new User("U-4", "tester2", "Tester Two", "hash", Role.TESTER);
+        issue.assignFromNew(assignee, verifier, pl, createdAt.plusMinutes(10));
+        issue.markFixed(assignee, "Fix completed", createdAt.plusMinutes(20));
+        issue.resolve(verifier, "Verified", createdAt.plusMinutes(30));
+        var changedAt = createdAt.plusMinutes(40);
+
+        issue.reopen(pl, "Needs more work", changedAt);
+
+        assertEquals(IssueStatus.REOPENED, issue.getStatus());
+        assertNull(issue.getAssignee());
+        assertNull(issue.getVerifier());
+        assertSame(assignee, issue.getFixer());
+        assertSame(verifier, issue.getResolver());
+        assertEquals(6, issue.getHistories().size());
+        var history = issue.getHistories().getLast();
+        assertEquals(ActionType.STATUS_CHANGED, history.getAction());
+        assertEquals(IssueStatus.RESOLVED.name(), history.getPreviousValue());
+        assertEquals(IssueStatus.REOPENED.name(), history.getNewValue());
+        assertEquals("Needs more work", history.getMessage());
+        assertEquals(changedAt, history.getChangedDate());
+    }
+
+    @Test
+    @DisplayName("같은 우선순위로는 변경할 수 없고 NEW 이슈는 reopen할 수 없다")
+    void rejectNoOpChanges() {
+        var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> issue.changePriority(Priority.MAJOR, pl, createdAt));
+        assertThrows(IllegalStateException.class,
+                () -> issue.reopen(pl, "Needs more work", createdAt));
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCommentTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCommentTest.java
@@ -1,0 +1,56 @@
+package com.github.marcellokim.issuetracker.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("이슈 댓글")
+class IssueCommentTest {
+
+    private final User reporter = new User("U-1", "tester1", "Tester One", "hash", Role.TESTER);
+    private final User developer = new User("U-2", "dev1", "Dev One", "hash", Role.DEV);
+    private final LocalDateTime createdAt = LocalDateTime.of(2026, 5, 18, 10, 0);
+
+    @Test
+    @DisplayName("댓글을 추가하면 댓글 목록과 COMMENTED 이력이 함께 기록된다")
+    void addCommentAndCommentedHistory() {
+        var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+        var commentedAt = createdAt.plusMinutes(5);
+
+        var comment = issue.addComment("C-1", "I will check it.", developer, commentedAt);
+
+        assertEquals("C-1", comment.getCommentId());
+        assertEquals("I will check it.", comment.getContent());
+        assertSame(developer, comment.getWriter());
+        assertEquals(commentedAt, comment.getCreatedDate());
+        assertEquals(1, issue.getComments().size());
+        assertSame(comment, issue.getComments().getFirst());
+
+        assertEquals(2, issue.getHistories().size());
+        var history = issue.getHistories().get(1);
+        assertEquals(ActionType.COMMENTED, history.getAction());
+        assertEquals("C-1", history.getNewValue());
+        assertEquals("I will check it.", history.getMessage());
+        assertSame(developer, history.getChangedBy());
+        assertEquals(commentedAt, history.getChangedDate());
+    }
+
+    @Test
+    @DisplayName("댓글 내용과 작성자는 필수 값이다")
+    void rejectInvalidCommentArguments() {
+        var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> issue.addComment("", "content", developer, createdAt));
+        assertThrows(IllegalArgumentException.class,
+                () -> issue.addComment("C-1", "", developer, createdAt));
+        assertThrows(NullPointerException.class,
+                () -> issue.addComment("C-1", "content", null, createdAt));
+        assertThrows(NullPointerException.class,
+                () -> issue.addComment("C-1", "content", developer, null));
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCreationTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCreationTest.java
@@ -1,0 +1,62 @@
+package com.github.marcellokim.issuetracker.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("이슈 생성")
+class IssueCreationTest {
+
+    private final User reporter = new User("U-1", "tester1", "Tester One", "hash", Role.TESTER);
+    private final LocalDateTime now = LocalDateTime.of(2026, 5, 18, 10, 0);
+
+    @Test
+    @DisplayName("이슈는 reporter, 기본 상태, 생성 이력을 가지고 생성된다")
+    void createIssueWithReporterDefaultStatusAndCreationHistory() {
+        var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, now);
+
+        assertEquals("ISSUE-1", issue.getIssueId());
+        assertEquals("Login fails", issue.getTitle());
+        assertEquals("Cannot log in", issue.getDescription());
+        assertSame(reporter, issue.getReporter());
+        assertEquals(now, issue.getReportedDate());
+        assertEquals(Priority.MAJOR, issue.getPriority());
+        assertEquals(IssueStatus.NEW, issue.getStatus());
+        assertEquals(1, issue.getHistories().size());
+
+        var history = issue.getHistories().getFirst();
+        assertEquals(ActionType.CREATED, history.getAction());
+        assertNull(history.getPreviousValue());
+        assertEquals(IssueStatus.NEW.name(), history.getNewValue());
+        assertSame(reporter, history.getChangedBy());
+        assertEquals(now, history.getChangedDate());
+    }
+
+    @Test
+    @DisplayName("명시한 우선순위가 있으면 해당 값으로 생성된다")
+    void createIssueWithExplicitPriority() {
+        var issue = Issue.create("ISSUE-1", "Crash", "App crashes", Priority.CRITICAL, reporter, now);
+
+        assertEquals(Priority.CRITICAL, issue.getPriority());
+    }
+
+    @Test
+    @DisplayName("이슈 생성 필수 값은 비어 있을 수 없다")
+    void rejectInvalidIssueCreationArguments() {
+        assertThrows(IllegalArgumentException.class,
+                () -> Issue.create("", "Title", "Description", null, reporter, now));
+        assertThrows(IllegalArgumentException.class,
+                () -> Issue.create("ISSUE-1", "", "Description", null, reporter, now));
+        assertThrows(IllegalArgumentException.class,
+                () -> Issue.create("ISSUE-1", "Title", "", null, reporter, now));
+        assertThrows(NullPointerException.class,
+                () -> Issue.create("ISSUE-1", "Title", "Description", null, null, now));
+        assertThrows(NullPointerException.class,
+                () -> Issue.create("ISSUE-1", "Title", "Description", null, reporter, null));
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueDependencyTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueDependencyTest.java
@@ -1,0 +1,75 @@
+package com.github.marcellokim.issuetracker.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("이슈 의존성")
+class IssueDependencyTest {
+
+    private final User reporter = new User("U-1", "tester1", "Tester One", "hash", Role.TESTER);
+    private final User pl = new User("U-2", "pl1", "PL One", "hash", Role.PL);
+    private final LocalDateTime createdAt = LocalDateTime.of(2026, 5, 18, 10, 0);
+
+    @Test
+    @DisplayName("의존성은 blocking issue와 blocked issue 방향으로 표현된다")
+    void createDependencyWithBlockingAndBlockedDirection() {
+        var blockingIssue = Issue.create("ISSUE-1", "Fix auth", "Auth must be fixed", null, reporter, createdAt);
+        var blockedIssue = Issue.create("ISSUE-2", "Login UI", "UI depends on auth", null, reporter, createdAt);
+        var discoveredAt = createdAt.plusMinutes(20);
+
+        var dependency = blockedIssue.addDependency("ISSUE-1->ISSUE-2", blockingIssue, pl, discoveredAt);
+
+        assertEquals("ISSUE-1->ISSUE-2", dependency.getDependencyId());
+        assertSame(blockingIssue, dependency.getBlockingIssue());
+        assertSame(blockedIssue, dependency.getBlockedIssue());
+        assertEquals(discoveredAt, dependency.getDiscoveredDate());
+        assertSame(dependency, blockingIssue.getBlockingDependencies().getFirst());
+        assertSame(dependency, blockedIssue.getBlockedByDependencies().getFirst());
+
+        var history = findHistory(blockedIssue, ActionType.DEPENDENCY_CHANGED);
+        assertEquals(ActionType.DEPENDENCY_CHANGED, history.getAction());
+        assertEquals("ISSUE-1->ISSUE-2", history.getNewValue());
+    }
+
+    @Test
+    @DisplayName("이슈는 자기 자신에 의존할 수 없다")
+    void rejectSelfDependency() {
+        var issue = Issue.create("ISSUE-1", "Fix auth", "Auth must be fixed", null, reporter, createdAt);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> issue.addDependency("SELF", issue, pl, createdAt));
+    }
+
+    @Test
+    @DisplayName("같은 issueId를 가진 다른 인스턴스도 자기 의존성으로 거부한다")
+    void rejectSelfDependencyByIssueId() {
+        var blockedIssue = Issue.create("ISSUE-1", "Fix auth", "Auth must be fixed", null, reporter, createdAt);
+        var sameIssueId = Issue.create("ISSUE-1", "Same auth", "Same logical issue", null, reporter, createdAt);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> blockedIssue.addDependency("SELF", sameIssueId, pl, createdAt));
+    }
+
+    @Test
+    @DisplayName("같은 blocking issue에 대한 의존성은 중복 추가할 수 없다")
+    void rejectDuplicateDependency() {
+        var blockingIssue = Issue.create("ISSUE-1", "Fix auth", "Auth must be fixed", null, reporter, createdAt);
+        var blockedIssue = Issue.create("ISSUE-2", "Login UI", "UI depends on auth", null, reporter, createdAt);
+        blockedIssue.addDependency("ISSUE-1->ISSUE-2", blockingIssue, pl, createdAt.plusMinutes(20));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> blockedIssue.addDependency("DUPLICATE", blockingIssue, pl, createdAt.plusMinutes(30)));
+    }
+
+    private static IssueHistory findHistory(Issue issue, ActionType action) {
+        return issue.getHistories().stream()
+                .filter(history -> history.getAction() == action)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("History not found for action " + action));
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueFixResolveTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueFixResolveTest.java
@@ -1,0 +1,122 @@
+package com.github.marcellokim.issuetracker.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("이슈 수정 완료와 검증 완료")
+class IssueFixResolveTest {
+
+    private final User reporter = new User("U-1", "tester1", "Tester One", "hash", Role.TESTER);
+    private final User assignee = new User("U-2", "dev1", "Dev One", "hash", Role.DEV);
+    private final User verifier = new User("U-3", "tester2", "Tester Two", "hash", Role.TESTER);
+    private final User pl = new User("U-4", "pl1", "PL One", "hash", Role.PL);
+    private final LocalDateTime createdAt = LocalDateTime.of(2026, 5, 18, 10, 0);
+
+    @Test
+    @DisplayName("ASSIGNED 이슈를 fixed로 변경하면 fixer와 STATUS_CHANGED 이력이 기록된다")
+    void markAssignedIssueFixed() {
+        var issue = assignedIssue();
+        var fixedAt = createdAt.plusMinutes(20);
+
+        issue.markFixed(assignee, "Fix completed", fixedAt);
+
+        assertSame(assignee, issue.getFixer());
+        assertEquals(IssueStatus.FIXED, issue.getStatus());
+        var history = issue.getHistories().getLast();
+        assertEquals(ActionType.STATUS_CHANGED, history.getAction());
+        assertEquals(IssueStatus.ASSIGNED.name(), history.getPreviousValue());
+        assertEquals(IssueStatus.FIXED.name(), history.getNewValue());
+        assertEquals("Fix completed", history.getMessage());
+        assertSame(assignee, history.getChangedBy());
+    }
+
+    @Test
+    @DisplayName("FIXED 이슈를 resolved로 변경하면 resolver와 STATUS_CHANGED 이력이 기록된다")
+    void resolveFixedIssue() {
+        var issue = assignedIssue();
+        issue.markFixed(assignee, "Fix completed", createdAt.plusMinutes(20));
+        var resolvedAt = createdAt.plusMinutes(30);
+
+        issue.resolve(verifier, "Verified", resolvedAt);
+
+        assertSame(verifier, issue.getResolver());
+        assertEquals(IssueStatus.RESOLVED, issue.getStatus());
+        var history = issue.getHistories().getLast();
+        assertEquals(ActionType.STATUS_CHANGED, history.getAction());
+        assertEquals(IssueStatus.FIXED.name(), history.getPreviousValue());
+        assertEquals(IssueStatus.RESOLVED.name(), history.getNewValue());
+        assertEquals("Verified", history.getMessage());
+        assertSame(verifier, history.getChangedBy());
+    }
+
+    @Test
+    @DisplayName("fixer는 DEV, resolver는 TESTER여야 한다")
+    void rejectInvalidFixerAndResolverRoles() {
+        var issue = assignedIssue();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> issue.markFixed(verifier, "Fix completed", createdAt.plusMinutes(20)));
+        issue.markFixed(assignee, "Fix completed", createdAt.plusMinutes(20));
+        assertThrows(IllegalArgumentException.class,
+                () -> issue.resolve(assignee, "Verified", createdAt.plusMinutes(30)));
+    }
+
+    @Test
+    @DisplayName("ASSIGNED가 아니면 fixed로, FIXED가 아니면 resolved로 변경할 수 없다")
+    void rejectInvalidSourceStatuses() {
+        var newIssue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+        var assignedIssue = assignedIssue();
+        var fixedIssue = assignedIssue();
+        fixedIssue.markFixed(assignee, "Fix completed", createdAt.plusMinutes(20));
+
+        assertThrows(IllegalStateException.class,
+                () -> newIssue.markFixed(assignee, "Fix completed", createdAt.plusMinutes(20)));
+        assertThrows(IllegalStateException.class,
+                () -> fixedIssue.markFixed(assignee, "Fix completed again", createdAt.plusMinutes(30)));
+        assertThrows(IllegalStateException.class,
+                () -> newIssue.resolve(verifier, "Verified", createdAt.plusMinutes(20)));
+        assertThrows(IllegalStateException.class,
+                () -> assignedIssue.resolve(verifier, "Verified", createdAt.plusMinutes(20)));
+    }
+
+    @Test
+    @DisplayName("상태 변경 comment는 비어 있을 수 없다")
+    void rejectBlankStatusComment() {
+        var issue = assignedIssue();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> issue.markFixed(assignee, "", createdAt.plusMinutes(20)));
+        issue.markFixed(assignee, "Fix completed", createdAt.plusMinutes(20));
+        assertThrows(IllegalArgumentException.class,
+                () -> issue.resolve(verifier, " ", createdAt.plusMinutes(30)));
+    }
+
+    @Test
+    @DisplayName("비활성 사용자는 fixer 또는 resolver가 될 수 없다")
+    void rejectInactiveFixerAndResolver() {
+        var inactiveFixer = new User("U-5", "dev2", "Dev Two", "hash", Role.DEV);
+        var inactiveResolver = new User("U-6", "tester3", "Tester Three", "hash", Role.TESTER);
+        inactiveFixer.deactivate();
+        inactiveResolver.deactivate();
+
+        var issueForFixer = assignedIssue();
+        assertThrows(IllegalArgumentException.class,
+                () -> issueForFixer.markFixed(inactiveFixer, "Fix completed", createdAt.plusMinutes(20)));
+
+        var issueForResolver = assignedIssue();
+        issueForResolver.markFixed(assignee, "Fix completed", createdAt.plusMinutes(20));
+        assertThrows(IllegalArgumentException.class,
+                () -> issueForResolver.resolve(inactiveResolver, "Verified", createdAt.plusMinutes(30)));
+    }
+
+    private Issue assignedIssue() {
+        var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+        issue.assignFromNew(assignee, verifier, pl, createdAt.plusMinutes(10));
+        return issue;
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/UserTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/UserTest.java
@@ -1,0 +1,58 @@
+package com.github.marcellokim.issuetracker.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("사용자 도메인 모델")
+class UserTest {
+
+    @Test
+    @DisplayName("사용자는 인증 식별자와 역할을 가진 활성 계정으로 생성된다")
+    void createActiveUserWithLoginIdentifierAndRole() {
+        var user = new User("U-1", "dev1", "Dev One", "hash", Role.DEV);
+
+        assertEquals("U-1", user.getUserId());
+        assertEquals("dev1", user.getLoginId());
+        assertEquals("Dev One", user.getName());
+        assertEquals("hash", user.getPasswordHash());
+        assertEquals(Role.DEV, user.getRole());
+        assertTrue(user.isActive());
+        assertTrue(user.hasRole(Role.DEV));
+        assertFalse(user.hasRole(Role.TESTER));
+    }
+
+    @Test
+    @DisplayName("사용자 핵심 값은 비어 있을 수 없다")
+    void rejectBlankUserFields() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new User("", "dev1", "Dev One", "hash", Role.DEV));
+        assertThrows(IllegalArgumentException.class,
+                () -> new User("U-1", " ", "Dev One", "hash", Role.DEV));
+        assertThrows(IllegalArgumentException.class,
+                () -> new User("U-1", "dev1", "", "hash", Role.DEV));
+        assertThrows(IllegalArgumentException.class,
+                () -> new User("U-1", "dev1", "Dev One", "", Role.DEV));
+    }
+
+    @Test
+    @DisplayName("사용자 역할은 필수 값이다")
+    void rejectMissingRole() {
+        assertThrows(NullPointerException.class,
+                () -> new User("U-1", "dev1", "Dev One", "hash", null));
+    }
+
+    @Test
+    @DisplayName("사용자는 비활성화될 수 있다")
+    void deactivateUser() {
+        var user = new User("U-1", "dev1", "Dev One", "hash", Role.DEV);
+
+        user.deactivate();
+
+        assertFalse(user.isActive());
+    }
+}


### PR DESCRIPTION
## 요약
- 작업 브랜치: `feat/17-issue-domain-model`
- 관련 이슈: #17

## 검증
- `./gradlew check`

## 관련 이슈
- Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Issue `#17`: 이슈 도메인 모델 구현

## 개요
이 PR은 이슈 워크플로우의 도메인 모델(엔터티, 상태 전이, 역할, 이력)을 구현하여 향후 정책·서비스 계층의 기반을 제공합니다. 권한·영속성·UI 등 외부 책임은 제외하고 모델 내부 불변성·검증·히스토리 기록에만 집중했습니다.

## 변경 의도
- Issue 중심의 상태 전이 및 역할(assignee/verifier/fixer/resolver) 관리 로직을 도메인 레벨에서 일관되게 제공
- 코멘트·이력·의존성 관리를 불변/검증 규칙과 함께 제공하여 이후 정책 이슈(`#43`–#47) 구현 기반 마련

## 주요 파일(핵심)
- src/main/java/com/github/marcellokim/issuetracker/domain/Issue.java — Issue 엔터티, 상태 전이 메서드(assignFromNew, assignReopened, markFixed, resolve, reopen), 우선순위 변경, 의존성·코멘트 추가, 히스토리 기록 로직
- src/main/java/com/github/marcellokim/issuetracker/domain/Comment.java — 불변 Comment 도메인
- src/main/java/com/github/marcellokim/issuetracker/domain/IssueHistory.java — 불변 이력 레코드
- src/main/java/com/github/marcellokim/issuetracker/domain/IssueDependency.java — 이슈 의존성(양방향) 모델
- src/main/java/com/github/marcellokim/issuetracker/domain/User.java — User 도메인(역할, 활성화)
- src/main/java/com/github/marcellokim/issuetracker/domain/*.java — 열거형 추가: IssueStatus, Priority, ActionType, Role
- docs/superpowers/specs/2026-05-18-issue-domain-role-foundation-design.md — 메서드/검증 규칙 명세
- docs/superpowers/plans/2026-05-18-issue-domain-role-foundation.md — 구현 및 테스트 실행 계획

## 검증 상태
- 단위 테스트 추가(도메인 레이어 중심):
  - IssueCreationTest, IssueAssignmentRoleTest, IssueFixResolveTest, IssueChangeTest, IssueCommentTest, IssueDependencyTest, UserTest
- 로컬 검증: ./gradlew check 실행(PR 설명 기준)
- 주요 검증 항목:
  - 생성 시 reporter·reportedDate·기본 우선순위·CREATED 이력 자동 기록
  - 상태 전이 규칙(허용 출발 상태 검사) 및 역할 검증(역할 유형·활성화 체크)
  - Comment/IssueHistory/IssueDependency의 불변성 및 순서·연관성 보존
  - enum 외 값 차단 및 자기 의존성 방지

## 범위·제약
- 삭제 관련 필드(Issue.deletedAt 등) 추가 금지 — 삭제/복구는 히스토리로 유도
- 권한(PL 전용)·서비스·컨트롤러·영속성·UI 행동은 모델 범위에서 제외
- Priority.BLOCKER는 의존성 차단 의미로 해석하지 않음

## 영향 요약
- 도메인 및 도메인 테스트 중심의 신규 파일 다수 추가(엔터티·열거형·테스트)
- 모델 수준의 불변성·검증·히스토리 기록 기반을 제공하여 후속 정책 구현이 가능

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcellokim/se-issue-tracker/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->