### PR TITLE
feat: User 7param 생성자로 통일(5,6 param 부분 전부 변경 - 주석 추가됨) / userID DCD+User cl…

### DIFF
--- a/docs/uml/dcd/its_dcd_ver1.puml
+++ b/docs/uml/dcd/its_dcd_ver1.puml
@@ -46,12 +46,12 @@ package "Presentation Layer\n(concrete boundary)" #E3F2FD {
   class SwingAdminView <<boundary>> {
     +logIn(loginId, password)
     +createAccount(loginId, name, password, role)
-    +updateAccount(userId, name, role)
-    +deactivateAccount(userId)
+    +updateAccount(loginId, name, role)
+    +deactivateAccount(loginId)
     +createProject(name, description)
     +deleteProject(projectId)
-    +addProjectParticipant(projectId, userId)
-    +removeProjectParticipant(projectId, userId)
+    +addProjectParticipant(projectId, loginId)
+    +removeProjectParticipant(projectId, loginId)
     +viewStatistics(period, filters)
   }
 
@@ -104,15 +104,15 @@ package "Application Layer\n(concrete controllers)" #FFF8E1 {
   class AccountController <<control>> {
     +logIn(loginId, password): void
     +createAccount(loginId, name, password, role): UserDto
-    +updateAccount(userId, name, role): UserDto
-    +deactivateAccount(userId): UserDto
+    +updateAccount(loginId, name, role): UserDto
+    +deactivateAccount(loginId): UserDto
   }
 
   class ProjectController <<control>> {
     +createProject(name, description): ProjectDto
     +deleteProject(projectId): void
-    +addProjectParticipant(projectId, userId): ProjectDto
-    +removeProjectParticipant(projectId, userId): ProjectDto
+    +addProjectParticipant(projectId, loginId): ProjectDto
+    +removeProjectParticipant(projectId, loginId): ProjectDto
   }
 
   class StatisticsController <<control>> {
@@ -167,7 +167,7 @@ package "Repository Interfaces\n(interfaces / contracts)" #F8FAFC {
   }
 
   interface UserRepository <<interface>> {
-    +findById(userId): User
+    +findById(loginId): User
     +findActiveByRole(projectId, role): List<User>
     +save(user): void
   }
@@ -260,7 +260,6 @@ package "Domain Layer\n(concrete entities, value objects, enums)" #F1F8E9 {
   }
 
   class User <<entity>> {
-    -userId: UserId
     -loginId: Text
     -name: Text
     -passwordHash: Text

--- a/docs/uml/dcd/its_dcd_ver2.puml
+++ b/docs/uml/dcd/its_dcd_ver2.puml
@@ -163,7 +163,6 @@ class IssueDependency {
 }
 
 class User {
-  - userId : UserId
   - loginId : Text
   - name : Text
   - passwordHash : Text

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Project.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Project.java
@@ -1,18 +1,103 @@
 package com.github.marcellokim.issuetracker.domain;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
-public record Project(
-        long id,
-        String name,
-        String description,
-        String managedById,
-        LocalDateTime createdDate,
-        LocalDateTime updatedAt) {
+public class Project {
 
-    public Project {
+    private final long id;
+    private final String name;
+    private final String description;
+    private final String managedById;
+    private final LocalDateTime createdDate;
+    private final LocalDateTime updatedAt;
+    private final List<Issue> issues = new ArrayList<>();
+    private final List<User> participants = new ArrayList<>();
+
+    public static Project create(long id, String name, String description, String managedById,
+                                  LocalDateTime createdDate, LocalDateTime updatedAt) {
+        return new Project(id, name, description, managedById, createdDate, updatedAt);
+    }
+
+    private Project(long id, String name, String description, String managedById,
+                    LocalDateTime createdDate, LocalDateTime updatedAt) {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(managedById, "managedById");
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.managedById = managedById;
+        this.createdDate = createdDate;
+        this.updatedAt = updatedAt;
+    }
+
+    // --- domain methods ---
+
+    public Issue registerIssue(
+            String issueId,
+            String title,
+            String description,
+            Priority priority,
+            User reporter,
+            LocalDateTime now
+    ) {
+        var issue = Issue.create(issueId, title, description, priority, reporter, now);
+        issues.add(issue);
+        return issue;
+    }
+
+    public void addParticipant(User user) {
+        Objects.requireNonNull(user, "user must not be null");
+        if (participants.stream().anyMatch(p -> p.getUserId().equals(user.getUserId()))) {
+            throw new IllegalArgumentException("user is already a participant");
+        }
+        participants.add(user);
+    }
+
+    public void removeParticipant(User user) {
+        Objects.requireNonNull(user, "user must not be null");
+        boolean removed = participants.removeIf(p -> p.getUserId().equals(user.getUserId()));
+        if (!removed) {
+            throw new IllegalArgumentException("user is not a participant");
+        }
+    }
+
+    // --- getters ---
+
+    public long id() {
+        return id;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public String managedById() {
+        return managedById;
+    }
+
+    public LocalDateTime createdDate() {
+        return createdDate;
+    }
+
+    public LocalDateTime updatedAt() {
+        return updatedAt;
+    }
+
+    // --- collection accessors ---
+
+    public List<Issue> getIssues() {
+        return Collections.unmodifiableList(issues);
+    }
+
+    public List<User> getParticipants() {
+        return Collections.unmodifiableList(participants);
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/User.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/User.java
@@ -3,9 +3,9 @@ package com.github.marcellokim.issuetracker.domain;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-public final class User {
+public class User {
 
-    private final String userId;
+    // loginId를 시스템 식별자로 겸용 (DCD: loginId가 유일 식별자)
     private final String loginId;
     private final String name;
     private final String password;
@@ -14,28 +14,12 @@ public final class User {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    public User(String userId, String loginId, String name, String passwordHash, Role role) {
-        this.userId = requireText(userId, "userId");
-        this.loginId = requireText(loginId, "loginId");
-        this.name = requireText(name, "name");
-        this.password = requireText(passwordHash, "passwordHash");
-        this.role = Objects.requireNonNull(role, "role must not be null");
-        this.active = true;
-        this.createdAt = null;
-        this.updatedAt = null;
+    public static User create(String loginId, String name, String password, Role role,
+                               boolean active, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        return new User(loginId, name, password, role, active, createdAt, updatedAt);
     }
 
-    public User(
-            String loginId,
-            String password,
-            Role role,
-            boolean active,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt) {
-        this(loginId, loginId, password, role, active, createdAt, updatedAt);
-    }
-
-    public User(
+    private User(
             String loginId,
             String name,
             String password,
@@ -44,7 +28,6 @@ public final class User {
             LocalDateTime createdAt,
             LocalDateTime updatedAt) {
         this.loginId = requireText(loginId, "loginId");
-        this.userId = this.loginId;
         this.name = requireText(name, "name");
         this.password = requireText(password, "password");
         this.role = Objects.requireNonNull(role, "role must not be null");
@@ -53,8 +36,21 @@ public final class User {
         this.updatedAt = updatedAt;
     }
 
+    // --- domain methods ---
+
+    public boolean hasRole(Role expectedRole) {
+        return role == expectedRole;
+    }
+
+    public void deactivate() {
+        active = false;
+    }
+
+    // --- getters ---
+
+    // getUserId()는 loginId를 반환 (하위 호환)
     public String getUserId() {
-        return userId;
+        return loginId;
     }
 
     public String getLoginId() {
@@ -77,13 +73,7 @@ public final class User {
         return active;
     }
 
-    public boolean hasRole(Role expectedRole) {
-        return role == expectedRole;
-    }
-
-    public void deactivate() {
-        active = false;
-    }
+    // --- record-style accessors (기존 호환) ---
 
     public String loginId() {
         return loginId;

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueRepository.java
@@ -673,7 +673,7 @@ public final class JdbcIssueRepository implements IssueRepository {
         if (loginId == null || loginId.isBlank()) {
             return null;
         }
-        return new User(
+        return User.create(
                 loginId,
                 resultSet.getString(prefix + "_name"),
                 resultSet.getString(prefix + "_password"),

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcProjectRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcProjectRepository.java
@@ -248,7 +248,7 @@ public final class JdbcProjectRepository implements ProjectRepository {
     }
 
     static Project mapProject(ResultSet resultSet) throws SQLException {
-        return new Project(
+        return Project.create(
                 resultSet.getLong("id"),
                 resultSet.getString("name"),
                 resultSet.getString("description"),

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcUserRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcUserRepository.java
@@ -265,7 +265,7 @@ public final class JdbcUserRepository implements UserRepository {
     }
 
     static User mapUser(ResultSet resultSet) throws SQLException {
-        return new User(
+        return User.create(
                 resultSet.getString("login_id"),
                 resultSet.getString("name"),
                 resultSet.getString("password"),

--- a/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerCoverageTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerCoverageTest.java
@@ -313,11 +313,11 @@ class ControllerCoverageTest {
     }
 
     private static User user(String loginId, Role role) {
-        return new User(loginId, loginId, "stored-password", role, true, NOW, NOW);
+        return User.create(loginId, loginId, "stored-password", role, true, NOW, NOW);
     }
 
     private static Project project(long projectId) {
-        return new Project(projectId, "project-" + projectId, "demo project", "admin", NOW, NOW);
+        return Project.create(projectId, "project-" + projectId, "demo project", "admin", NOW, NOW);
     }
 
     private static Issue issue(long id, long projectId, IssueStatus status) {

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/DomainValueObjectsTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/DomainValueObjectsTest.java
@@ -20,7 +20,8 @@ import org.junit.jupiter.api.Test;
 class DomainValueObjectsTest {
 
     private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 19, 14, 0);
-    private final User dev = new User("dev1", "dev1", "Developer One", "hash", Role.DEV);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User dev = User.create("dev1", "Developer One", "hash", Role.DEV, true, null, null);
 
     @Test
     @DisplayName("assignment candidate builds default reasons")

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueAssignmentRoleTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueAssignmentRoleTest.java
@@ -11,12 +11,18 @@ import org.junit.jupiter.api.Test;
 @DisplayName("이슈 배정 역할")
 class IssueAssignmentRoleTest {
 
-    private final User reporter = new User("U-1", "tester1", "Tester One", "hash", Role.TESTER);
-    private final User assignee = new User("U-2", "dev1", "Dev One", "hash", Role.DEV);
-    private final User anotherAssignee = new User("U-5", "dev2", "Dev Two", "hash", Role.DEV);
-    private final User verifier = new User("U-3", "tester2", "Tester Two", "hash", Role.TESTER);
-    private final User anotherVerifier = new User("U-6", "tester3", "Tester Three", "hash", Role.TESTER);
-    private final User pl = new User("U-4", "pl1", "PL One", "hash", Role.PL);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User reporter = User.create("tester1", "Tester One", "hash", Role.TESTER, true, null, null);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User assignee = User.create("dev1", "Dev One", "hash", Role.DEV, true, null, null);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User anotherAssignee = User.create("dev2", "Dev Two", "hash", Role.DEV, true, null, null);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User verifier = User.create("tester2", "Tester Two", "hash", Role.TESTER, true, null, null);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User anotherVerifier = User.create("tester3", "Tester Three", "hash", Role.TESTER, true, null, null);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User pl = User.create("pl1", "PL One", "hash", Role.PL, true, null, null);
     private final LocalDateTime createdAt = LocalDateTime.of(2026, 5, 18, 10, 0);
 
     @Test
@@ -107,8 +113,10 @@ class IssueAssignmentRoleTest {
     @Test
     @DisplayName("비활성 사용자는 assignee 또는 verifier가 될 수 없다")
     void rejectInactiveAssignmentParticipants() {
-        var inactiveAssignee = new User("U-5", "dev2", "Dev Two", "hash", Role.DEV);
-        var inactiveVerifier = new User("U-6", "tester3", "Tester Three", "hash", Role.TESTER);
+        // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+        var inactiveAssignee = User.create("dev2", "Dev Two", "hash", Role.DEV, true, null, null);
+        // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+        var inactiveVerifier = User.create("tester3", "Tester Three", "hash", Role.TESTER, true, null, null);
         inactiveAssignee.deactivate();
         inactiveVerifier.deactivate();
 
@@ -149,7 +157,8 @@ class IssueAssignmentRoleTest {
         var assignedIssue = assignedIssue();
         var fixedIssue = assignedIssue();
         fixedIssue.markFixed(assignee, "Fix completed", createdAt.plusMinutes(20));
-        var inactiveDev = new User("U-7", "dev3", "Dev Three", "hash", Role.DEV);
+        // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+        var inactiveDev = User.create("dev3", "Dev Three", "hash", Role.DEV, true, null, null);
         inactiveDev.deactivate();
 
         assertThrows(IllegalArgumentException.class,

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueChangeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueChangeTest.java
@@ -12,10 +12,14 @@ import org.junit.jupiter.api.Test;
 @DisplayName("이슈 변경")
 class IssueChangeTest {
 
-    private final User reporter = new User("U-1", "tester1", "Tester One", "hash", Role.TESTER);
-    private final User pl = new User("U-2", "pl1", "PL One", "hash", Role.PL);
-    private final User assignee = new User("U-3", "dev1", "Dev One", "hash", Role.DEV);
-    private final User verifier = new User("U-4", "tester2", "Tester Two", "hash", Role.TESTER);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User reporter = User.create("tester1", "Tester One", "hash", Role.TESTER, true, null, null);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User pl = User.create("pl1", "PL One", "hash", Role.PL, true, null, null);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User assignee = User.create("dev1", "Dev One", "hash", Role.DEV, true, null, null);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User verifier = User.create("tester2", "Tester Two", "hash", Role.TESTER, true, null, null);
     private final LocalDateTime createdAt = LocalDateTime.of(2026, 5, 18, 10, 0);
 
     @Test

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCommentTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCommentTest.java
@@ -12,8 +12,10 @@ import org.junit.jupiter.api.Test;
 @DisplayName("이슈 댓글")
 class IssueCommentTest {
 
-    private final User reporter = new User("U-1", "tester1", "Tester One", "hash", Role.TESTER);
-    private final User developer = new User("U-2", "dev1", "Dev One", "hash", Role.DEV);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User reporter = User.create("tester1", "Tester One", "hash", Role.TESTER, true, null, null);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User developer = User.create("dev1", "Dev One", "hash", Role.DEV, true, null, null);
     private final LocalDateTime createdAt = LocalDateTime.of(2026, 5, 18, 10, 0);
 
     @Test

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCreationTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCreationTest.java
@@ -13,7 +13,8 @@ import org.junit.jupiter.api.Test;
 @DisplayName("이슈 생성")
 class IssueCreationTest {
 
-    private final User reporter = new User("U-1", "tester1", "Tester One", "hash", Role.TESTER);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User reporter = User.create("tester1", "Tester One", "hash", Role.TESTER, true, null, null);
     private final LocalDateTime now = LocalDateTime.of(2026, 5, 18, 10, 0);
 
     @Test

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueDependencyTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueDependencyTest.java
@@ -13,8 +13,10 @@ import org.junit.jupiter.api.Test;
 @DisplayName("이슈 의존성")
 class IssueDependencyTest {
 
-    private final User reporter = new User("U-1", "tester1", "Tester One", "hash", Role.TESTER);
-    private final User pl = new User("U-2", "pl1", "PL One", "hash", Role.PL);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User reporter = User.create("tester1", "Tester One", "hash", Role.TESTER, true, null, null);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User pl = User.create("pl1", "PL One", "hash", Role.PL, true, null, null);
     private final LocalDateTime createdAt = LocalDateTime.of(2026, 5, 18, 10, 0);
 
     @Test

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueFixResolveTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueFixResolveTest.java
@@ -11,12 +11,18 @@ import org.junit.jupiter.api.Test;
 @DisplayName("이슈 수정 완료와 검증 완료")
 class IssueFixResolveTest {
 
-    private final User reporter = new User("U-1", "tester1", "Tester One", "hash", Role.TESTER);
-    private final User assignee = new User("U-2", "dev1", "Dev One", "hash", Role.DEV);
-    private final User otherDeveloper = new User("U-5", "dev2", "Dev Two", "hash", Role.DEV);
-    private final User verifier = new User("U-3", "tester2", "Tester Two", "hash", Role.TESTER);
-    private final User otherTester = new User("U-6", "tester3", "Tester Three", "hash", Role.TESTER);
-    private final User pl = new User("U-4", "pl1", "PL One", "hash", Role.PL);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User reporter = User.create("tester1", "Tester One", "hash", Role.TESTER, true, null, null);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User assignee = User.create("dev1", "Dev One", "hash", Role.DEV, true, null, null);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User otherDeveloper = User.create("dev2", "Dev Two", "hash", Role.DEV, true, null, null);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User verifier = User.create("tester2", "Tester Two", "hash", Role.TESTER, true, null, null);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User otherTester = User.create("tester3", "Tester Three", "hash", Role.TESTER, true, null, null);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User pl = User.create("pl1", "PL One", "hash", Role.PL, true, null, null);
     private final LocalDateTime createdAt = LocalDateTime.of(2026, 5, 18, 10, 0);
 
     @Test
@@ -120,8 +126,10 @@ class IssueFixResolveTest {
     @Test
     @DisplayName("비활성 사용자는 fixer 또는 resolver가 될 수 없다")
     void rejectInactiveFixerAndResolver() {
-        var inactiveFixer = new User("U-5", "dev2", "Dev Two", "hash", Role.DEV);
-        var inactiveResolver = new User("U-6", "tester3", "Tester Three", "hash", Role.TESTER);
+        // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+        var inactiveFixer = User.create("dev2", "Dev Two", "hash", Role.DEV, true, null, null);
+        // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+        var inactiveResolver = User.create("tester3", "Tester Three", "hash", Role.TESTER, true, null, null);
         inactiveFixer.deactivate();
         inactiveResolver.deactivate();
 

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueHistoryTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueHistoryTest.java
@@ -13,7 +13,8 @@ import org.junit.jupiter.api.Test;
 class IssueHistoryTest {
 
     private static final LocalDateTime CHANGED_AT = LocalDateTime.of(2026, 5, 19, 13, 0);
-    private final User pl = new User("pl1", "pl1", "PL One", "hash", Role.PL);
+    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+    private final User pl = User.create("pl1", "PL One", "hash", Role.PL, true, null, null);
 
     @Test
     @DisplayName("preserves persisted history fields")

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/UserTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/UserTest.java
@@ -14,9 +14,10 @@ class UserTest {
     @Test
     @DisplayName("사용자는 인증 식별자와 역할을 가진 활성 계정으로 생성된다")
     void createActiveUserWithLoginIdentifierAndRole() {
-        var user = new User("U-1", "dev1", "Dev One", "hash", Role.DEV);
+        // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+        var user = User.create("dev1", "Dev One", "hash", Role.DEV, true, null, null);
 
-        assertEquals("U-1", user.getUserId());
+        assertEquals("dev1", user.getUserId());
         assertEquals("dev1", user.getLoginId());
         assertEquals("Dev One", user.getName());
         assertEquals("hash", user.getPasswordHash());
@@ -29,27 +30,28 @@ class UserTest {
     @Test
     @DisplayName("사용자 핵심 값은 비어 있을 수 없다")
     void rejectBlankUserFields() {
+        // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
         assertThrows(IllegalArgumentException.class,
-                () -> new User("", "dev1", "Dev One", "hash", Role.DEV));
+                () -> User.create("", "Dev One", "hash", Role.DEV, true, null, null));
         assertThrows(IllegalArgumentException.class,
-                () -> new User("U-1", " ", "Dev One", "hash", Role.DEV));
+                () -> User.create("dev1", " ", "hash", Role.DEV, true, null, null));
         assertThrows(IllegalArgumentException.class,
-                () -> new User("U-1", "dev1", "", "hash", Role.DEV));
-        assertThrows(IllegalArgumentException.class,
-                () -> new User("U-1", "dev1", "Dev One", "", Role.DEV));
+                () -> User.create("dev1", "Dev One", "", Role.DEV, true, null, null));
     }
 
     @Test
     @DisplayName("사용자 역할은 필수 값이다")
     void rejectMissingRole() {
+        // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
         assertThrows(NullPointerException.class,
-                () -> new User("U-1", "dev1", "Dev One", "hash", null));
+                () -> User.create("dev1", "Dev One", "hash", null, true, null, null));
     }
 
     @Test
     @DisplayName("사용자는 비활성화될 수 있다")
     void deactivateUser() {
-        var user = new User("U-1", "dev1", "Dev One", "hash", Role.DEV);
+        // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+        var user = User.create("dev1", "Dev One", "hash", Role.DEV, true, null, null);
 
         user.deactivate();
 

--- a/src/test/java/com/github/marcellokim/issuetracker/persistence/OracleRepositoryIntegrationTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/persistence/OracleRepositoryIntegrationTest.java
@@ -352,7 +352,7 @@ class OracleRepositoryIntegrationTest {
         LocalDateTime now = LocalDateTime.now();
 
         try {
-            User created = repositories.users().save(new User(
+            User created = repositories.users().save(User.create(
                     loginId,
                     "Repository CRUD Dev",
                     "InitialPassword!",
@@ -366,7 +366,7 @@ class OracleRepositoryIntegrationTest {
             assertEquals(Role.DEV, repositories.users().findByLoginId(loginId).orElseThrow().role());
             assertTrue(repositories.users().findAll().stream().anyMatch(user -> user.loginId().equals(loginId)));
 
-            User updated = repositories.users().save(new User(
+            User updated = repositories.users().save(User.create(
                     loginId,
                     "Repository CRUD Tester",
                     "UpdatedPassword!",
@@ -395,7 +395,7 @@ class OracleRepositoryIntegrationTest {
         Issue issue = null;
 
         try {
-            project = repositories.projects().save(new Project(
+            project = repositories.projects().save(Project.create(
                     0L,
                     projectName,
                     "Repository CRUD test project.",
@@ -405,7 +405,7 @@ class OracleRepositoryIntegrationTest {
 
             assertEquals(projectName, repositories.projects().findByName(projectName).orElseThrow().name());
 
-            Project updated = repositories.projects().save(new Project(
+            Project updated = repositories.projects().save(Project.create(
                     project.id(),
                     project.name(),
                     "Updated repository CRUD test project.",

--- a/src/test/java/com/github/marcellokim/issuetracker/service/AssignmentRecommendationServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/AssignmentRecommendationServiceTest.java
@@ -86,7 +86,8 @@ class AssignmentRecommendationServiceTest {
     }
 
     private static User user(String loginId, Role role) {
-        return new User(loginId, loginId, loginId, "hash", role);
+        // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+        return User.create(loginId, loginId, "hash", role, true, null, null);
     }
 
     private static final class FakeAssignmentRecommendationRepository implements AssignmentRecommendationRepository {

--- a/src/test/java/com/github/marcellokim/issuetracker/service/AssignmentServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/AssignmentServiceTest.java
@@ -24,12 +24,12 @@ class AssignmentServiceTest {
 
     private static final long PROJECT_ID = 10L;
     private static final long ISSUE_ID = 1L;
-    private final User reporter = new User("tester1", "Tester One", "hash", Role.TESTER, true, createdAt(), createdAt());
-    private final User assignee = new User("dev1", "Dev One", "hash", Role.DEV, true, createdAt(), createdAt());
-    private final User verifier = new User("tester2", "Tester Two", "hash", Role.TESTER, true, createdAt(), createdAt());
-    private final User pl = new User("pl1", "PL One", "hash", Role.PL, true, createdAt(), createdAt());
-    private final User anotherAssignee = new User("dev2", "Dev Two", "hash", Role.DEV, true, createdAt(), createdAt());
-    private final User anotherVerifier = new User("tester3", "Tester Three", "hash", Role.TESTER, true, createdAt(), createdAt());
+    private final User reporter = User.create("tester1", "Tester One", "hash", Role.TESTER, true, createdAt(), createdAt());
+    private final User assignee = User.create("dev1", "Dev One", "hash", Role.DEV, true, createdAt(), createdAt());
+    private final User verifier = User.create("tester2", "Tester Two", "hash", Role.TESTER, true, createdAt(), createdAt());
+    private final User pl = User.create("pl1", "PL One", "hash", Role.PL, true, createdAt(), createdAt());
+    private final User anotherAssignee = User.create("dev2", "Dev Two", "hash", Role.DEV, true, createdAt(), createdAt());
+    private final User anotherVerifier = User.create("tester3", "Tester Three", "hash", Role.TESTER, true, createdAt(), createdAt());
 
     @Test
     @DisplayName("배정 시작은 이슈 상태에 맞는 추천 후보 구조를 반환한다")

--- a/src/test/java/com/github/marcellokim/issuetracker/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/AuthenticationServiceTest.java
@@ -103,7 +103,8 @@ class AuthenticationServiceTest {
 
     private static User user(String loginId, String password, Role role, boolean active) {
         LocalDateTime timestamp = LocalDateTime.of(2026, 5, 18, 0, 0);
-        return new User(loginId, PASSWORD_HASHER.hash(password), role, active, timestamp, timestamp);
+        // userId 제거: 6-param → 7-param 통합 (DCD ver1 기준)
+        return User.create(loginId, loginId, PASSWORD_HASHER.hash(password), role, active, timestamp, timestamp);
     }
 
     private static final class FakeUserRepository implements UserRepository {
@@ -147,9 +148,11 @@ class AuthenticationServiceTest {
 
         @Override
         public void deactivate(String loginId) {
+            // userId 제거: 6-param → 7-param 통합 (DCD ver1 기준)
             findById(loginId).ifPresent(user -> usersByLoginId.put(
                     user.loginId(),
-                    new User(
+                    User.create(
+                            user.loginId(),
                             user.loginId(),
                             user.password(),
                             user.role(),

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
@@ -22,11 +22,11 @@ class IssueStateServiceTest {
 
     private static final long PROJECT_ID = 10L;
     private static final long ISSUE_ID = 1L;
-    private final User reporter = new User("tester1", "Tester One", "hash", Role.TESTER, true, createdAt(), createdAt());
-    private final User assignee = new User("dev1", "Dev One", "hash", Role.DEV, true, createdAt(), createdAt());
-    private final User verifier = new User("tester2", "Tester Two", "hash", Role.TESTER, true, createdAt(), createdAt());
-    private final User pl = new User("pl1", "PL One", "hash", Role.PL, true, createdAt(), createdAt());
-    private final User otherDev = new User("dev2", "Dev Two", "hash", Role.DEV, true, createdAt(), createdAt());
+    private final User reporter = User.create("tester1", "Tester One", "hash", Role.TESTER, true, createdAt(), createdAt());
+    private final User assignee = User.create("dev1", "Dev One", "hash", Role.DEV, true, createdAt(), createdAt());
+    private final User verifier = User.create("tester2", "Tester Two", "hash", Role.TESTER, true, createdAt(), createdAt());
+    private final User pl = User.create("pl1", "PL One", "hash", Role.PL, true, createdAt(), createdAt());
+    private final User otherDev = User.create("dev2", "Dev Two", "hash", Role.DEV, true, createdAt(), createdAt());
 
     @Test
     @DisplayName("assignee DEV는 ASSIGNED 이슈를 FIXED로 변경한다")

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueWorkflowServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueWorkflowServiceTest.java
@@ -25,10 +25,10 @@ class IssueWorkflowServiceTest {
     private static final long PROJECT_ID = 10L;
     private static final long ISSUE_ID = 1L;
     private static final LocalDateTime CREATED_AT = LocalDateTime.of(2026, 5, 18, 10, 0);
-    private final User reporter = new User("tester1", "Tester One", "hash", Role.TESTER, true, CREATED_AT, CREATED_AT);
-    private final User assignee = new User("dev1", "Dev One", "hash", Role.DEV, true, CREATED_AT, CREATED_AT);
-    private final User verifier = new User("tester2", "Tester Two", "hash", Role.TESTER, true, CREATED_AT, CREATED_AT);
-    private final User pl = new User("pl1", "PL One", "hash", Role.PL, true, CREATED_AT, CREATED_AT);
+    private final User reporter = User.create("tester1", "Tester One", "hash", Role.TESTER, true, CREATED_AT, CREATED_AT);
+    private final User assignee = User.create("dev1", "Dev One", "hash", Role.DEV, true, CREATED_AT, CREATED_AT);
+    private final User verifier = User.create("tester2", "Tester Two", "hash", Role.TESTER, true, CREATED_AT, CREATED_AT);
+    private final User pl = User.create("pl1", "PL One", "hash", Role.PL, true, CREATED_AT, CREATED_AT);
 
     @Test
     @DisplayName("tester -> PL -> dev -> tester -> PL 메인 데모 흐름이 완료된다")

--- a/src/test/java/com/github/marcellokim/issuetracker/service/PermissionPolicyTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/PermissionPolicyTest.java
@@ -25,7 +25,7 @@ class PermissionPolicyTest {
     private final User pl = user("pl1", Role.PL);
     private final User dev = user("dev1", Role.DEV);
     private final User tester = user("tester1", Role.TESTER);
-    private final Project project = new Project(1L, "project1", "Demo project", "admin", NOW, NOW);
+    private final Project project = Project.create(1L, "project1", "Demo project", "admin", NOW, NOW);
 
     @Test
     @DisplayName("allows ADMIN account and project management only")
@@ -145,7 +145,7 @@ class PermissionPolicyTest {
     @Test
     @DisplayName("rejects issue registration without an active auth actor or persisted project")
     void rejectsInvalidIssueRegistrationRequests() {
-        Project transientProject = new Project(0L, "draft", "Draft project", "admin", NOW, NOW);
+        Project transientProject = Project.create(0L, "draft", "Draft project", "admin", NOW, NOW);
 
         assertThrows(SecurityException.class, () -> policy.assertCanRegisterIssue(inactive("dev2", Role.DEV), project));
         assertThrows(SecurityException.class, () -> policy.assertCanRegisterIssue(admin, project));
@@ -179,7 +179,8 @@ class PermissionPolicyTest {
     }
 
     private static User user(String loginId, Role role) {
-        return new User(loginId, loginId, loginId, "hash", role);
+        // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+        return User.create(loginId, loginId, "hash", role, true, null, null);
     }
 
     private static User inactive(String loginId, Role role) {

--- a/src/test/java/com/github/marcellokim/issuetracker/technical/SessionStoreTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/technical/SessionStoreTest.java
@@ -17,7 +17,8 @@ class SessionStoreTest {
     @DisplayName("starts, reads, and clears a user session")
     void startsReadsAndClearsSession() {
         SessionStore store = new SessionStore();
-        User user = new User("dev1", "dev1", "Developer One", "hash", Role.DEV);
+        // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
+        User user = User.create("dev1", "Developer One", "hash", Role.DEV, true, null, null);
 
         assertFalse(store.currentUser().isPresent());
 


### PR DESCRIPTION
## 요약
- 관련 이슈: Closes #16
- 변경 목적: User/Project 도메인 모델을 DCD ver1 기준에 맞춰 정비. userId를 제거하고 loginId로 식별자 통합, 생성자를 private + 팩토리 패턴으로 통일.

## 변경 분류
- [x] 기능 개발
- [ ] 버그 수정
- [ ] 테스트 보강
- [x] 문서화
- [ ] 환경설정 / 자동화

## 검증 내역
- [x] `./gradlew check`
- [ ] 수동 기능 확인
- [ ] CI 통과 확인
- 결과 요약: `BUILD SUCCESSFUL` — 컴파일 및 전체 테스트 통과 확인 완료

## 과제 요구사항 영향
- [x] MVC 분리 관련 변경 반영
- [x] Persistence 관련 변경 반영
- [ ] 다중 UI toolkit 영향 확인
- [ ] 통계 / 추천 기능 영향 확인
- [ ] 해당 없음

## 문서 및 증빙
- [ ] README 반영
- [x] docs/ 반영
- [ ] 스크린샷 또는 GIF 첨부
- [ ] GitHub 프로젝트 상태 업데이트
- [ ] 해당 없음

## 리뷰 포인트
- 집중해서 봐야 할 부분:
  - `User.java`: userId 필드 제거 후 loginId 단일 식별자 구조가 기존 호출부와 정합성 유지되는지
  - `Project.java`: record → class 전환 후 기존 record-style accessor(`id()`, `name()` 등)가 유지되는지
- 남아 있는 위험/후속 작업:
  - `AccountController.createAccount()` (issue #108, marcellokim 담당)에서 loginId 중복 체크 구현 필요
  - SSD-16에 사전조건으로 명시된 "loginId 중복 없음" 검증이 아직 코드에 없음

## 변경 파일 상세

### 도메인 (2개)
| 파일 | 변경 |
|------|------|
| `User.java` | userId 제거, 7-param 생성자 하나로 통일 (private + `create()` 팩토리) |
| `Project.java` | record → class 전환, private 생성자 + `create()` 팩토리, DCD 메서드 포함 |

### DCD (2개)
| 파일 | 변경 |
|------|------|
| `its_dcd_ver1.puml` | User에서 `-userId: UserId` 제거, 파라미터명 `userId` → `loginId` 통일 |
| `its_dcd_ver2.puml` | User에서 `- userId : UserId` 제거 |

### JDBC (3개)
| 파일 | 변경 |
|------|------|
| `JdbcProjectRepository.java` | `new Project()` → `Project.create()` |
| `JdbcIssueRepository.java` | `new Project()` → `Project.create()` |
| `JdbcUserRepository.java` | `new User()` → `User.create()` |

### 테스트 (18개)
- `User.create()` 5/6-param → 7-param 일괄 전환
- 변환된 호출부에 `// userId 제거` 주석 추가