### PR TITLE
feat: 도메인 작성 위한 프리즈, 컨플릭트 머지됨

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/controller/IssueController.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/controller/IssueController.java
@@ -1,40 +1,38 @@
 package com.github.marcellokim.issuetracker.controller;
 
-import com.github.marcellokim.issuetracker.repository.IssueRepository;
-import com.github.marcellokim.issuetracker.repository.ProjectRepository;
-import com.github.marcellokim.issuetracker.repository.UserRepository;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.User;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
-import com.github.marcellokim.issuetracker.service.Clock;
-import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.service.CommentResult;
+import com.github.marcellokim.issuetracker.service.IssueResult;
+import com.github.marcellokim.issuetracker.service.IssueService;
 import java.util.Objects;
 
 public final class IssueController {
 
     private final AuthenticationService authenticationService;
-    private final PermissionPolicy permissionPolicy;
-    private final ProjectRepository projectRepository;
-    private final IssueRepository issueRepository;
-    private final UserRepository userRepository;
-    private final Clock clock;
+    private final IssueService issueService;
 
     public IssueController(
             AuthenticationService authenticationService,
-            PermissionPolicy permissionPolicy,
-            ProjectRepository projectRepository,
-            IssueRepository issueRepository,
-            UserRepository userRepository,
-            Clock clock
+            IssueService issueService
     ) {
         this.authenticationService = Objects.requireNonNull(authenticationService, "authenticationService");
-        this.permissionPolicy = Objects.requireNonNull(permissionPolicy, "permissionPolicy");
-        this.projectRepository = Objects.requireNonNull(projectRepository, "projectRepository");
-        this.issueRepository = Objects.requireNonNull(issueRepository, "issueRepository");
-        this.userRepository = Objects.requireNonNull(userRepository, "userRepository");
-        this.clock = Objects.requireNonNull(clock, "clock");
+        this.issueService = Objects.requireNonNull(issueService, "issueService");
     }
 
-    /*
-     * 다른 팀원이 구현해야하는 부분:
-     * 이슈 등록/검색/상세 조회/수정 UC의 입력 검증, DTO 변환, UI 요청 처리를 구현한다.
-     */
+    public IssueResult registerIssue(long projectId, String title, String description, Priority priority) {
+        User user = requireCurrentUser();
+        return issueService.registerIssue(projectId, title, description, priority, user.getLoginId());
+    }
+
+    public CommentResult addComment(long issueId, String content) {
+        User user = requireCurrentUser();
+        return issueService.addComment(issueId, content, user.getLoginId());
+    }
+
+    private User requireCurrentUser() {
+        return authenticationService.currentUser()
+                .orElseThrow(() -> new SecurityException("Login is required."));
+    }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Comment.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Comment.java
@@ -47,6 +47,7 @@ public final class Comment {
         return new Comment(commentId, content, writer, createdDate);
     }
 
+    // --- getters ---
     public long id() {
         return id;
     }

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Issue.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Issue.java
@@ -88,7 +88,7 @@ public class Issue {
         recordHistory(ActionType.CREATED, CREATED_PREVIOUS_VALUE, IssueStatus.NEW.name(), "Issue created", reporter, reportedDate);
     }
 
-    public static Issue create(
+    public static Issue create( // 테스트용 생성 메서드, 실제로는 Persistence 계층에서 PersistedState를 통해 생성
             String issueId,
             String title,
             String description,
@@ -111,6 +111,7 @@ public class Issue {
         return new Issue(state, false);
     }
 
+    // --- getters ---
     public long id() {
         return id;
     }
@@ -223,6 +224,7 @@ public class Issue {
         return Collections.unmodifiableList(blockedByDependencies);
     }
 
+    // --- status management ---
     public void assignFromNew(User assignee, User verifier, User changedBy, LocalDateTime changedDate) {
         requireStatus(IssueStatus.NEW);
         assign(assignee, verifier, changedBy, changedDate, "Issue assigned from NEW");
@@ -327,6 +329,15 @@ public class Issue {
         changeStatusTo(IssueStatus.REOPENED, requiredComment, changedBy, changedDate);
     }
 
+    public void rejectFix(User tester, String comment, LocalDateTime changedDate) {
+        requireStatus(IssueStatus.FIXED);
+        requireRole(tester, Role.TESTER, "tester");
+        requireCurrentParticipant(tester, verifier, "tester must be current verifier");
+        var requiredComment = requireText(comment, COMMENT_FIELD);
+        changeStatusTo(IssueStatus.ASSIGNED, requiredComment, tester, changedDate);
+    }
+
+    // --- other methods ---
     public IssueDependency addDependency(
             String dependencyId,
             Issue blockingIssue,
@@ -378,7 +389,36 @@ public class Issue {
                 changedDate
         );
     }
+    public void updateTitleAndDescription(
+        String newTitle,
+        String newDescription,
+        User changer,
+        LocalDateTime changedDate
+    ) {
+        Objects.requireNonNull(changer, CHANGED_BY_REQUIRED);
+        Objects.requireNonNull(changedDate, CHANGED_DATE_REQUIRED);
 
+        if (!sameUser(changer, reporter)) {
+            throw new IllegalArgumentException("changer must be Reporter");
+        }
+        if (status != IssueStatus.NEW && status != IssueStatus.REOPENED) {
+            throw new IllegalStateException("Issue status must be before Assigned");
+        }
+        String previousValue = title + "\n" + description;
+        this.title = requireText(newTitle, "title");
+        this.description = requireText(newDescription, "description");
+        this.updatedAt = changedDate;
+        recordHistory(
+            ActionType.TITLE_DESCRIPTION_UPDATED,
+            previousValue,
+            title + "\n" + description,
+            "Title and description changed",
+            changer,
+            changedDate
+        );
+    }
+
+    // --- general-purpose private methods ---
     private void changeStatusTo(IssueStatus targetStatus, String message, User changedBy, LocalDateTime changedDate) {
         Objects.requireNonNull(targetStatus, "targetStatus must not be null");
         Objects.requireNonNull(changedBy, CHANGED_BY_REQUIRED);

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Project.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Project.java
@@ -6,11 +6,11 @@ import java.util.Objects;
 public class Project {
 
     private final long id;
-    private final String name;
-    private final String description;
+    private String name;
+    private String description;
     private final String managedById;
     private final LocalDateTime createdDate;
-    private final LocalDateTime updatedAt;
+    private LocalDateTime updatedAt;
 
     // factory
     public static Project create(long id, String name, String description, String managedById,
@@ -24,14 +24,37 @@ public class Project {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(managedById, "managedById");
         this.id = id;
-        this.name = name;
+        this.name = requireText(name, "name");
         this.description = description;
-        this.managedById = managedById;
+        this.managedById = managedById; // AdminID
         this.createdDate = createdDate;
         this.updatedAt = updatedAt;
     }
 
     // --- domain methods ---
+
+    public Issue registerIssue(
+            String issueId,
+            String title,
+            String description,
+            Priority priority,
+            User reporter,
+            LocalDateTime now
+    ) {
+        return Issue.create(issueId, title, description, priority, reporter, now);
+    }
+
+    // --- setters ---
+
+    public void rename(String newName, LocalDateTime updatedAt) {
+        this.name = requireText(newName, "name");
+        this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt");
+    }
+
+    public void changeDescription(String newDescription, LocalDateTime updatedAt) {
+        this.description = newDescription;
+        this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt");
+    }
 
     // --- getters ---
 
@@ -57,6 +80,13 @@ public class Project {
 
     public LocalDateTime getUpdatedAt() {
         return updatedAt;
+    }
+
+    private static String requireText(String text, String fieldName) {
+        if (text == null || text.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return text;
     }
 
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/service/CommentResult.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/CommentResult.java
@@ -1,0 +1,12 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.User;
+import java.time.LocalDateTime;
+
+public record CommentResult(
+        String commentId,
+        String content,
+        User writer,
+        LocalDateTime createdDate
+) {
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueResult.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueResult.java
@@ -1,0 +1,15 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.User;
+
+public record IssueResult(
+        String issueId,
+        IssueStatus status,
+        Priority priority,
+        String title,
+        String description,
+        User reporter
+) {
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
@@ -1,0 +1,102 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.Comment;
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Project;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.IssueRepository;
+import com.github.marcellokim.issuetracker.repository.ProjectRepository;
+import com.github.marcellokim.issuetracker.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public final class IssueService {
+
+    private final ProjectRepository projectRepository;
+    private final IssueRepository issueRepository;
+    private final UserRepository userRepository;
+    private final PermissionPolicy permissionPolicy;
+    private final Clock clock;
+
+    public IssueService(
+            ProjectRepository projectRepository,
+            IssueRepository issueRepository,
+            UserRepository userRepository,
+            PermissionPolicy permissionPolicy,
+            Clock clock
+    ) {
+        this.projectRepository = Objects.requireNonNull(projectRepository, "projectRepository");
+        this.issueRepository = Objects.requireNonNull(issueRepository, "issueRepository");
+        this.userRepository = Objects.requireNonNull(userRepository, "userRepository");
+        this.permissionPolicy = Objects.requireNonNull(permissionPolicy, "permissionPolicy");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    public IssueResult registerIssue(long projectId, String title, String description, Priority priority, String currentUserId) {
+        Project project = findProject(projectId);
+        User reporter = findUser(currentUserId);
+        permissionPolicy.assertCanRegisterIssue(reporter, project);
+        LocalDateTime now = now();
+        Issue issue = Issue.newForPersistence(
+                Issue.persistedState(project.getId(), title, description, reporter)
+                        .priority(priority != null ? priority : Priority.MAJOR)
+                        .reportedDate(now)
+                        .updatedAt(now)
+        );
+        Issue saved = issueRepository.save(issue);
+        return toIssueResult(saved);
+    }
+
+    public CommentResult addComment(long issueId, String content, String currentUserId) {
+        Issue issue = findIssue(issueId);
+        User writer = findUser(currentUserId);
+        LocalDateTime now = now();
+        Comment comment = issue.addComment(nextCommentId(issue), content, writer, now);
+        issueRepository.save(issue);
+        return toCommentResult(comment);
+    }
+
+    private Project findProject(long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("Project not found: " + projectId));
+    }
+
+    private Issue findIssue(long issueId) {
+        return issueRepository.findById(issueId)
+                .orElseThrow(() -> new IllegalArgumentException("Issue not found: " + issueId));
+    }
+
+    private User findUser(String userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+    }
+
+    private LocalDateTime now() {
+        return clock.now();
+    }
+
+    private static String nextCommentId(Issue issue) {
+        return issue.getIssueId() + "-C" + (issue.getComments().size() + 1);
+    }
+
+    private static IssueResult toIssueResult(Issue issue) {
+        return new IssueResult(
+                issue.getIssueId(),
+                issue.status(),
+                issue.priority(),
+                issue.title(),
+                issue.description(),
+                issue.getReporter()
+        );
+    }
+
+    private static CommentResult toCommentResult(Comment comment) {
+        return new CommentResult(
+                comment.getCommentId(),
+                comment.getContent(),
+                comment.getWriter(),
+                comment.getCreatedDate()
+        );
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerCoverageTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerCoverageTest.java
@@ -269,7 +269,9 @@ class ControllerCoverageTest {
         Clock clock = new Clock();
 
         assertDoesNotThrow(() -> new AccountController(auth.service(), policy, users, new PasswordHasher()));
-        assertDoesNotThrow(() -> new IssueController(auth.service(), policy, projects, issues, users, clock));
+        assertDoesNotThrow(() -> new IssueController(
+                auth.service(),
+                new com.github.marcellokim.issuetracker.service.IssueService(projects, issues, users, policy, clock)));
         assertDoesNotThrow(() -> new IssueStateController(
                 auth.service(),
                 new com.github.marcellokim.issuetracker.service.IssueStateService(issues, users, policy, clock)));


### PR DESCRIPTION
## 요약
- 관련 이슈: Closes #119
- 변경 목적:
  - Domain freeze 과정에서 `User`, `Project`, `Issue` 도메인 클래스의 변경 가능 필드와 상태 전이 책임을 정리하고 구현합니다.
  - `Issue` title/description 수정 정책을 `NEW` 및 `REOPENED` 상태의 원래 reporter 기준으로 정리합니다.
  - issue/comment application flow를 위한 `IssueService`, `IssueResult`, `CommentResult`를 추가합니다.
  - domain에서 처리하지 않는 권한 검사, 저장, 중복/조회 판단 사항을 `docs/260520_Domain_Freeze.md`에 후속 작업으로 기록합니다.

## 변경 분류
- [x] 기능 개발
- [ ] 버그 수정
- [x] 테스트 보강
- [x] 문서화
- [ ] 환경설정 / 자동화

## 검증 내역
- [x] `./gradlew check`
- [ ] 수동 기능 확인
- [ ] CI 통과 확인
- 결과 요약:
  - 로컬에서 `./gradlew check` 통과 여부를 확인했습니다.
  - PR 생성 후 GitHub Actions CI 결과를 추가 확인할 예정입니다.

## 과제 요구사항 영향
- [x] MVC 분리 관련 변경 반영
- [x] Persistence 관련 변경 반영
- [ ] 다중 UI toolkit 영향 확인
- [ ] 통계 / 추천 기능 영향 확인
- [ ] 해당 없음

## 문서 및 증빙
- [ ] README 반영
- [x] docs/ 반영
- [ ] 스크린샷 또는 GIF 첨부
- [ ] GitHub 프로젝트 상태 업데이트
- [ ] 해당 없음

## 리뷰 포인트
- 집중해서 봐야 할 부분:
  - `Issue.updateTitleAndDescription(...)`가 `NEW` 및 `REOPENED` 상태에서만 동작하는지 확인이 필요합니다.
  - `reopen` 이후에도 `Issue.reporter`가 원래 등록자로 유지되고, PL은 `changedBy` / comment writer / history actor로만 기록되는지 확인이 필요합니다.
  - `User`와 `Project`의 변경 가능 필드가 domain method로만 제한되고, 권한 검사와 저장 책임이 application service로 분리되는지 확인이 필요합니다.
  - 새로 추가된 `IssueService`, `IssueResult`, `CommentResult`가 domain entity 책임을 침범하지 않고 application/service 반환 계층에 머무르는지 확인이 필요합니다.

- 남아 있는 위험/후속 작업:
  - `removeDependency` 및 dependency association cleanup은 아직 후속 구현 대상입니다.
  - dependency cycle/graph 검사는 repository 조회가 필요하므로 application service에서 추가 정리해야 합니다.
  - role 변경 가능 여부, 프로젝트명 중복 검사, 프로젝트 participant 관리 정책은 application service 테스트로 보강해야 합니다.
  - `REOPENED` 상태 title/description 수정 정책은 기존 `NEW only` 문구가 남아 있는 문서/테스트와 충돌하지 않는지 추가 검토가 필요합니다.