### PR TITLE
feat: freeze test conflict merged

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/controller/IssueController.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/controller/IssueController.java
@@ -1,40 +1,38 @@
 package com.github.marcellokim.issuetracker.controller;
 
-import com.github.marcellokim.issuetracker.repository.IssueRepository;
-import com.github.marcellokim.issuetracker.repository.ProjectRepository;
-import com.github.marcellokim.issuetracker.repository.UserRepository;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.User;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
-import com.github.marcellokim.issuetracker.service.Clock;
-import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.service.CommentResult;
+import com.github.marcellokim.issuetracker.service.IssueResult;
+import com.github.marcellokim.issuetracker.service.IssueService;
 import java.util.Objects;
 
 public final class IssueController {
 
     private final AuthenticationService authenticationService;
-    private final PermissionPolicy permissionPolicy;
-    private final ProjectRepository projectRepository;
-    private final IssueRepository issueRepository;
-    private final UserRepository userRepository;
-    private final Clock clock;
+    private final IssueService issueService;
 
     public IssueController(
             AuthenticationService authenticationService,
-            PermissionPolicy permissionPolicy,
-            ProjectRepository projectRepository,
-            IssueRepository issueRepository,
-            UserRepository userRepository,
-            Clock clock
+            IssueService issueService
     ) {
         this.authenticationService = Objects.requireNonNull(authenticationService, "authenticationService");
-        this.permissionPolicy = Objects.requireNonNull(permissionPolicy, "permissionPolicy");
-        this.projectRepository = Objects.requireNonNull(projectRepository, "projectRepository");
-        this.issueRepository = Objects.requireNonNull(issueRepository, "issueRepository");
-        this.userRepository = Objects.requireNonNull(userRepository, "userRepository");
-        this.clock = Objects.requireNonNull(clock, "clock");
+        this.issueService = Objects.requireNonNull(issueService, "issueService");
     }
 
-    /*
-     * 다른 팀원이 구현해야하는 부분:
-     * 이슈 등록/검색/상세 조회/수정 UC의 입력 검증, DTO 변환, UI 요청 처리를 구현한다.
-     */
+    public IssueResult registerIssue(long projectId, String title, String description, Priority priority) {
+        User user = requireCurrentUser();
+        return issueService.registerIssue(projectId, title, description, priority, user.getLoginId());
+    }
+
+    public CommentResult addComment(long issueId, String content) {
+        User user = requireCurrentUser();
+        return issueService.addComment(issueId, content, user.getLoginId());
+    }
+
+    private User requireCurrentUser() {
+        return authenticationService.currentUser()
+                .orElseThrow(() -> new SecurityException("Login is required."));
+    }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Comment.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Comment.java
@@ -47,6 +47,7 @@ public final class Comment {
         return new Comment(commentId, content, writer, createdDate);
     }
 
+    // --- getters ---
     public long id() {
         return id;
     }

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Issue.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Issue.java
@@ -88,7 +88,7 @@ public class Issue {
         recordHistory(ActionType.CREATED, CREATED_PREVIOUS_VALUE, IssueStatus.NEW.name(), "Issue created", reporter, reportedDate);
     }
 
-    public static Issue create(
+    public static Issue create( // 테스트용 생성 메서드, 실제로는 Persistence 계층에서 PersistedState를 통해 생성
             String issueId,
             String title,
             String description,
@@ -111,6 +111,7 @@ public class Issue {
         return new Issue(state, false);
     }
 
+    // --- getters ---
     public long id() {
         return id;
     }
@@ -223,6 +224,7 @@ public class Issue {
         return Collections.unmodifiableList(blockedByDependencies);
     }
 
+    // --- status management ---
     public void assignFromNew(User assignee, User verifier, User changedBy, LocalDateTime changedDate) {
         requireStatus(IssueStatus.NEW);
         assign(assignee, verifier, changedBy, changedDate, "Issue assigned from NEW");
@@ -327,6 +329,15 @@ public class Issue {
         changeStatusTo(IssueStatus.REOPENED, requiredComment, changedBy, changedDate);
     }
 
+    public void rejectFix(User tester, String comment, LocalDateTime changedDate) {
+        requireStatus(IssueStatus.FIXED);
+        requireRole(tester, Role.TESTER, "tester");
+        requireCurrentParticipant(tester, verifier, "tester must be current verifier");
+        var requiredComment = requireText(comment, COMMENT_FIELD);
+        changeStatusTo(IssueStatus.ASSIGNED, requiredComment, tester, changedDate);
+    }
+
+    // --- other methods ---
     public IssueDependency addDependency(
             String dependencyId,
             Issue blockingIssue,
@@ -378,7 +389,36 @@ public class Issue {
                 changedDate
         );
     }
+    public void updateTitleAndDescription(
+        String newTitle,
+        String newDescription,
+        User changer,
+        LocalDateTime changedDate
+    ) {
+        Objects.requireNonNull(changer, CHANGED_BY_REQUIRED);
+        Objects.requireNonNull(changedDate, CHANGED_DATE_REQUIRED);
 
+        if (!sameUser(changer, reporter)) {
+            throw new IllegalArgumentException("changer must be Reporter");
+        }
+        if (status != IssueStatus.NEW && status != IssueStatus.REOPENED) {
+            throw new IllegalStateException("Issue status must be before Assigned");
+        }
+        String previousValue = title + "\n" + description;
+        this.title = requireText(newTitle, "title");
+        this.description = requireText(newDescription, "description");
+        this.updatedAt = changedDate;
+        recordHistory(
+            ActionType.TITLE_DESCRIPTION_UPDATED,
+            previousValue,
+            title + "\n" + description,
+            "Title and description changed",
+            changer,
+            changedDate
+        );
+    }
+
+    // --- general-purpose private methods ---
     private void changeStatusTo(IssueStatus targetStatus, String message, User changedBy, LocalDateTime changedDate) {
         Objects.requireNonNull(targetStatus, "targetStatus must not be null");
         Objects.requireNonNull(changedBy, CHANGED_BY_REQUIRED);

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Project.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Project.java
@@ -6,11 +6,11 @@ import java.util.Objects;
 public class Project {
 
     private final long id;
-    private final String name;
-    private final String description;
+    private String name;
+    private String description;
     private final String managedById;
     private final LocalDateTime createdDate;
-    private final LocalDateTime updatedAt;
+    private LocalDateTime updatedAt;
 
     // factory
     public static Project create(long id, String name, String description, String managedById,
@@ -24,14 +24,37 @@ public class Project {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(managedById, "managedById");
         this.id = id;
-        this.name = name;
+        this.name = requireText(name, "name");
         this.description = description;
-        this.managedById = managedById;
+        this.managedById = managedById; // AdminID
         this.createdDate = createdDate;
         this.updatedAt = updatedAt;
     }
 
     // --- domain methods ---
+
+    public Issue registerIssue(
+            String issueId,
+            String title,
+            String description,
+            Priority priority,
+            User reporter,
+            LocalDateTime now
+    ) {
+        return Issue.create(issueId, title, description, priority, reporter, now);
+    }
+
+    // --- setters ---
+
+    public void rename(String newName, LocalDateTime updatedAt) {
+        this.name = requireText(newName, "name");
+        this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt");
+    }
+
+    public void changeDescription(String newDescription, LocalDateTime updatedAt) {
+        this.description = newDescription;
+        this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt");
+    }
 
     // --- getters ---
 
@@ -57,6 +80,13 @@ public class Project {
 
     public LocalDateTime getUpdatedAt() {
         return updatedAt;
+    }
+
+    private static String requireText(String text, String fieldName) {
+        if (text == null || text.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return text;
     }
 
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/service/CommentResult.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/CommentResult.java
@@ -1,0 +1,12 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.User;
+import java.time.LocalDateTime;
+
+public record CommentResult(
+        String commentId,
+        String content,
+        User writer,
+        LocalDateTime createdDate
+) {
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueResult.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueResult.java
@@ -1,0 +1,15 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.User;
+
+public record IssueResult(
+        String issueId,
+        IssueStatus status,
+        Priority priority,
+        String title,
+        String description,
+        User reporter
+) {
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
@@ -1,0 +1,102 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.Comment;
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Project;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.IssueRepository;
+import com.github.marcellokim.issuetracker.repository.ProjectRepository;
+import com.github.marcellokim.issuetracker.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public final class IssueService {
+
+    private final ProjectRepository projectRepository;
+    private final IssueRepository issueRepository;
+    private final UserRepository userRepository;
+    private final PermissionPolicy permissionPolicy;
+    private final Clock clock;
+
+    public IssueService(
+            ProjectRepository projectRepository,
+            IssueRepository issueRepository,
+            UserRepository userRepository,
+            PermissionPolicy permissionPolicy,
+            Clock clock
+    ) {
+        this.projectRepository = Objects.requireNonNull(projectRepository, "projectRepository");
+        this.issueRepository = Objects.requireNonNull(issueRepository, "issueRepository");
+        this.userRepository = Objects.requireNonNull(userRepository, "userRepository");
+        this.permissionPolicy = Objects.requireNonNull(permissionPolicy, "permissionPolicy");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    public IssueResult registerIssue(long projectId, String title, String description, Priority priority, String currentUserId) {
+        Project project = findProject(projectId);
+        User reporter = findUser(currentUserId);
+        permissionPolicy.assertCanRegisterIssue(reporter, project);
+        LocalDateTime now = now();
+        Issue issue = Issue.newForPersistence(
+                Issue.persistedState(project.getId(), title, description, reporter)
+                        .priority(priority != null ? priority : Priority.MAJOR)
+                        .reportedDate(now)
+                        .updatedAt(now)
+        );
+        Issue saved = issueRepository.save(issue);
+        return toIssueResult(saved);
+    }
+
+    public CommentResult addComment(long issueId, String content, String currentUserId) {
+        Issue issue = findIssue(issueId);
+        User writer = findUser(currentUserId);
+        LocalDateTime now = now();
+        Comment comment = issue.addComment(nextCommentId(issue), content, writer, now);
+        issueRepository.save(issue);
+        return toCommentResult(comment);
+    }
+
+    private Project findProject(long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("Project not found: " + projectId));
+    }
+
+    private Issue findIssue(long issueId) {
+        return issueRepository.findById(issueId)
+                .orElseThrow(() -> new IllegalArgumentException("Issue not found: " + issueId));
+    }
+
+    private User findUser(String userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+    }
+
+    private LocalDateTime now() {
+        return clock.now();
+    }
+
+    private static String nextCommentId(Issue issue) {
+        return issue.getIssueId() + "-C" + (issue.getComments().size() + 1);
+    }
+
+    private static IssueResult toIssueResult(Issue issue) {
+        return new IssueResult(
+                issue.getIssueId(),
+                issue.status(),
+                issue.priority(),
+                issue.title(),
+                issue.description(),
+                issue.getReporter()
+        );
+    }
+
+    private static CommentResult toCommentResult(Comment comment) {
+        return new CommentResult(
+                comment.getCommentId(),
+                comment.getContent(),
+                comment.getWriter(),
+                comment.getCreatedDate()
+        );
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerCoverageTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerCoverageTest.java
@@ -269,7 +269,9 @@ class ControllerCoverageTest {
         Clock clock = new Clock();
 
         assertDoesNotThrow(() -> new AccountController(auth.service(), policy, users, new PasswordHasher()));
-        assertDoesNotThrow(() -> new IssueController(auth.service(), policy, projects, issues, users, clock));
+        assertDoesNotThrow(() -> new IssueController(
+                auth.service(),
+                new com.github.marcellokim.issuetracker.service.IssueService(projects, issues, users, policy, clock)));
         assertDoesNotThrow(() -> new IssueStateController(
                 auth.service(),
                 new com.github.marcellokim.issuetracker.service.IssueStateService(issues, users, policy, clock)));

--- a/src/test/java/com/github/marcellokim/issuetracker/controller/IssueControllerTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/controller/IssueControllerTest.java
@@ -1,0 +1,168 @@
+package com.github.marcellokim.issuetracker.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Project;
+import com.github.marcellokim.issuetracker.domain.ProjectMember;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.ProjectRepository;
+import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.Clock;
+import com.github.marcellokim.issuetracker.service.CommentResult;
+import com.github.marcellokim.issuetracker.service.IssueResult;
+import com.github.marcellokim.issuetracker.service.IssueService;
+import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.technical.PasswordHasher;
+import com.github.marcellokim.issuetracker.technical.SessionStore;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Issue controller")
+class IssueControllerTest {
+
+    private static final long PROJECT_ID = 10L;
+    private static final long ISSUE_ID = 1L;
+    private static final String PASSWORD = "pass123";
+    private final LocalDateTime now = LocalDateTime.of(2026, 5, 21, 10, 0);
+    private final PasswordHasher hasher = new PasswordHasher();
+    private final User dev = User.create("dev1", "Dev One", hasher.hash(PASSWORD), Role.DEV, true, now, now);
+    private final Project project = Project.create(PROJECT_ID, "ITS", "Issue Tracking", "admin", now, now);
+
+    @Test
+    @DisplayName("authenticated user registers issue")
+    void registerIssue() {
+        var controller = authenticatedController(dev);
+
+        IssueResult result = controller.registerIssue(PROJECT_ID, "Bug", "Login fails", Priority.MAJOR);
+
+        assertNotNull(result.issueId());
+        assertEquals(IssueStatus.NEW, result.status());
+        assertEquals("Bug", result.title());
+    }
+
+    @Test
+    @DisplayName("authenticated user adds comment")
+    void addComment() {
+        var issue = persistedIssue();
+        var controller = authenticatedController(dev, issue);
+
+        CommentResult result = controller.addComment(ISSUE_ID, "Confirmed this bug");
+
+        assertEquals("Confirmed this bug", result.content());
+        assertEquals(dev, result.writer());
+    }
+
+    @Test
+    @DisplayName("unauthenticated user is rejected")
+    void rejectUnauthenticated() {
+        var controller = unauthenticatedController();
+
+        assertThrows(SecurityException.class,
+                () -> controller.registerIssue(PROJECT_ID, "Bug", "desc", Priority.MAJOR));
+        assertThrows(SecurityException.class,
+                () -> controller.addComment(ISSUE_ID, "comment"));
+    }
+
+    private IssueController authenticatedController(User user, Issue... issues) {
+        var users = new InMemoryUserRepository(user);
+        var sessionStore = new SessionStore();
+        var authService = new AuthenticationService(users, hasher, sessionStore);
+        authService.login(user.getLoginId(), PASSWORD);
+        var issueService = new IssueService(
+                new FakeProjectRepository(project),
+                new InMemoryIssueRepository(issues),
+                users,
+                new PermissionPolicy(),
+                new Clock()
+        );
+        return new IssueController(authService, issueService);
+    }
+
+    private IssueController unauthenticatedController() {
+        var users = new InMemoryUserRepository(dev);
+        var authService = new AuthenticationService(users, hasher, new SessionStore());
+        var issueService = new IssueService(
+                new FakeProjectRepository(project),
+                new InMemoryIssueRepository(),
+                users,
+                new PermissionPolicy(),
+                new Clock()
+        );
+        return new IssueController(authService, issueService);
+    }
+
+    private Issue persistedIssue() {
+        return Issue.fromPersistence(
+                Issue.persistedState(PROJECT_ID, "Login fails", "Cannot log in", dev)
+                        .id(ISSUE_ID)
+                        .issueId("ISSUE-1")
+                        .reportedDate(now)
+                        .priority(Priority.MAJOR)
+                        .status(IssueStatus.NEW)
+                        .updatedAt(now));
+    }
+
+    private static final class FakeProjectRepository implements ProjectRepository {
+
+        private final Map<Long, Project> projects = new LinkedHashMap<>();
+
+        private FakeProjectRepository(Project... projects) {
+            for (Project p : projects) {
+                this.projects.put(p.getId(), p);
+            }
+        }
+
+        @Override
+        public Optional<Project> findById(long projectId) {
+            return Optional.ofNullable(projects.get(projectId));
+        }
+
+        @Override
+        public Optional<Project> findByName(String name) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<Project> findAll() {
+            return new ArrayList<>(projects.values());
+        }
+
+        @Override
+        public Project save(Project project) {
+            projects.put(project.getId(), project);
+            return project;
+        }
+
+        @Override
+        public void deleteById(long projectId) {
+            projects.remove(projectId);
+        }
+
+        @Override
+        public void addParticipant(long projectId, String userLoginId) {
+        }
+
+        @Override
+        public void removeParticipant(long projectId, String userLoginId) {
+        }
+
+        @Override
+        public List<ProjectMember> findParticipants(long projectId) {
+            return List.of();
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueAssignmentRoleTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueAssignmentRoleTest.java
@@ -151,6 +151,25 @@ class IssueAssignmentRoleTest {
     }
 
     @Test
+    @DisplayName("같은 assignee로 재배정할 수 없다")
+    void rejectSameAssigneeReassignment() {
+        var issue = assignedIssue();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> issue.reassignAssignee(assignee, pl, createdAt.plusMinutes(20)));
+    }
+
+    @Test
+    @DisplayName("같은 verifier로 변경할 수 없다")
+    void rejectSameVerifierChange() {
+        var issue = assignedIssue();
+        issue.markFixed(assignee, "Fix completed", createdAt.plusMinutes(20));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> issue.changeVerifier(verifier, pl, createdAt.plusMinutes(30)));
+    }
+
+    @Test
     @DisplayName("assignment changes require valid active participants")
     void rejectInvalidReassignmentParticipants() {
         var assignedIssue = assignedIssue();

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueChangeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueChangeTest.java
@@ -101,6 +101,75 @@ class IssueChangeTest {
     }
 
     @Test
+    @DisplayName("reporter가 NEW 이슈의 제목과 설명을 변경하면 이력이 기록된다")
+    void updateTitleAndDescriptionByReporter() {
+        var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+        var changedAt = createdAt.plusMinutes(10);
+
+        issue.updateTitleAndDescription("Login fixed", "Updated description", reporter, changedAt);
+
+        assertEquals("Login fixed", issue.getTitle());
+        assertEquals("Updated description", issue.getDescription());
+        var history = issue.getHistories().getLast();
+        assertEquals(ActionType.TITLE_DESCRIPTION_UPDATED, history.getAction());
+        assertEquals("Login fails\nCannot log in", history.getPreviousValue());
+        assertEquals("Login fixed\nUpdated description", history.getNewValue());
+        assertEquals(changedAt, history.getChangedDate());
+    }
+
+    @Test
+    @DisplayName("reporter가 REOPENED 이슈의 제목과 설명을 변경할 수 있다")
+    void updateTitleAndDescriptionOnReopenedIssue() {
+        var issue = resolvedIssue();
+        issue.reopen(pl, "Needs more work", createdAt.plusMinutes(40));
+
+        issue.updateTitleAndDescription("Revised title", "Revised desc", reporter, createdAt.plusMinutes(50));
+
+        assertEquals("Revised title", issue.getTitle());
+        assertEquals("Revised desc", issue.getDescription());
+    }
+
+    @Test
+    @DisplayName("reporter가 아닌 사용자는 제목/설명을 변경할 수 없다")
+    void rejectUpdateTitleByNonReporter() {
+        var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> issue.updateTitleAndDescription("New", "Desc", pl, createdAt.plusMinutes(10)));
+    }
+
+    @Test
+    @DisplayName("ASSIGNED 이후 상태에서는 제목/설명을 변경할 수 없다")
+    void rejectUpdateTitleOnAssignedIssue() {
+        var issue = assignedIssue();
+
+        assertThrows(IllegalStateException.class,
+                () -> issue.updateTitleAndDescription("New", "Desc", reporter, createdAt.plusMinutes(20)));
+    }
+
+    @Test
+    @DisplayName("빈 제목이나 설명으로는 변경할 수 없다")
+    void rejectUpdateTitleWithBlankValues() {
+        var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> issue.updateTitleAndDescription("", "Desc", reporter, createdAt.plusMinutes(10)));
+        assertThrows(IllegalArgumentException.class,
+                () -> issue.updateTitleAndDescription("Title", "", reporter, createdAt.plusMinutes(10)));
+    }
+
+    @Test
+    @DisplayName("CLOSED 이슈를 reopen할 수 있다")
+    void reopenClosedIssue() {
+        var issue = resolvedIssue();
+        issue.close(pl, "Release completed", createdAt.plusMinutes(40));
+
+        issue.reopen(pl, "Found regression", createdAt.plusMinutes(50));
+
+        assertEquals(IssueStatus.REOPENED, issue.getStatus());
+    }
+
+    @Test
     @DisplayName("같은 우선순위로는 변경할 수 없고 NEW 이슈는 reopen할 수 없다")
     void rejectNoOpChanges() {
         var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCreationTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCreationTest.java
@@ -88,6 +88,68 @@ class IssueCreationTest {
     }
 
     @Test
+    @DisplayName("newForPersistence with explicit issueId preserves it")
+    void newForPersistenceWithExplicitIssueId() {
+        var issue = Issue.newForPersistence(Issue.persistedState(
+                1L, "Bug", "desc", reporter)
+                .issueId("CUSTOM-ID")
+                .reportedDate(now)
+                .updatedAt(now));
+
+        assertEquals("CUSTOM-ID", issue.getIssueId());
+    }
+
+    @Test
+    @DisplayName("fromPersistence rejects non-positive id")
+    void fromPersistenceRejectsNonPositiveId() {
+        assertThrows(IllegalArgumentException.class, () -> Issue.fromPersistence(
+                Issue.persistedState(1L, "Bug", "desc", reporter)
+                        .id(0L)
+                        .issueId("ISSUE-1")
+                        .reportedDate(now)
+                        .updatedAt(now)));
+        assertThrows(IllegalArgumentException.class, () -> Issue.fromPersistence(
+                Issue.persistedState(1L, "Bug", "desc", reporter)
+                        .id(-1L)
+                        .issueId("ISSUE-1")
+                        .reportedDate(now)
+                        .updatedAt(now)));
+    }
+
+    @Test
+    @DisplayName("newForPersistence rejects non-zero id")
+    void newForPersistenceRejectsNonZeroId() {
+        assertThrows(IllegalArgumentException.class, () -> Issue.newForPersistence(
+                Issue.persistedState(1L, "Bug", "desc", reporter)
+                        .id(5L)
+                        .reportedDate(now)
+                        .updatedAt(now)));
+    }
+
+    @Test
+    @DisplayName("persistence getters return expected values")
+    void persistenceGettersReturnExpectedValues() {
+        var issue = Issue.fromPersistence(Issue.persistedState(
+                1L, "Bug", "desc", reporter)
+                .id(10L)
+                .issueId("ISSUE-1")
+                .reportedDate(now)
+                .updatedAt(now));
+
+        assertEquals("Bug", issue.title());
+        assertEquals("desc", issue.description());
+        assertEquals(now, issue.reportedDate());
+        assertEquals(Priority.MAJOR, issue.priority());
+        assertEquals(IssueStatus.NEW, issue.status());
+        assertEquals(reporter.getLoginId(), issue.reporterId());
+        assertNull(issue.assigneeId());
+        assertNull(issue.verifierId());
+        assertNull(issue.fixerId());
+        assertNull(issue.resolverId());
+        assertEquals(now, issue.updatedAt());
+    }
+
+    @Test
     @DisplayName("이슈 생성 필수 값은 비어 있을 수 없다")
     void rejectInvalidIssueCreationArguments() {
         assertThrows(IllegalArgumentException.class,

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueDependencyTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueDependencyTest.java
@@ -71,6 +71,19 @@ class IssueDependencyTest {
     }
 
     @Test
+    @DisplayName("여러 blocking issue에 대한 의존성을 추가할 수 있다")
+    void addMultipleDifferentDependencies() {
+        var blockingIssue1 = Issue.create("ISSUE-1", "Fix auth", "Auth fix", null, reporter, createdAt);
+        var blockingIssue2 = Issue.create("ISSUE-3", "Fix DB", "DB fix", null, reporter, createdAt);
+        var blockedIssue = Issue.create("ISSUE-2", "Login UI", "UI depends", null, reporter, createdAt);
+
+        blockedIssue.addDependency("ISSUE-1->ISSUE-2", blockingIssue1, pl, createdAt.plusMinutes(20));
+        blockedIssue.addDependency("ISSUE-3->ISSUE-2", blockingIssue2, pl, createdAt.plusMinutes(30));
+
+        assertEquals(2, blockedIssue.getBlockedByDependencies().size());
+    }
+
+    @Test
     @DisplayName("persisted dependency derives deterministic id and keeps database fields")
     void persistedDependencyDerivesDeterministicId() {
         var dependency = IssueDependency.fromPersistence(7L, 10L, 20L, createdAt);

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueFixResolveTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueFixResolveTest.java
@@ -145,6 +145,40 @@ class IssueFixResolveTest {
                                                 createdAt.plusMinutes(30)));
         }
 
+        @Test
+        @DisplayName("FIXED 이슈를 rejectFix하면 ASSIGNED로 돌아간다")
+        void rejectFixReturnsToAssigned() {
+                var issue = assignedIssue();
+                issue.markFixed(assignee, "Fix completed", createdAt.plusMinutes(20));
+
+                issue.rejectFix(verifier, "Not fixed properly", createdAt.plusMinutes(30));
+
+                assertEquals(IssueStatus.ASSIGNED, issue.getStatus());
+                var history = issue.getHistories().getLast();
+                assertEquals(ActionType.STATUS_CHANGED, history.getAction());
+                assertEquals(IssueStatus.FIXED.name(), history.getPreviousValue());
+                assertEquals(IssueStatus.ASSIGNED.name(), history.getNewValue());
+        }
+
+        @Test
+        @DisplayName("현재 verifier만 rejectFix할 수 있다")
+        void onlyCurrentVerifierCanRejectFix() {
+                var issue = assignedIssue();
+                issue.markFixed(assignee, "Fix completed", createdAt.plusMinutes(20));
+
+                assertThrows(IllegalArgumentException.class,
+                                () -> issue.rejectFix(otherTester, "Not fixed", createdAt.plusMinutes(30)));
+        }
+
+        @Test
+        @DisplayName("FIXED가 아닌 이슈는 rejectFix할 수 없다")
+        void rejectFixRequiresFixedStatus() {
+                var issue = assignedIssue();
+
+                assertThrows(IllegalStateException.class,
+                                () -> issue.rejectFix(verifier, "Not fixed", createdAt.plusMinutes(20)));
+        }
+
         private Issue assignedIssue() {
                 var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
                 issue.assignFromNew(assignee, verifier, pl, createdAt.plusMinutes(10));

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/ProjectTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/ProjectTest.java
@@ -6,6 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
 
 @DisplayName("Project domain model")
 class ProjectTest {
@@ -37,5 +41,61 @@ class ProjectTest {
     void rejectNullManagedById() {
         assertThrows(NullPointerException.class,
                 () -> Project.create(1L, "ITS", "desc", null, now, now));
+    }
+
+    @Test
+    @DisplayName("blank name is rejected by requireText")
+    void rejectBlankName() {
+        assertThrows(IllegalArgumentException.class,
+                () -> Project.create(1L, "", "desc", "admin", now, now));
+        assertThrows(IllegalArgumentException.class,
+                () -> Project.create(1L, " ", "desc", "admin", now, now));
+    }
+
+    @Test
+    @DisplayName("registerIssue creates issue via Creator pattern")
+    void registerIssueCreatesIssue() {
+        var project = Project.create(1L, "ITS", "desc", "admin", now, now);
+        var reporter = User.create("dev1", "Dev One", "hash", Role.DEV, true, now, now);
+
+        var issue = project.registerIssue("ISSUE-1", "Bug", "Login fails", Priority.MAJOR, reporter, now);
+
+        assertEquals("ISSUE-1", issue.getIssueId());
+        assertEquals("Bug", issue.getTitle());
+        assertEquals(IssueStatus.NEW, issue.getStatus());
+        assertEquals(Priority.MAJOR, issue.getPriority());
+    }
+
+    @Test
+    @DisplayName("rename updates name and updatedAt")
+    void renameUpdatesNameAndTimestamp() {
+        var project = Project.create(1L, "ITS", "desc", "admin", now, now);
+        var later = now.plusHours(1);
+
+        project.rename("ITS v2", later);
+
+        assertEquals("ITS v2", project.getName());
+        assertEquals(later, project.getUpdatedAt());
+    }
+
+    @Test
+    @DisplayName("rename rejects blank name")
+    void renameRejectsBlankName() {
+        var project = Project.create(1L, "ITS", "desc", "admin", now, now);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> project.rename("", now.plusHours(1)));
+    }
+
+    @Test
+    @DisplayName("changeDescription updates description and updatedAt")
+    void changeDescriptionUpdatesDescriptionAndTimestamp() {
+        var project = Project.create(1L, "ITS", "desc", "admin", now, now);
+        var later = now.plusHours(1);
+
+        project.changeDescription("New description", later);
+
+        assertEquals("New description", project.getDescription());
+        assertEquals(later, project.getUpdatedAt());
     }
 }

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueServiceTest.java
@@ -1,0 +1,194 @@
+package com.github.marcellokim.issuetracker.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Project;
+import com.github.marcellokim.issuetracker.domain.ProjectMember;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.ProjectRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Issue service")
+class IssueServiceTest {
+
+    private static final long PROJECT_ID = 10L;
+    private static final long ISSUE_ID = 1L;
+    private final LocalDateTime now = LocalDateTime.of(2026, 5, 21, 10, 0);
+    private final User dev = User.create("dev1", "Dev One", "hash", Role.DEV, true, now, now);
+    private final User tester = User.create("tester1", "Tester One", "hash", Role.TESTER, true, now, now);
+    private final User pl = User.create("pl1", "PL One", "hash", Role.PL, true, now, now);
+    private final Project project = Project.create(PROJECT_ID, "ITS", "Issue Tracking", "admin", now, now);
+
+    @Test
+    @DisplayName("registers a new issue with project and reporter")
+    void registerIssueSucceeds() {
+        var service = service(new InMemoryIssueRepository());
+
+        IssueResult result = service.registerIssue(PROJECT_ID, "Login bug", "Cannot login", Priority.MAJOR, dev.getLoginId());
+
+        assertNotNull(result.issueId());
+        assertEquals(IssueStatus.NEW, result.status());
+        assertEquals(Priority.MAJOR, result.priority());
+        assertEquals("Login bug", result.title());
+        assertEquals("Cannot login", result.description());
+    }
+
+    @Test
+    @DisplayName("registers issue with default priority when null")
+    void registerIssueDefaultPriority() {
+        var service = service(new InMemoryIssueRepository());
+
+        IssueResult result = service.registerIssue(PROJECT_ID, "Bug", "desc", null, dev.getLoginId());
+
+        assertEquals(Priority.MAJOR, result.priority());
+    }
+
+    @Test
+    @DisplayName("rejects issue registration for nonexistent project")
+    void registerIssueRejectsUnknownProject() {
+        var service = service(new InMemoryIssueRepository());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.registerIssue(999L, "Bug", "desc", Priority.MAJOR, dev.getLoginId()));
+    }
+
+    @Test
+    @DisplayName("rejects issue registration for nonexistent user")
+    void registerIssueRejectsUnknownUser() {
+        var service = service(new InMemoryIssueRepository());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.registerIssue(PROJECT_ID, "Bug", "desc", Priority.MAJOR, "unknown"));
+    }
+
+    @Test
+    @DisplayName("adds comment to existing issue")
+    void addCommentSucceeds() {
+        var issue = persistedIssue();
+        var service = service(new InMemoryIssueRepository(issue));
+
+        CommentResult result = service.addComment(ISSUE_ID, "Looks like a real bug", dev.getLoginId());
+
+        assertNotNull(result.commentId());
+        assertEquals("Looks like a real bug", result.content());
+        assertEquals(dev, result.writer());
+        assertNotNull(result.createdDate());
+    }
+
+    @Test
+    @DisplayName("rejects comment on nonexistent issue")
+    void addCommentRejectsUnknownIssue() {
+        var service = service(new InMemoryIssueRepository());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.addComment(999L, "comment", dev.getLoginId()));
+    }
+
+    @Test
+    @DisplayName("rejects comment with nonexistent user")
+    void addCommentRejectsUnknownUser() {
+        var issue = persistedIssue();
+        var service = service(new InMemoryIssueRepository(issue));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.addComment(ISSUE_ID, "comment", "unknown"));
+    }
+
+    @Test
+    @DisplayName("rejects blank comment content")
+    void addCommentRejectsBlankContent() {
+        var issue = persistedIssue();
+        var service = service(new InMemoryIssueRepository(issue));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.addComment(ISSUE_ID, "", dev.getLoginId()));
+    }
+
+    private IssueService service(InMemoryIssueRepository issues) {
+        return new IssueService(
+                new FakeProjectRepository(project),
+                issues,
+                new InMemoryUserRepository(dev, tester, pl),
+                new PermissionPolicy(),
+                new Clock()
+        );
+    }
+
+    private Issue persistedIssue() {
+        return Issue.fromPersistence(
+                Issue.persistedState(PROJECT_ID, "Login fails", "Cannot log in", dev)
+                        .id(ISSUE_ID)
+                        .issueId("ISSUE-1")
+                        .reportedDate(now)
+                        .priority(Priority.MAJOR)
+                        .status(IssueStatus.NEW)
+                        .updatedAt(now));
+    }
+
+    private static final class FakeProjectRepository implements ProjectRepository {
+
+        private final Map<Long, Project> projects = new LinkedHashMap<>();
+
+        private FakeProjectRepository(Project... projects) {
+            for (Project p : projects) {
+                this.projects.put(p.getId(), p);
+            }
+        }
+
+        @Override
+        public Optional<Project> findById(long projectId) {
+            return Optional.ofNullable(projects.get(projectId));
+        }
+
+        @Override
+        public Optional<Project> findByName(String name) {
+            return projects.values().stream()
+                    .filter(p -> p.getName().equals(name))
+                    .findFirst();
+        }
+
+        @Override
+        public List<Project> findAll() {
+            return new ArrayList<>(projects.values());
+        }
+
+        @Override
+        public Project save(Project project) {
+            projects.put(project.getId(), project);
+            return project;
+        }
+
+        @Override
+        public void deleteById(long projectId) {
+            projects.remove(projectId);
+        }
+
+        @Override
+        public void addParticipant(long projectId, String userLoginId) {
+        }
+
+        @Override
+        public void removeParticipant(long projectId, String userLoginId) {
+        }
+
+        @Override
+        public List<ProjectMember> findParticipants(long projectId) {
+            return List.of();
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
@@ -1,9 +1,13 @@
 package com.github.marcellokim.issuetracker.service;
 
+import java.time.LocalDateTime;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import com.github.marcellokim.issuetracker.domain.ActionType;
 import com.github.marcellokim.issuetracker.domain.Issue;
@@ -13,9 +17,6 @@ import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.User;
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
-import java.time.LocalDateTime;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 @DisplayName("Issue state service")
 class IssueStateServiceTest {


### PR DESCRIPTION
## 요약
- 관련 이슈: Closes #119
- 변경 목적:
  - Domain freeze 과정에서 `User`, `Project`, `Issue` 도메인 클래스의 변경 가능 필드와 상태 전이 책임을 정리하고 구현합니다.
  - `Issue` title/description 수정 정책을 `NEW` 및 `REOPENED` 상태의 원래 reporter 기준으로 정리합니다.
  - issue/comment application flow를 위한 `IssueService`, `IssueResult`, `CommentResult`를 추가합니다.
  - domain에서 처리하지 않는 권한 검사, 저장, 중복/조회 판단 사항을 `docs/260520_Domain_Freeze.md`에 후속 작업으로 기록합니다.

## 변경 분류
- [x] 기능 개발
- [ ] 버그 수정
- [x] 테스트 보강
- [x] 문서화
- [ ] 환경설정 / 자동화

## 검증 내역
- [x] `./gradlew check`
- [ ] 수동 기능 확인
- [ ] CI 통과 확인
- 결과 요약:
  - 로컬에서 `./gradlew check` 통과 여부를 확인했습니다.
  - PR 생성 후 GitHub Actions CI 결과를 추가 확인할 예정입니다.

## 과제 요구사항 영향
- [x] MVC 분리 관련 변경 반영
- [x] Persistence 관련 변경 반영
- [ ] 다중 UI toolkit 영향 확인
- [ ] 통계 / 추천 기능 영향 확인
- [ ] 해당 없음

## 문서 및 증빙
- [ ] README 반영
- [x] docs/ 반영
- [ ] 스크린샷 또는 GIF 첨부
- [ ] GitHub 프로젝트 상태 업데이트
- [ ] 해당 없음

## 리뷰 포인트
- 집중해서 봐야 할 부분:
  - `Issue.updateTitleAndDescription(...)`가 `NEW` 및 `REOPENED` 상태에서만 동작하는지 확인이 필요합니다.
  - `reopen` 이후에도 `Issue.reporter`가 원래 등록자로 유지되고, PL은 `changedBy` / comment writer / history actor로만 기록되는지 확인이 필요합니다.
  - `User`와 `Project`의 변경 가능 필드가 domain method로만 제한되고, 권한 검사와 저장 책임이 application service로 분리되는지 확인이 필요합니다.
  - 새로 추가된 `IssueService`, `IssueResult`, `CommentResult`가 domain entity 책임을 침범하지 않고 application/service 반환 계층에 머무르는지 확인이 필요합니다.

- 남아 있는 위험/후속 작업:
  - `removeDependency` 및 dependency association cleanup은 아직 후속 구현 대상입니다.
  - dependency cycle/graph 검사는 repository 조회가 필요하므로 application service에서 추가 정리해야 합니다.
  - role 변경 가능 여부, 프로젝트명 중복 검사, 프로젝트 participant 관리 정책은 application service 테스트로 보강해야 합니다.
  - `REOPENED` 상태 title/description 수정 정책은 기존 `NEW only` 문구가 남아 있는 문서/테스트와 충돌하지 않는지 추가 검토가 필요합니다.