### PR TITLE
feat: IssueController 등록과 코멘트 API 구현

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Comment.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Comment.java
@@ -10,6 +10,7 @@ public final class Comment {
     private final String commentId;
     private final String writerId;
     private final String content;
+    private final CommentPurpose purpose;
     private final LocalDateTime createdDate;
     private final User writer;
 
@@ -20,31 +21,61 @@ public final class Comment {
             String content,
             LocalDateTime createdDate
     ) {
-        return new Comment(id, issueId, writerId, content, createdDate);
+        return fromPersistence(id, issueId, writerId, content, CommentPurpose.GENERAL, createdDate);
     }
 
-    private Comment(long id, long issueId, String writerId, String content, LocalDateTime createdDate) {
+    public static Comment fromPersistence(
+            long id,
+            long issueId,
+            String writerId,
+            String content,
+            CommentPurpose purpose,
+            LocalDateTime createdDate
+    ) {
+        return new Comment(id, issueId, writerId, content, purpose, createdDate);
+    }
+
+    private Comment(
+            long id,
+            long issueId,
+            String writerId,
+            String content,
+            CommentPurpose purpose,
+            LocalDateTime createdDate
+    ) {
         this.id = id;
         this.issueId = issueId;
         this.commentId = Long.toString(id);
         this.writerId = requireText(writerId, "writerId");
         this.content = requireText(content, "content");
+        this.purpose = Objects.requireNonNull(purpose, "purpose must not be null");
         this.createdDate = Objects.requireNonNull(createdDate, "createdDate must not be null");
         this.writer = null;
     }
 
-    private Comment(String commentId, String content, User writer, LocalDateTime createdDate) {
+    private Comment(String commentId, String content, User writer, CommentPurpose purpose, LocalDateTime createdDate) {
         this.id = 0L;
         this.issueId = 0L;
         this.commentId = requireText(commentId, "commentId");
         this.writer = Objects.requireNonNull(writer, "writer must not be null");
         this.writerId = writer.getLoginId();
         this.content = requireText(content, "content");
+        this.purpose = Objects.requireNonNull(purpose, "purpose must not be null");
         this.createdDate = Objects.requireNonNull(createdDate, "createdDate must not be null");
     }
 
     public static Comment create(String commentId, String content, User writer, LocalDateTime createdDate) {
-        return new Comment(commentId, content, writer, createdDate);
+        return create(commentId, content, writer, CommentPurpose.GENERAL, createdDate);
+    }
+
+    public static Comment create(
+            String commentId,
+            String content,
+            User writer,
+            CommentPurpose purpose,
+            LocalDateTime createdDate
+    ) {
+        return new Comment(commentId, content, writer, purpose, createdDate);
     }
 
     // --- getters ---
@@ -64,6 +95,10 @@ public final class Comment {
         return content;
     }
 
+    public CommentPurpose purpose() {
+        return purpose;
+    }
+
     public LocalDateTime createdDate() {
         return createdDate;
     }
@@ -74,6 +109,10 @@ public final class Comment {
 
     public String getContent() {
         return content;
+    }
+
+    public CommentPurpose getPurpose() {
+        return purpose;
     }
 
     public LocalDateTime getCreatedDate() {

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/CommentPurpose.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/CommentPurpose.java
@@ -1,0 +1,6 @@
+package com.github.marcellokim.issuetracker.domain;
+
+public enum CommentPurpose {
+    GENERAL,
+    STATUS_CHANGE_REASON
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Issue.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Issue.java
@@ -363,7 +363,17 @@ public class Issue {
     }
 
     public Comment addComment(String commentId, String content, User writer, LocalDateTime createdDate) {
-        var comment = Comment.create(commentId, content, writer, createdDate);
+        return addComment(commentId, content, writer, createdDate, CommentPurpose.GENERAL);
+    }
+
+    public Comment addComment(
+            String commentId,
+            String content,
+            User writer,
+            LocalDateTime createdDate,
+            CommentPurpose purpose
+    ) {
+        var comment = Comment.create(commentId, content, writer, purpose, createdDate);
         comments.add(comment);
         recordHistory(ActionType.COMMENTED, null, commentId, content, writer, createdDate);
         return comment;

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcCommentRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcCommentRepository.java
@@ -1,6 +1,7 @@
 package com.github.marcellokim.issuetracker.persistence.jdbc;
 
 import com.github.marcellokim.issuetracker.domain.Comment;
+import com.github.marcellokim.issuetracker.domain.CommentPurpose;
 import com.github.marcellokim.issuetracker.persistence.DatabaseConnectionProvider;
 import com.github.marcellokim.issuetracker.repository.CommentRepository;
 import com.github.marcellokim.issuetracker.repository.RepositoryException;
@@ -14,7 +15,8 @@ import java.util.Optional;
 
 public final class JdbcCommentRepository implements CommentRepository {
 
-    private static final String BASE_SELECT = "select id, issue_id, writer_login_id, content, created_date from comments";
+    private static final String BASE_SELECT =
+            "select id, issue_id, writer_login_id, content, purpose, created_date from comments";
     private static final String FIND_BY_ID_SQL = BASE_SELECT + " where id = ?";
     private static final String FIND_BY_ISSUE_ID_SQL = BASE_SELECT + " where issue_id = ? order by created_date, id";
 
@@ -79,15 +81,16 @@ public final class JdbcCommentRepository implements CommentRepository {
 
     private Comment insert(Comment comment) {
         String sql = """
-                insert into comments (issue_id, writer_login_id, content, created_date)
-                values (?, ?, ?, coalesce(?, current_timestamp))
+                insert into comments (issue_id, writer_login_id, content, purpose, created_date)
+                values (?, ?, ?, ?, coalesce(?, current_timestamp))
                 """;
         try (Connection connection = connectionProvider.getConnection();
                 PreparedStatement statement = JdbcSupport.prepareInsertReturningId(connection, sql)) {
             statement.setLong(1, comment.issueId());
             statement.setString(2, comment.writerId());
             statement.setString(3, comment.content());
-            JdbcSupport.setNullableTimestamp(statement, 4, comment.createdDate());
+            statement.setString(4, comment.purpose().name());
+            JdbcSupport.setNullableTimestamp(statement, 5, comment.createdDate());
             statement.executeUpdate();
             return findById(JdbcSupport.generatedId(statement))
                     .orElseThrow(() -> new RepositoryException("Inserted comment was not found.", null));
@@ -102,6 +105,7 @@ public final class JdbcCommentRepository implements CommentRepository {
                 set issue_id = ?,
                     writer_login_id = ?,
                     content = ?,
+                    purpose = ?,
                     created_date = coalesce(?, created_date)
                 where id = ?
                 """;
@@ -110,8 +114,9 @@ public final class JdbcCommentRepository implements CommentRepository {
             statement.setLong(1, comment.issueId());
             statement.setString(2, comment.writerId());
             statement.setString(3, comment.content());
-            JdbcSupport.setNullableTimestamp(statement, 4, comment.createdDate());
-            statement.setLong(5, comment.id());
+            statement.setString(4, comment.purpose().name());
+            JdbcSupport.setNullableTimestamp(statement, 5, comment.createdDate());
+            statement.setLong(6, comment.id());
             statement.executeUpdate();
             return findById(comment.id())
                     .orElseThrow(() -> new RepositoryException("Updated comment was not found.", null));
@@ -126,6 +131,7 @@ public final class JdbcCommentRepository implements CommentRepository {
                 resultSet.getLong("issue_id"),
                 resultSet.getString("writer_login_id"),
                 resultSet.getString("content"),
+                CommentPurpose.valueOf(resultSet.getString("purpose")),
                 JdbcSupport.nullableDateTime(resultSet, "created_date"));
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcCommentRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcCommentRepository.java
@@ -131,7 +131,14 @@ public final class JdbcCommentRepository implements CommentRepository {
                 resultSet.getLong("issue_id"),
                 resultSet.getString("writer_login_id"),
                 resultSet.getString("content"),
-                CommentPurpose.valueOf(resultSet.getString("purpose")),
+                commentPurposeOf(resultSet.getString("purpose")),
                 JdbcSupport.nullableDateTime(resultSet, "created_date"));
+    }
+
+    private static CommentPurpose commentPurposeOf(String value) {
+        if (value == null || value.isBlank()) {
+            return CommentPurpose.GENERAL;
+        }
+        return CommentPurpose.valueOf(value);
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueRepository.java
@@ -411,8 +411,8 @@ public final class JdbcIssueRepository implements IssueRepository {
     private static void insertTransientComments(Connection connection, long issueId, List<Comment> comments)
             throws SQLException {
         String sql = """
-                insert into comments (issue_id, writer_login_id, content, created_date)
-                values (?, ?, ?, coalesce(?, current_timestamp))
+                insert into comments (issue_id, writer_login_id, content, purpose, created_date)
+                values (?, ?, ?, ?, coalesce(?, current_timestamp))
                 """;
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             for (Comment comment : comments) {
@@ -422,7 +422,8 @@ public final class JdbcIssueRepository implements IssueRepository {
                 statement.setLong(1, issueId);
                 statement.setString(2, comment.writerId());
                 statement.setString(3, comment.content());
-                JdbcSupport.setNullableTimestamp(statement, 4, comment.createdDate());
+                statement.setString(4, comment.purpose().name());
+                JdbcSupport.setNullableTimestamp(statement, 5, comment.createdDate());
                 statement.addBatch();
             }
             statement.executeBatch();

--- a/src/main/java/com/github/marcellokim/issuetracker/service/CommentIdGenerator.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/CommentIdGenerator.java
@@ -1,0 +1,15 @@
+package com.github.marcellokim.issuetracker.service;
+
+import java.util.UUID;
+
+final class CommentIdGenerator {
+
+    private static final String COMMENT_ID_PREFIX = "COMMENT-";
+
+    private CommentIdGenerator() {
+    }
+
+    static String nextCommentId() {
+        return COMMENT_ID_PREFIX + UUID.randomUUID();
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/CommentResult.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/CommentResult.java
@@ -1,11 +1,13 @@
 package com.github.marcellokim.issuetracker.service;
 
+import com.github.marcellokim.issuetracker.domain.CommentPurpose;
 import com.github.marcellokim.issuetracker.domain.User;
 import java.time.LocalDateTime;
 
 public record CommentResult(
         String commentId,
         String content,
+        CommentPurpose purpose,
         User writer,
         LocalDateTime createdDate
 ) {

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
@@ -51,8 +51,9 @@ public final class IssueService {
     public CommentResult addComment(long issueId, String content, String currentUserId) {
         Issue issue = findIssue(issueId);
         User writer = findUser(currentUserId);
+        permissionPolicy.assertCanAddComment(writer, issue);
         LocalDateTime now = now();
-        Comment comment = issue.addComment(nextCommentId(issue), content, writer, now);
+        Comment comment = issue.addComment(CommentIdGenerator.nextCommentId(), content, writer, now);
         issueRepository.save(issue);
         return toCommentResult(comment);
     }
@@ -76,10 +77,6 @@ public final class IssueService {
         return clock.now();
     }
 
-    private static String nextCommentId(Issue issue) {
-        return issue.getIssueId() + "-C" + (issue.getComments().size() + 1);
-    }
-
     private static IssueResult toIssueResult(Issue issue) {
         return new IssueResult(
                 issue.getIssueId(),
@@ -95,6 +92,7 @@ public final class IssueService {
         return new CommentResult(
                 comment.getCommentId(),
                 comment.getContent(),
+                comment.getPurpose(),
                 comment.getWriter(),
                 comment.getCreatedDate()
         );

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java
@@ -1,5 +1,6 @@
 package com.github.marcellokim.issuetracker.service;
 
+import com.github.marcellokim.issuetracker.domain.CommentPurpose;
 import com.github.marcellokim.issuetracker.domain.Issue;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.User;
@@ -46,21 +47,36 @@ public final class IssueStateService {
         permissionPolicy.assertCanChangeStatus(actor, issue, IssueStatus.FIXED);
         LocalDateTime changedAt = now();
         issue.markFixed(actor, comment, changedAt);
-        issue.addComment(nextCommentId(issue), comment, actor, changedAt);
+        issue.addComment(
+                CommentIdGenerator.nextCommentId(),
+                comment,
+                actor,
+                changedAt,
+                CommentPurpose.STATUS_CHANGE_REASON);
     }
 
     private void resolve(Issue issue, User actor, String comment) {
         permissionPolicy.assertCanChangeStatus(actor, issue, IssueStatus.RESOLVED);
         LocalDateTime changedAt = now();
         issue.resolve(actor, comment, changedAt);
-        issue.addComment(nextCommentId(issue), comment, actor, changedAt);
+        issue.addComment(
+                CommentIdGenerator.nextCommentId(),
+                comment,
+                actor,
+                changedAt,
+                CommentPurpose.STATUS_CHANGE_REASON);
     }
 
     private void close(Issue issue, User actor, String comment) {
         permissionPolicy.assertCanChangeStatus(actor, issue, IssueStatus.CLOSED);
         LocalDateTime changedAt = now();
         issue.close(actor, comment, changedAt);
-        issue.addComment(nextCommentId(issue), comment, actor, changedAt);
+        issue.addComment(
+                CommentIdGenerator.nextCommentId(),
+                comment,
+                actor,
+                changedAt,
+                CommentPurpose.STATUS_CHANGE_REASON);
     }
 
     private Issue findIssue(long issueId) {
@@ -75,10 +91,6 @@ public final class IssueStateService {
 
     private LocalDateTime now() {
         return clock.now();
-    }
-
-    private static String nextCommentId(Issue issue) {
-        return issue.getIssueId() + "-C" + (issue.getComments().size() + 1);
     }
 
     private static String requireComment(String comment) {

--- a/src/main/java/com/github/marcellokim/issuetracker/service/PermissionPolicy.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/PermissionPolicy.java
@@ -44,6 +44,11 @@ public final class PermissionPolicy {
         requirePl(user, "Only PL can assign issue owners.");
     }
 
+    public void assertCanAddComment(User user, Issue issue) {
+        Objects.requireNonNull(issue, ISSUE_REQUIRED);
+        requireAuthenticatedUserRole(user, "Only active PL, DEV, or TESTER users can add issue comments.");
+    }
+
     public void assertCanChangeStatus(User user, Issue issue, IssueStatus targetStatus) {
         Issue targetIssue = Objects.requireNonNull(issue, ISSUE_REQUIRED);
         IssueStatus nextStatus = Objects.requireNonNull(targetStatus, "targetStatus");

--- a/src/main/resources/db/oracle/schema-oracle.sql
+++ b/src/main/resources/db/oracle/schema-oracle.sql
@@ -313,6 +313,7 @@ begin
                 issue_id number not null,
                 writer_login_id varchar2(50) not null,
                 content clob not null,
+                purpose varchar2(32) default 'GENERAL' not null,
                 created_date timestamp default current_timestamp not null,
                 constraint fk_comments_issue foreign key (issue_id) references issues(id) on delete cascade,
                 constraint fk_comments_writer foreign key (writer_login_id) references users(login_id)

--- a/src/main/resources/db/oracle/schema-oracle.sql
+++ b/src/main/resources/db/oracle/schema-oracle.sql
@@ -315,10 +315,47 @@ begin
                 content clob not null,
                 purpose varchar2(32) default 'GENERAL' not null,
                 created_date timestamp default current_timestamp not null,
+                constraint chk_comments_purpose check (purpose in ('GENERAL', 'STATUS_CHANGE_REASON')),
                 constraint fk_comments_issue foreign key (issue_id) references issues(id) on delete cascade,
                 constraint fk_comments_writer foreign key (writer_login_id) references users(login_id)
             )
         ]';
+   end if;
+end;
+/
+declare
+   column_count  number;
+   nullable_flag varchar2(1);
+begin
+   select count(*),
+          max(nullable)
+     into
+      column_count,
+      nullable_flag
+     from user_tab_columns
+    where table_name = 'COMMENTS'
+      and column_name = 'PURPOSE';
+
+   if column_count = 0 then
+      execute immediate q'[alter table comments add purpose varchar2(32) default 'GENERAL' not null]';
+   elsif nullable_flag = 'Y' then
+      execute immediate q'[update comments set purpose = 'GENERAL' where purpose is null]';
+      execute immediate q'[alter table comments modify purpose varchar2(32) default 'GENERAL' not null]';
+   end if;
+end;
+/
+declare
+   constraint_count number;
+begin
+   select count(*)
+     into constraint_count
+     from user_constraints
+    where table_name = 'COMMENTS'
+      and constraint_name = 'CHK_COMMENTS_PURPOSE';
+
+   if constraint_count = 0 then
+      execute immediate q'[update comments set purpose = 'GENERAL' where purpose not in ('GENERAL', 'STATUS_CHANGE_REASON')]';
+      execute immediate q'[alter table comments add constraint chk_comments_purpose check (purpose in ('GENERAL', 'STATUS_CHANGE_REASON'))]';
    end if;
 end;
 /

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCommentTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCommentTest.java
@@ -28,6 +28,7 @@ class IssueCommentTest {
 
         assertEquals("C-1", comment.getCommentId());
         assertEquals("I will check it.", comment.getContent());
+        assertEquals(CommentPurpose.GENERAL, comment.getPurpose());
         assertSame(developer, comment.getWriter());
         assertEquals(commentedAt, comment.getCreatedDate());
         assertEquals(1, issue.getComments().size());
@@ -40,6 +41,25 @@ class IssueCommentTest {
         assertEquals("I will check it.", history.getMessage());
         assertSame(developer, history.getChangedBy());
         assertEquals(commentedAt, history.getChangedDate());
+    }
+
+    @Test
+    @DisplayName("상태 변경 사유 댓글은 일반 댓글과 목적이 구분된다")
+    void addStatusChangeReasonComment() {
+        var issue = Issue.create("ISSUE-1", "Login fails", "Cannot log in", null, reporter, createdAt);
+        var commentedAt = createdAt.plusMinutes(5);
+
+        var comment = issue.addComment(
+                "C-1",
+                "Fixed with regression tests.",
+                developer,
+                commentedAt,
+                CommentPurpose.STATUS_CHANGE_REASON
+        );
+
+        assertEquals(CommentPurpose.STATUS_CHANGE_REASON, comment.getPurpose());
+        assertEquals(ActionType.COMMENTED, issue.getHistories().getLast().getAction());
+        assertEquals("C-1", issue.getHistories().getLast().getNewValue());
     }
 
     @Test
@@ -68,6 +88,7 @@ class IssueCommentTest {
         assertEquals("dev1", comment.writerId());
         assertEquals("I fixed this.", comment.content());
         assertEquals("I fixed this.", comment.getContent());
+        assertEquals(CommentPurpose.GENERAL, comment.getPurpose());
         assertEquals(createdAt, comment.createdDate());
         assertEquals(createdAt, comment.getCreatedDate());
         assertNull(comment.getWriter());
@@ -83,6 +104,7 @@ class IssueCommentTest {
         assertEquals("C-2", comment.getCommentId());
         assertEquals("dev1", comment.writerId());
         assertEquals("Please verify again.", comment.content());
+        assertEquals(CommentPurpose.GENERAL, comment.getPurpose());
         assertSame(developer, comment.getWriter());
         assertEquals(createdAt.plusMinutes(15), comment.createdDate());
     }

--- a/src/test/java/com/github/marcellokim/issuetracker/persistence/PersistenceResourceSmokeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/persistence/PersistenceResourceSmokeTest.java
@@ -70,6 +70,16 @@ class PersistenceResourceSmokeTest {
     }
 
     @Test
+    @DisplayName("Comments schema upgrades existing tables with purpose column")
+    void commentsSchemaUpgradesExistingPurposeColumn() throws IOException {
+        String schema = readResource("db/oracle/schema-oracle.sql").toLowerCase();
+
+        assertTrue(schema.contains("alter table comments add purpose varchar2(32) default 'general' not null"));
+        assertTrue(schema.contains("chk_comments_purpose"));
+        assertTrue(schema.contains("'status_change_reason'"));
+    }
+
+    @Test
     @DisplayName("Seed SQL includes required demo accounts and status history samples")
     void seedIncludesRequiredDemoAccountsAndHistorySamples() throws IOException {
         String schema = readResource("db/oracle/schema-oracle.sql").toLowerCase();

--- a/src/test/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcCommentRepositoryTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcCommentRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.github.marcellokim.issuetracker.persistence.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.marcellokim.issuetracker.domain.CommentPurpose;
+import java.lang.reflect.Proxy;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("JDBC comment repository")
+class JdbcCommentRepositoryTest {
+
+    @Test
+    @DisplayName("legacy comments without purpose are treated as general comments")
+    void mapCommentDefaultsMissingPurposeToGeneral() throws Exception {
+        var createdDate = LocalDateTime.of(2026, 5, 21, 12, 0);
+        var row = resultSet(Map.of(
+                "id", 10L,
+                "issue_id", 20L,
+                "writer_login_id", "dev1",
+                "content", "legacy comment",
+                "created_date", Timestamp.valueOf(createdDate)
+        ));
+
+        var comment = JdbcCommentRepository.mapComment(row);
+
+        assertEquals(CommentPurpose.GENERAL, comment.getPurpose());
+        assertEquals(createdDate, comment.getCreatedDate());
+    }
+
+    private static ResultSet resultSet(Map<String, Object> values) {
+        return (ResultSet) Proxy.newProxyInstance(
+                JdbcCommentRepositoryTest.class.getClassLoader(),
+                new Class<?>[] {ResultSet.class},
+                (proxy, method, args) -> {
+                    var name = method.getName();
+                    if ("getLong".equals(name)) {
+                        return ((Number) values.get((String) args[0])).longValue();
+                    }
+                    if ("getString".equals(name)) {
+                        return (String) values.get((String) args[0]);
+                    }
+                    if ("getTimestamp".equals(name)) {
+                        return (Timestamp) values.get((String) args[0]);
+                    }
+                    throw new UnsupportedOperationException(name);
+                }
+        );
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.github.marcellokim.issuetracker.domain.CommentPurpose;
 import com.github.marcellokim.issuetracker.domain.Issue;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.Priority;
@@ -32,6 +33,8 @@ class IssueServiceTest {
     private final User dev = User.create("dev1", "Dev One", "hash", Role.DEV, true, now, now);
     private final User tester = User.create("tester1", "Tester One", "hash", Role.TESTER, true, now, now);
     private final User pl = User.create("pl1", "PL One", "hash", Role.PL, true, now, now);
+    private final User admin = User.create("admin", "Admin", "hash", Role.ADMIN, true, now, now);
+    private final User inactiveDev = User.create("dev-disabled", "Inactive Dev", "hash", Role.DEV, false, now, now);
     private final Project project = Project.create(PROJECT_ID, "ITS", "Issue Tracking", "admin", now, now);
 
     @Test
@@ -85,9 +88,37 @@ class IssueServiceTest {
         CommentResult result = service.addComment(ISSUE_ID, "Looks like a real bug", dev.getLoginId());
 
         assertNotNull(result.commentId());
+        assertEquals(CommentPurpose.GENERAL, result.purpose());
         assertEquals("Looks like a real bug", result.content());
         assertEquals(dev, result.writer());
         assertNotNull(result.createdDate());
+    }
+
+    @Test
+    @DisplayName("general comment id is generated independently from hydrated comment count")
+    void addCommentUsesGeneratedCommentId() {
+        var issue = persistedIssue();
+        var service = service(new InMemoryIssueRepository(issue));
+
+        CommentResult result = service.addComment(ISSUE_ID, "Looks like a real bug", dev.getLoginId());
+
+        assertEquals(CommentPurpose.GENERAL, result.purpose());
+        org.junit.jupiter.api.Assertions.assertTrue(
+                result.commentId().startsWith("COMMENT-"),
+                "commentId should use the shared generated comment id contract"
+        );
+    }
+
+    @Test
+    @DisplayName("ADMIN과 비활성 사용자는 이슈 댓글을 추가할 수 없다")
+    void addCommentRejectsAdminAndInactiveUser() {
+        var issue = persistedIssue();
+        var service = service(new InMemoryIssueRepository(issue));
+
+        assertThrows(SecurityException.class,
+                () -> service.addComment(ISSUE_ID, "admin comment", admin.getLoginId()));
+        assertThrows(SecurityException.class,
+                () -> service.addComment(ISSUE_ID, "inactive comment", inactiveDev.getLoginId()));
     }
 
     @Test
@@ -123,7 +154,7 @@ class IssueServiceTest {
         return new IssueService(
                 new FakeProjectRepository(project),
                 issues,
-                new InMemoryUserRepository(dev, tester, pl),
+                new InMemoryUserRepository(dev, tester, pl, admin, inactiveDev),
                 new PermissionPolicy(),
                 new Clock()
         );

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.github.marcellokim.issuetracker.domain.ActionType;
+import com.github.marcellokim.issuetracker.domain.CommentPurpose;
 import com.github.marcellokim.issuetracker.domain.Issue;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.Priority;
@@ -43,6 +44,8 @@ class IssueStateServiceTest {
         assertSame(assignee, issue.getFixer());
         assertEquals(1, issue.getComments().size());
         assertEquals("Fix completed", issue.getComments().getFirst().getContent());
+        assertEquals(CommentPurpose.STATUS_CHANGE_REASON, issue.getComments().getFirst().getPurpose());
+        org.junit.jupiter.api.Assertions.assertTrue(issue.getComments().getFirst().getCommentId().startsWith("COMMENT-"));
         assertEquals(ActionType.COMMENTED, issue.getHistories().getLast().getAction());
         assertStatusChangedThenCommented(issue);
     }
@@ -59,6 +62,7 @@ class IssueStateServiceTest {
         assertSame(verifier, issue.getResolver());
         assertEquals(1, issue.getComments().size());
         assertEquals("Verified", issue.getComments().getFirst().getContent());
+        assertEquals(CommentPurpose.STATUS_CHANGE_REASON, issue.getComments().getFirst().getPurpose());
         assertEquals(ActionType.COMMENTED, issue.getHistories().getLast().getAction());
         assertStatusChangedThenCommented(issue);
     }
@@ -78,6 +82,7 @@ class IssueStateServiceTest {
         assertSame(verifier, issue.getResolver());
         assertEquals(1, issue.getComments().size());
         assertEquals("Release completed", issue.getComments().getFirst().getContent());
+        assertEquals(CommentPurpose.STATUS_CHANGE_REASON, issue.getComments().getFirst().getPurpose());
         assertEquals(ActionType.COMMENTED, issue.getHistories().getLast().getAction());
         assertStatusChangedThenCommented(issue);
     }


### PR DESCRIPTION
## 요약
- #121 머지 후 남은 #102 계약 빈틈 보강
- `CommentPurpose`로 일반 댓글과 상태 변경 사유 댓글 구분
- 일반 댓글 권한을 active Auth User(PL/DEV/TESTER)로 제한하고 ADMIN/비활성 사용자를 거부
- comment id 생성을 `COMMENT-UUID` 공통 계약으로 통일해 hydrated comment count 의존 제거
- Oracle `comments.purpose` 컬럼과 JDBC comment 저장/조회 매핑 반영

## 검증
- `./gradlew test --tests '*IssueCommentTest' --tests '*IssueServiceTest' --tests '*IssueStateServiceTest' --no-daemon --console=plain`
- `./gradlew check --no-daemon --console=plain`
- `./scripts/open-pr.sh` 내부 `./gradlew check`

## 남은 범위
- #103 검색/상세 조회는 별도 유지
- #43/#47 상태 변경 service/controller 분기는 `CommentPurpose.STATUS_CHANGE_REASON` 재사용
- #45/#98 dependency 구현은 별도 유지

## 관련 이슈
- Closes #102
