### PR TITLE
chore: dev 머지 PR 완료 동기화 보강

### DIFF
--- a/scripts/lib/project_maintenance.py
+++ b/scripts/lib/project_maintenance.py
@@ -668,7 +668,7 @@ def sync_issue_completion_from_merged_dev_prs(repo: str, *, dry_run: bool, chang
         "--limit", "100",
         "--json", "number,title,body,closingIssuesReferences",
     ])
-    completed_issue_numbers: dict[int, int] = {}
+    completed_issue_numbers: dict[int, tuple[int, str]] = {}
     repo_owner, repo_name = repo.split("/", 1)
     for pr in prs:
         for issue in pr.get("closingIssuesReferences", []):
@@ -676,16 +676,21 @@ def sync_issue_completion_from_merged_dev_prs(repo: str, *, dry_run: bool, chang
             issue_owner = issue_repo.get("owner") or {}
             if issue_repo.get("name") != repo_name or issue_owner.get("login") != repo_owner:
                 continue
-            completed_issue_numbers.setdefault(int(issue["number"]), int(pr["number"]))
+            completed_issue_numbers[int(issue["number"])] = (int(pr["number"]), "closingIssuesReferences")
         for issue_number in parse_closing_issue_numbers_from_body(str(pr.get("body") or "")):
-            completed_issue_numbers.setdefault(issue_number, int(pr["number"]))
+            completed_issue_numbers.setdefault(issue_number, (int(pr["number"]), "body"))
 
-    for issue_number, pr_number in sorted(completed_issue_numbers.items()):
-        issue = gh_json([
-            "issue", "view", str(issue_number),
-            "--repo", repo,
-            "--json", "number,title,state,labels",
-        ])
+    for issue_number, (pr_number, source) in sorted(completed_issue_numbers.items()):
+        try:
+            issue = gh_json([
+                "issue", "view", str(issue_number),
+                "--repo", repo,
+                "--json", "number,title,state,labels",
+            ])
+        except SystemExit:
+            if source != "body":
+                raise
+            continue
         labels = label_names(issue)
         labels_to_remove = sorted((labels & STATUS_LABELS) - {"status:done"})
         needs_done_label = "status:done" not in labels

--- a/scripts/lib/project_maintenance.py
+++ b/scripts/lib/project_maintenance.py
@@ -658,7 +658,7 @@ def sync_issue_completion_from_merged_dev_prs(repo: str, *, dry_run: bool, chang
         "--state", "merged",
         "--base", "dev",
         "--limit", "100",
-        "--json", "number,title,closingIssuesReferences",
+        "--json", "number,title,body,closingIssuesReferences",
     ])
     completed_issue_numbers: dict[int, int] = {}
     repo_owner, repo_name = repo.split("/", 1)
@@ -669,6 +669,8 @@ def sync_issue_completion_from_merged_dev_prs(repo: str, *, dry_run: bool, chang
             if issue_repo.get("name") != repo_name or issue_owner.get("login") != repo_owner:
                 continue
             completed_issue_numbers.setdefault(int(issue["number"]), int(pr["number"]))
+        for issue_number in parse_issue_numbers_from_body(str(pr.get("body") or "")):
+            completed_issue_numbers.setdefault(issue_number, int(pr["number"]))
 
     for issue_number, pr_number in sorted(completed_issue_numbers.items()):
         issue = gh_json([

--- a/scripts/lib/project_maintenance.py
+++ b/scripts/lib/project_maintenance.py
@@ -136,8 +136,16 @@ def parse_issue_number_from_branch(branch: str) -> int | None:
 
 
 def parse_issue_numbers_from_body(body: str) -> list[int]:
+    return parse_issue_numbers_with_keywords(body, r"close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?")
+
+
+def parse_closing_issue_numbers_from_body(body: str) -> list[int]:
+    return parse_issue_numbers_with_keywords(body, r"close[sd]?|fix(?:e[sd])?|resolve[sd]?")
+
+
+def parse_issue_numbers_with_keywords(body: str, keywords: str) -> list[int]:
     numbers: list[int] = []
-    pattern = re.compile(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?):?\s+#([0-9]+)", re.IGNORECASE)
+    pattern = re.compile(rf"\b(?:{keywords}):?\s+#([0-9]+)", re.IGNORECASE)
     for match in pattern.finditer(body):
         number = int(match.group(1))
         if number not in numbers:
@@ -669,7 +677,7 @@ def sync_issue_completion_from_merged_dev_prs(repo: str, *, dry_run: bool, chang
             if issue_repo.get("name") != repo_name or issue_owner.get("login") != repo_owner:
                 continue
             completed_issue_numbers.setdefault(int(issue["number"]), int(pr["number"]))
-        for issue_number in parse_issue_numbers_from_body(str(pr.get("body") or "")):
+        for issue_number in parse_closing_issue_numbers_from_body(str(pr.get("body") or "")):
             completed_issue_numbers.setdefault(issue_number, int(pr["number"]))
 
     for issue_number, pr_number in sorted(completed_issue_numbers.items()):

--- a/scripts/lib/project_maintenance.py
+++ b/scripts/lib/project_maintenance.py
@@ -135,22 +135,37 @@ def parse_issue_number_from_branch(branch: str) -> int | None:
     return int(match.group(1)) if match else None
 
 
-def parse_issue_numbers_from_body(body: str) -> list[int]:
-    return parse_issue_numbers_with_keywords(body, r"close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?")
+def parse_issue_numbers_from_body(body: str, repo: str | None = None) -> list[int]:
+    return parse_issue_numbers_with_keywords(body, r"close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?", repo=repo)
 
 
-def parse_closing_issue_numbers_from_body(body: str) -> list[int]:
-    return parse_issue_numbers_with_keywords(body, r"close[sd]?|fix(?:e[sd])?|resolve[sd]?")
+def parse_closing_issue_numbers_from_body(body: str, repo: str | None = None) -> list[int]:
+    return parse_issue_numbers_with_keywords(body, r"close[sd]?|fix(?:e[sd])?|resolve[sd]?", repo=repo)
 
 
-def parse_issue_numbers_with_keywords(body: str, keywords: str) -> list[int]:
+def parse_issue_numbers_with_keywords(body: str, keywords: str, repo: str | None = None) -> list[int]:
     numbers: list[int] = []
-    pattern = re.compile(rf"\b(?:{keywords}):?\s+#([0-9]+)", re.IGNORECASE)
+    pattern = re.compile(
+        rf"\b(?:{keywords}):?\s+(?:(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(?P<number>[0-9]+)",
+        re.IGNORECASE,
+    )
     for match in pattern.finditer(body):
-        number = int(match.group(1))
+        qualified_repo = match.group("repo")
+        if qualified_repo is not None and (repo is None or qualified_repo.lower() != repo.lower()):
+            continue
+        number = int(match.group("number"))
         if number not in numbers:
             numbers.append(number)
     return numbers
+
+
+def is_issue_not_found_error(error: SystemExit) -> bool:
+    message = str(error).lower()
+    return (
+        "not found" in message
+        or "could not resolve to an issue" in message
+        or "could not resolve to issue" in message
+    )
 
 
 def is_bot_login(login: str) -> bool:
@@ -477,7 +492,7 @@ def ensure_project_item(context: ProjectContext, url: str, dry_run: bool, change
 
 def append_issue_link_if_missing(pr_number: int, pr: dict[str, object], issue_number: int, repo: str, dry_run: bool, changes: list[str]) -> None:
     body = str(pr.get("body") or "")
-    if issue_number in parse_issue_numbers_from_body(body):
+    if issue_number in parse_issue_numbers_from_body(body, repo=repo):
         return
 
     if dry_run:
@@ -578,7 +593,7 @@ def sync_single_pr_metadata(args: argparse.Namespace) -> int:
         return 0
 
     linked_numbers = [int(issue["number"]) for issue in pr.get("closingIssuesReferences", [])]
-    linked_numbers.extend(parse_issue_numbers_from_body(str(pr.get("body") or "")))
+    linked_numbers.extend(parse_issue_numbers_from_body(str(pr.get("body") or ""), repo=repo))
     if not linked_numbers:
         branch_issue = parse_issue_number_from_branch(str(pr.get("headRefName") or ""))
         if branch_issue is not None:
@@ -677,7 +692,7 @@ def sync_issue_completion_from_merged_dev_prs(repo: str, *, dry_run: bool, chang
             if issue_repo.get("name") != repo_name or issue_owner.get("login") != repo_owner:
                 continue
             completed_issue_numbers[int(issue["number"])] = (int(pr["number"]), "closingIssuesReferences")
-        for issue_number in parse_closing_issue_numbers_from_body(str(pr.get("body") or "")):
+        for issue_number in parse_closing_issue_numbers_from_body(str(pr.get("body") or ""), repo=repo):
             completed_issue_numbers.setdefault(issue_number, (int(pr["number"]), "body"))
 
     for issue_number, (pr_number, source) in sorted(completed_issue_numbers.items()):
@@ -687,10 +702,10 @@ def sync_issue_completion_from_merged_dev_prs(repo: str, *, dry_run: bool, chang
                 "--repo", repo,
                 "--json", "number,title,state,labels",
             ])
-        except SystemExit:
-            if source != "body":
-                raise
-            continue
+        except SystemExit as error:
+            if source == "body" and is_issue_not_found_error(error):
+                continue
+            raise
         labels = label_names(issue)
         labels_to_remove = sorted((labels & STATUS_LABELS) - {"status:done"})
         needs_done_label = "status:done" not in labels

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
@@ -38,6 +38,11 @@ class ProjectMaintenanceScriptTest {
                             "title": "reference only",
                             "body": "## 참고\\n- Refs #103\\n",
                             "closingIssuesReferences": []
+                        }, {
+                            "number": 125,
+                            "title": "invalid closing reference",
+                            "body": "## 관련 이슈\\n- Closes: #999\\n",
+                            "closingIssuesReferences": []
                         }]
                     if args[:3] == ["issue", "view", "102"]:
                         return {
@@ -46,6 +51,8 @@ class ProjectMaintenanceScriptTest {
                             "state": "OPEN",
                             "labels": [{"name": "status:review"}]
                         }
+                    if args[:3] == ["issue", "view", "999"]:
+                        raise SystemExit("issue not found")
                     raise AssertionError(args)
 
                 project_maintenance.gh_json = fake_gh_json

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
@@ -1,6 +1,7 @@
 package com.github.marcellokim.issuetracker.setup;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -43,11 +44,28 @@ class ProjectMaintenanceScriptTest {
                             "title": "invalid closing reference",
                             "body": "## 관련 이슈\\n- Closes: #9999\\n",
                             "closingIssuesReferences": []
+                        }, {
+                            "number": 9004,
+                            "title": "qualified closing reference",
+                            "body": "## 관련 이슈\\n- Resolves marcellokim/se-issue-tracker#9104\\n",
+                            "closingIssuesReferences": []
+                        }, {
+                            "number": 9005,
+                            "title": "external qualified reference",
+                            "body": "## 관련 이슈\\n- Closes other/repo#9105\\n",
+                            "closingIssuesReferences": []
                         }]
                     if args[:3] == ["issue", "view", "9102"]:
                         return {
                             "number": 9102,
                             "title": "IssueController 등록과 코멘트 API 구현",
+                            "state": "OPEN",
+                            "labels": [{"name": "status:review"}]
+                        }
+                    if args[:3] == ["issue", "view", "9104"]:
+                        return {
+                            "number": 9104,
+                            "title": "fully qualified closing reference",
                             "state": "OPEN",
                             "labels": [{"name": "status:review"}]
                         }
@@ -66,13 +84,56 @@ class ProjectMaintenanceScriptTest {
                 )
 
                 assert changes == [
-                    "DRY-RUN merged dev PR #9001 linked issue 완료 처리: #9102 IssueController 등록과 코멘트 API 구현"
+                    "DRY-RUN merged dev PR #9001 linked issue 완료 처리: #9102 IssueController 등록과 코멘트 API 구현",
+                    "DRY-RUN merged dev PR #9004 linked issue 완료 처리: #9104 fully qualified closing reference"
                 ], changes
                 """;
 
         ScriptResult result = runPython(script);
 
         assertEquals(0, result.exitCode(), result.output());
+    }
+
+    @Test
+    @DisplayName("본문 fallback 이슈 조회 실패가 not-found가 아니면 오류를 숨기지 않는다")
+    void mergedDevPrCompletionReraisesNonMissingIssueLookupFailures() throws IOException, InterruptedException {
+        String script = """
+                import importlib.util
+                import sys
+                import types
+
+                spec = importlib.util.spec_from_file_location("project_maintenance", "scripts/lib/project_maintenance.py")
+                project_maintenance = importlib.util.module_from_spec(spec)
+                sys.modules[spec.name] = project_maintenance
+                spec.loader.exec_module(project_maintenance)
+
+                def fake_gh_json(args):
+                    if args[:2] == ["pr", "list"]:
+                        return [{
+                            "number": 9006,
+                            "title": "temporary cli failure",
+                            "body": "## 관련 이슈\\n- Closes #9998\\n",
+                            "closingIssuesReferences": []
+                        }]
+                    if args[:3] == ["issue", "view", "9998"]:
+                        raise SystemExit("rate limit exceeded")
+                    raise AssertionError(args)
+
+                project_maintenance.gh_json = fake_gh_json
+                project_maintenance.run = lambda *args, **kwargs: types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+                changes = []
+                project_maintenance.sync_issue_completion_from_merged_dev_prs(
+                    "marcellokim/se-issue-tracker",
+                    dry_run=True,
+                    changes=changes
+                )
+                """;
+
+        ScriptResult result = runPython(script);
+
+        assertTrue(result.exitCode() != 0, result.output());
+        assertTrue(result.output().contains("rate limit exceeded"), result.output());
     }
 
     private ScriptResult runPython(String script) throws IOException, InterruptedException {

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
@@ -25,10 +25,18 @@ class ProjectMaintenanceScriptTest {
 
                 def fake_gh_json(args):
                     if args[:2] == ["pr", "list"]:
+                        fields = set(args[args.index("--json") + 1].split(","))
+                        assert "body" in fields, args
+                        assert "closingIssuesReferences" in fields, args
                         return [{
                             "number": 122,
                             "title": "comment contract",
                             "body": "## 관련 이슈\\n- Closes #102\\n",
+                            "closingIssuesReferences": []
+                        }, {
+                            "number": 124,
+                            "title": "reference only",
+                            "body": "## 참고\\n- Refs #103\\n",
                             "closingIssuesReferences": []
                         }]
                     if args[:3] == ["issue", "view", "102"]:

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
@@ -29,29 +29,29 @@ class ProjectMaintenanceScriptTest {
                         assert "body" in fields, args
                         assert "closingIssuesReferences" in fields, args
                         return [{
-                            "number": 122,
+                            "number": 9001,
                             "title": "comment contract",
-                            "body": "## 관련 이슈\\n- Closes #102\\n",
+                            "body": "## 관련 이슈\\n- Closes #9102\\n",
                             "closingIssuesReferences": []
                         }, {
-                            "number": 124,
+                            "number": 9002,
                             "title": "reference only",
-                            "body": "## 참고\\n- Refs #103\\n",
+                            "body": "## 참고\\n- Refs #9103\\n",
                             "closingIssuesReferences": []
                         }, {
-                            "number": 125,
+                            "number": 9003,
                             "title": "invalid closing reference",
-                            "body": "## 관련 이슈\\n- Closes: #999\\n",
+                            "body": "## 관련 이슈\\n- Closes: #9999\\n",
                             "closingIssuesReferences": []
                         }]
-                    if args[:3] == ["issue", "view", "102"]:
+                    if args[:3] == ["issue", "view", "9102"]:
                         return {
-                            "number": 102,
+                            "number": 9102,
                             "title": "IssueController 등록과 코멘트 API 구현",
                             "state": "OPEN",
                             "labels": [{"name": "status:review"}]
                         }
-                    if args[:3] == ["issue", "view", "999"]:
+                    if args[:3] == ["issue", "view", "9999"]:
                         raise SystemExit("issue not found")
                     raise AssertionError(args)
 
@@ -66,7 +66,7 @@ class ProjectMaintenanceScriptTest {
                 )
 
                 assert changes == [
-                    "DRY-RUN merged dev PR #122 linked issue 완료 처리: #102 IssueController 등록과 코멘트 API 구현"
+                    "DRY-RUN merged dev PR #9001 linked issue 완료 처리: #9102 IssueController 등록과 코멘트 API 구현"
                 ], changes
                 """;
 

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
@@ -1,0 +1,76 @@
+package com.github.marcellokim.issuetracker.setup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("프로젝트 정합성 스크립트")
+class ProjectMaintenanceScriptTest {
+
+    @Test
+    @DisplayName("dev로 머지된 PR은 closingIssuesReferences가 비어도 본문 Closes를 기준으로 이슈 완료 후보를 찾는다")
+    void mergedDevPrCompletionFallsBackToBodyClosesReferences() throws IOException, InterruptedException {
+        String script = """
+                import importlib.util
+                import sys
+                import types
+
+                spec = importlib.util.spec_from_file_location("project_maintenance", "scripts/lib/project_maintenance.py")
+                project_maintenance = importlib.util.module_from_spec(spec)
+                sys.modules[spec.name] = project_maintenance
+                spec.loader.exec_module(project_maintenance)
+
+                def fake_gh_json(args):
+                    if args[:2] == ["pr", "list"]:
+                        return [{
+                            "number": 122,
+                            "title": "comment contract",
+                            "body": "## 관련 이슈\\n- Closes #102\\n",
+                            "closingIssuesReferences": []
+                        }]
+                    if args[:3] == ["issue", "view", "102"]:
+                        return {
+                            "number": 102,
+                            "title": "IssueController 등록과 코멘트 API 구현",
+                            "state": "OPEN",
+                            "labels": [{"name": "status:review"}]
+                        }
+                    raise AssertionError(args)
+
+                project_maintenance.gh_json = fake_gh_json
+                project_maintenance.run = lambda *args, **kwargs: types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+                changes = []
+                project_maintenance.sync_issue_completion_from_merged_dev_prs(
+                    "marcellokim/se-issue-tracker",
+                    dry_run=True,
+                    changes=changes
+                )
+
+                assert changes == [
+                    "DRY-RUN merged dev PR #122 linked issue 완료 처리: #102 IssueController 등록과 코멘트 API 구현"
+                ], changes
+                """;
+
+        ScriptResult result = runPython(script);
+
+        assertEquals(0, result.exitCode(), result.output());
+    }
+
+    private ScriptResult runPython(String script) throws IOException, InterruptedException {
+        var processBuilder = new ProcessBuilder("python3", "-c", script);
+        processBuilder.directory(Path.of(".").toAbsolutePath().normalize().toFile());
+        processBuilder.redirectErrorStream(true);
+
+        var process = processBuilder.start();
+        String output = new String(process.getInputStream().readAllBytes());
+        int exitCode = process.waitFor();
+        return new ScriptResult(exitCode, output);
+    }
+
+    record ScriptResult(int exitCode, String output) {
+    }
+}


### PR DESCRIPTION
## 요약
- dev에 merge된 PR의 linked issue 완료 처리가 `closingIssuesReferences` 누락 상황에서도 동작하도록 보강
- PR body의 `Closes/Fixes/Resolves #N`만 완료 후보로 인정하고 `Refs #N`은 제외
- body fallback에서 잘못된 이슈 번호가 잡히면 전체 동기화를 중단하지 않고 skip
- 테스트 fixture 번호를 실제 PR/issue 번호와 겹치지 않는 가짜 번호로 정리

## #27과의 관계
- #27 완료 기준 중 `자동 등록/동기화 workflow가 새 PR/issue를 빠뜨리지 않는지 확인` 항목 일부를 보강함
- Project 필드/마일스톤/최종 캡처 목록 준비까지 완료한 것은 아니므로 #27을 닫지 않음

## 검증
- `./gradlew test --tests '*ProjectMaintenanceScriptTest' --no-daemon --console=plain`
- `./gradlew check --no-daemon --console=plain`
- 원격 PR checks success 확인

## 관련 이슈
- Refs #27
