### PR TITLE
test: 아키텍처 경계 guard 추가

### DIFF
--- a/docs/uml/dcd/dcd_implementation_details.md
+++ b/docs/uml/dcd/dcd_implementation_details.md
@@ -144,7 +144,7 @@ IssueStateService
 | JDBC 구현체 생성 | JdbcRepositoryFactory |
 | 실행 환경별 객체 조립 | ApplicationContext |
 
-Controller가 너무 많은 repository, policy, clock, recommendation service를 직접 들기 시작하면 service 분리를 우선 검토한다. 반대로 흐름이 단순하고 branch가 적으면 controller가 repository interface를 직접 받아 조정할 수 있다.
+Controller가 repository, policy, clock, recommendation service를 직접 들고 조정하는 구조는 legacy 예외로만 남긴다. 신규 구현과 clean-code slice에서는 controller가 system operation 수신과 service 위임을 담당하고, repository interface 조정은 service 뒤로 이동한다.
 
 ## DCD 반영 기준
 
@@ -158,6 +158,35 @@ Controller가 너무 많은 repository, policy, clock, recommendation service를
 - `IssueStateController`의 repository/policy/clock 직접 dependency를 `IssueStateService`로 이동
 
 `dcd-ver2`는 core workflow DCD이므로 수정하지 않는다. ver2는 repository/authentication/clock infrastructure를 의도적으로 생략한 보고서 본문용 요약 DCD로 유지한다.
+
+## Executable Architecture Boundary Guard
+
+`ArchitectureBoundaryTest`는 production Java source의 `import` 선언을 스캔해서 MVC/GRASP/SOLID 패키지 의존성 방향을 실행 가능한 규칙으로 검증한다. 이 테스트는 현재 DCD 설명이 코드 구조와 함께 유지되도록 하는 경계 가드이다.
+
+가드 규칙은 다음이다.
+
+- `domain`은 `controller`, `service`, `repository`, `persistence`, `ui`, `config`, `technical`을 import하지 않는다.
+- `service`는 `controller`, `persistence`, `ui`, `config`를 import하지 않는다. Repository interface import는 허용한다.
+- `controller`는 `repository`, `persistence`, `ui`를 import하지 않는다.
+- `ui`는 `repository`, `persistence`를 import하지 않는다.
+
+현재 dev 구현에는 다음 임시 예외가 있다.
+
+- `controller/AccountController.java` -> `UserRepository`
+- `controller/DeletedIssueController.java` -> `IssueRepository`
+- `controller/StatisticsController.java` -> `StatisticsRepository`
+- `ui/DemoDashboardPresenter.java` -> `IssueRepository`
+- `ui/DemoDashboardPresenter.java` -> `ProjectRepository`
+- `ui/DemoDashboardPresenter.java` -> `StatisticsRepository`
+- `ui/DemoDashboardPresenter.java` -> `UserRepository`
+
+이 예외는 영구 설계가 아니라 debt marker이다. 이후 clean-code slice에서 해당 흐름이 service 또는 presenter boundary 뒤로 이동하면 예외 항목을 하나씩 제거해야 한다.
+
+Review comment 정책은 다음 기준을 따른다.
+
+- 임시 architecture exception, non-obvious responsibility boundary, side effect를 막는 ordering rule에는 짧은 code comment를 남긴다.
+- 명백한 assignment, getter, 단순 delegation에는 comment를 남기지 않는다.
+- debt를 표시하는 comment는 제거를 맡을 slice/workflow 이름을 같이 적는다.
 
 ## 주의사항
 

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/ArchitectureBoundaryTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/ArchitectureBoundaryTest.java
@@ -1,0 +1,179 @@
+package com.github.marcellokim.issuetracker.setup;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("architecture boundary rules")
+class ArchitectureBoundaryTest {
+
+    private static final Path MAIN_SOURCE_ROOT = Path.of("src/main/java");
+    private static final String ROOT_PACKAGE = "com.github.marcellokim.issuetracker";
+    private static final Path ROOT_PACKAGE_PATH = MAIN_SOURCE_ROOT.resolve(ROOT_PACKAGE.replace('.', '/'));
+    private static final Pattern IMPORT_PATTERN = Pattern.compile("^import\\s+(?:static\\s+)?([\\w.]+)(?:\\.\\*)?;");
+
+    /*
+     * Temporary architecture debt marker: later clean-code slices must remove each exception
+     * when that flow moves behind the intended service/presenter boundary.
+     */
+    private static final Set<AllowedImport> TEMPORARY_ALLOWED_IMPORTS = Set.of(
+            new AllowedImport("controller/AccountController.java", ROOT_PACKAGE + ".repository.UserRepository"),
+            new AllowedImport("controller/DeletedIssueController.java", ROOT_PACKAGE + ".repository.IssueRepository"),
+            new AllowedImport(
+                    "controller/StatisticsController.java",
+                    ROOT_PACKAGE + ".repository.StatisticsRepository"
+            ),
+            new AllowedImport("ui/DemoDashboardPresenter.java", ROOT_PACKAGE + ".repository.IssueRepository"),
+            new AllowedImport("ui/DemoDashboardPresenter.java", ROOT_PACKAGE + ".repository.ProjectRepository"),
+            new AllowedImport("ui/DemoDashboardPresenter.java", ROOT_PACKAGE + ".repository.StatisticsRepository"),
+            new AllowedImport("ui/DemoDashboardPresenter.java", ROOT_PACKAGE + ".repository.UserRepository")
+    );
+
+    @Test
+    @DisplayName("domain package does not depend on outer layers")
+    void domainDoesNotDependOnOuterLayers() throws IOException {
+        assertNoForbiddenImports(
+                "domain",
+                Set.of(
+                        ROOT_PACKAGE + ".controller",
+                        ROOT_PACKAGE + ".service",
+                        ROOT_PACKAGE + ".repository",
+                        ROOT_PACKAGE + ".persistence",
+                        ROOT_PACKAGE + ".ui",
+                        ROOT_PACKAGE + ".config",
+                        ROOT_PACKAGE + ".technical"
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("service package depends on repository contracts, not JDBC implementations")
+    void servicesDoNotDependOnJdbcImplementations() throws IOException {
+        assertNoForbiddenImports(
+                "service",
+                Set.of(
+                        ROOT_PACKAGE + ".controller",
+                        ROOT_PACKAGE + ".persistence",
+                        ROOT_PACKAGE + ".ui",
+                        ROOT_PACKAGE + ".config"
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("controllers delegate to services instead of repositories or persistence")
+    void controllersDoNotDependOnRepositoriesOrPersistence() throws IOException {
+        assertNoForbiddenImports(
+                "controller",
+                Set.of(
+                        ROOT_PACKAGE + ".repository",
+                        ROOT_PACKAGE + ".persistence",
+                        ROOT_PACKAGE + ".ui"
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("ui package does not depend directly on repositories or persistence")
+    void uiDoesNotDependOnRepositoriesOrPersistence() throws IOException {
+        assertNoForbiddenImports(
+                "ui",
+                Set.of(
+                        ROOT_PACKAGE + ".repository",
+                        ROOT_PACKAGE + ".persistence"
+                )
+        );
+    }
+
+    private static void assertNoForbiddenImports(String packageSegment, Set<String> forbiddenPrefixes)
+            throws IOException {
+        List<Violation> violations = new ArrayList<>();
+        for (JavaSource source : productionSources(packageSegment)) {
+            for (String importedType : source.importedTypes()) {
+                if (isForbidden(importedType, forbiddenPrefixes)
+                        && !TEMPORARY_ALLOWED_IMPORTS.contains(
+                                new AllowedImport(source.relativePath(), importedType))) {
+                    violations.add(new Violation(source.relativePath(), importedType));
+                }
+            }
+        }
+
+        assertTrue(
+                violations.isEmpty(),
+                () -> "Forbidden architecture imports found:%n%s".formatted(formatViolations(violations))
+        );
+    }
+
+    private static boolean isForbidden(String importedType, Set<String> forbiddenPrefixes) {
+        for (String forbiddenPrefix : forbiddenPrefixes) {
+            if (importedType.equals(forbiddenPrefix) || importedType.startsWith(forbiddenPrefix + ".")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<JavaSource> productionSources(String packageSegment) throws IOException {
+        Path packagePath = ROOT_PACKAGE_PATH.resolve(packageSegment);
+        try (Stream<Path> paths = Files.walk(packagePath)) {
+            return paths
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .map(ArchitectureBoundaryTest::readJavaSource)
+                    .toList();
+        }
+    }
+
+    private static JavaSource readJavaSource(Path path) {
+        try {
+            List<String> lines = Files.readAllLines(path);
+            return new JavaSource(
+                    ROOT_PACKAGE_PATH.relativize(path).toString().replace('\\', '/'),
+                    importedTypes(lines)
+            );
+        } catch (IOException exception) {
+            throw new IllegalStateException("Failed to read Java source: " + path, exception);
+        }
+    }
+
+    private static List<String> importedTypes(List<String> lines) {
+        List<String> imports = new ArrayList<>();
+        for (String line : lines) {
+            Matcher matcher = IMPORT_PATTERN.matcher(line.strip());
+            if (matcher.matches()) {
+                imports.add(matcher.group(1));
+            }
+        }
+        return imports;
+    }
+
+    private static String formatViolations(List<Violation> violations) {
+        StringBuilder message = new StringBuilder();
+        for (Violation violation : violations) {
+            message.append(System.lineSeparator())
+                    .append("- ")
+                    .append(violation.relativePath())
+                    .append(" imports ")
+                    .append(violation.importedType());
+        }
+        return message.toString();
+    }
+
+    record AllowedImport(String relativePath, String importedType) {
+    }
+
+    record JavaSource(String relativePath, List<String> importedTypes) {
+    }
+
+    record Violation(String relativePath, String importedType) {
+    }
+}


### PR DESCRIPTION
## 요약
- `ArchitectureBoundaryTest`를 추가해 `domain`, `service`, `controller`, `ui` 패키지의 의존 방향을 실행 가능한 테스트로 고정했습니다.
- DCD 구현 세부 문서에 guard 규칙, 임시 예외, review comment 정책을 추가했습니다.
- controller가 repository/policy/clock 등을 직접 조정하는 구조를 legacy 예외로 명시해 신규 clean-code slice 기준과 맞췄습니다.

## 검증
- `./gradlew check --console=plain`
- `git push` pre-push hook: test + repository setup 검증 통과

## 관련 이슈
- Refs #95
- #95는 추적용 이슈라서 이 PR에서 자동 close하지 않습니다.
