### PR TITLE
refactor: controller repository 조정을 service로 이동

### DIFF
--- a/docs/uml/dcd/dcd_implementation_details.md
+++ b/docs/uml/dcd/dcd_implementation_details.md
@@ -172,15 +172,14 @@ Controller가 repository, policy, clock, recommendation service를 직접 들고
 
 현재 dev 구현에는 다음 임시 예외가 있다.
 
-- `controller/AccountController.java` -> `UserRepository`
-- `controller/DeletedIssueController.java` -> `IssueRepository`
-- `controller/StatisticsController.java` -> `StatisticsRepository`
 - `ui/DemoDashboardPresenter.java` -> `IssueRepository`
 - `ui/DemoDashboardPresenter.java` -> `ProjectRepository`
 - `ui/DemoDashboardPresenter.java` -> `StatisticsRepository`
 - `ui/DemoDashboardPresenter.java` -> `UserRepository`
 
 이 예외는 영구 설계가 아니라 debt marker이다. 이후 clean-code slice에서 해당 흐름이 service 또는 presenter boundary 뒤로 이동하면 예외 항목을 하나씩 제거해야 한다.
+
+Controller layer의 repository 직접 의존 예외는 clean-code slice에서 `AccountService`, `DeletedIssueService`, `StatisticsService`로 이동했다. 이 상태를 유지하기 위해 신규 controller는 repository interface를 직접 import하지 않는다.
 
 Review comment 정책은 다음 기준을 따른다.
 

--- a/src/main/java/com/github/marcellokim/issuetracker/controller/AccountController.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/controller/AccountController.java
@@ -1,27 +1,19 @@
 package com.github.marcellokim.issuetracker.controller;
 
-import com.github.marcellokim.issuetracker.repository.UserRepository;
+import com.github.marcellokim.issuetracker.service.AccountService;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
-import com.github.marcellokim.issuetracker.service.PermissionPolicy;
-import com.github.marcellokim.issuetracker.technical.PasswordHasher;
 import java.util.Objects;
 
 public final class AccountController {
 
     private final AuthenticationService authenticationService;
-    private final PermissionPolicy permissionPolicy;
-    private final UserRepository userRepository;
-    private final PasswordHasher passwordHasher;
+    private final AccountService accountService;
 
     public AccountController(
             AuthenticationService authenticationService,
-            PermissionPolicy permissionPolicy,
-            UserRepository userRepository,
-            PasswordHasher passwordHasher) {
+            AccountService accountService) {
         this.authenticationService = Objects.requireNonNull(authenticationService, "authenticationService");
-        this.permissionPolicy = Objects.requireNonNull(permissionPolicy, "permissionPolicy");
-        this.userRepository = Objects.requireNonNull(userRepository, "userRepository");
-        this.passwordHasher = Objects.requireNonNull(passwordHasher, "passwordHasher");
+        this.accountService = Objects.requireNonNull(accountService, "accountService");
     }
 
     /*

--- a/src/main/java/com/github/marcellokim/issuetracker/controller/DeletedIssueController.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/controller/DeletedIssueController.java
@@ -2,76 +2,46 @@ package com.github.marcellokim.issuetracker.controller;
 
 import com.github.marcellokim.issuetracker.domain.Issue;
 import com.github.marcellokim.issuetracker.domain.User;
-import com.github.marcellokim.issuetracker.repository.IssueRepository;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
-import com.github.marcellokim.issuetracker.service.Clock;
-import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.service.DeletedIssueService;
 import java.util.List;
 import java.util.Objects;
 
 public final class DeletedIssueController {
 
-    private static final int MAX_DELETED_ISSUES_PER_PROJECT = 30;
-
     private final AuthenticationService authenticationService;
-    private final PermissionPolicy permissionPolicy;
-    private final IssueRepository issueRepository;
-    private final Clock clock;
+    private final DeletedIssueService deletedIssueService;
 
     public DeletedIssueController(
             AuthenticationService authenticationService,
-            PermissionPolicy permissionPolicy,
-            IssueRepository issueRepository,
-            Clock clock
+            DeletedIssueService deletedIssueService
     ) {
         this.authenticationService = Objects.requireNonNull(authenticationService, "authenticationService");
-        this.permissionPolicy = Objects.requireNonNull(permissionPolicy, "permissionPolicy");
-        this.issueRepository = Objects.requireNonNull(issueRepository, "issueRepository");
-        this.clock = Objects.requireNonNull(clock, "clock");
+        this.deletedIssueService = Objects.requireNonNull(deletedIssueService, "deletedIssueService");
     }
 
     public List<Issue> viewDeletedIssues(long projectId) {
         User user = requireCurrentUser();
-        requireDeletedIssuePermission(user, projectId);
-        return issueRepository.findDeletedByProject(projectId);
+        return deletedIssueService.viewDeletedIssues(projectId, user);
     }
 
     public Issue deleteIssue(long issueId, String comment) {
         User user = requireCurrentUser();
-        Issue issue = findIssue(issueId);
-        permissionPolicy.assertCanManageDeletedIssue(user, issue);
-
-        Issue deletedIssue = issueRepository.softDelete(issueId, user.getLoginId(), comment, clock.now());
-        issueRepository.purgeDeletedBeyondLimit(deletedIssue.projectId(), MAX_DELETED_ISSUES_PER_PROJECT);
-        return deletedIssue;
+        return deletedIssueService.deleteIssue(issueId, comment, user);
     }
 
     public Issue restoreIssue(long issueId, String comment) {
         User user = requireCurrentUser();
-        Issue issue = findIssue(issueId);
-        permissionPolicy.assertCanManageDeletedIssue(user, issue);
-        return issueRepository.restore(issueId, user.getLoginId(), comment, clock.now());
+        return deletedIssueService.restoreIssue(issueId, comment, user);
     }
 
     public int purgeOverflow(long projectId) {
         User user = requireCurrentUser();
-        requireDeletedIssuePermission(user, projectId);
-        return issueRepository.purgeDeletedBeyondLimit(projectId, MAX_DELETED_ISSUES_PER_PROJECT);
+        return deletedIssueService.purgeOverflow(projectId, user);
     }
 
     private User requireCurrentUser() {
         return authenticationService.currentUser()
                 .orElseThrow(() -> new SecurityException("Login is required."));
-    }
-
-    private Issue findIssue(long issueId) {
-        return issueRepository.findById(issueId)
-                .orElseThrow(() -> new IllegalArgumentException("Issue was not found: " + issueId));
-    }
-
-    private void requireDeletedIssuePermission(User user, long projectId) {
-        if (!permissionPolicy.verifyPermission(user, "MANAGE_DELETED_ISSUE", projectId)) {
-            throw new SecurityException("Only PL or ADMIN can manage deleted issues.");
-        }
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/controller/StatisticsController.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/controller/StatisticsController.java
@@ -2,9 +2,8 @@ package com.github.marcellokim.issuetracker.controller;
 
 import com.github.marcellokim.issuetracker.domain.StatisticsReport;
 import com.github.marcellokim.issuetracker.domain.User;
-import com.github.marcellokim.issuetracker.repository.StatisticsRepository;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
-import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.service.StatisticsService;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.Objects;
@@ -12,17 +11,14 @@ import java.util.Objects;
 public final class StatisticsController {
 
     private final AuthenticationService authenticationService;
-    private final PermissionPolicy permissionPolicy;
-    private final StatisticsRepository statisticsRepository;
+    private final StatisticsService statisticsService;
 
     public StatisticsController(
             AuthenticationService authenticationService,
-            PermissionPolicy permissionPolicy,
-            StatisticsRepository statisticsRepository
+            StatisticsService statisticsService
     ) {
         this.authenticationService = Objects.requireNonNull(authenticationService, "authenticationService");
-        this.permissionPolicy = Objects.requireNonNull(permissionPolicy, "permissionPolicy");
-        this.statisticsRepository = Objects.requireNonNull(statisticsRepository, "statisticsRepository");
+        this.statisticsService = Objects.requireNonNull(statisticsService, "statisticsService");
     }
 
     public StatisticsReport viewStatistics(
@@ -33,17 +29,13 @@ public final class StatisticsController {
             YearMonth monthlyToInclusive
     ) {
         User user = requireCurrentUser();
-        permissionPolicy.assertCanViewStatistics(user, projectId);
-        requireOrderedRange(dailyFromInclusive, dailyToInclusive, "dailyFromInclusive", "dailyToInclusive");
-        requireOrderedRange(monthlyFromInclusive, monthlyToInclusive, "monthlyFromInclusive", "monthlyToInclusive");
-
-        return statisticsRepository.buildReport(
+        return statisticsService.viewStatistics(
                 projectId,
                 dailyFromInclusive,
                 dailyToInclusive,
                 monthlyFromInclusive,
-                monthlyToInclusive
-        );
+                monthlyToInclusive,
+                user);
     }
 
     public StatisticsReport viewStatistics(long projectId) {
@@ -53,16 +45,5 @@ public final class StatisticsController {
     private User requireCurrentUser() {
         return authenticationService.currentUser()
                 .orElseThrow(() -> new SecurityException("Login is required."));
-    }
-
-    private static <T extends Comparable<T>> void requireOrderedRange(
-            T fromInclusive,
-            T toInclusive,
-            String fromName,
-            String toName
-    ) {
-        if (fromInclusive != null && toInclusive != null && fromInclusive.compareTo(toInclusive) > 0) {
-            throw new IllegalArgumentException(fromName + " must be <= " + toName);
-        }
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/service/AccountService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/AccountService.java
@@ -1,0 +1,26 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.repository.UserRepository;
+import com.github.marcellokim.issuetracker.technical.PasswordHasher;
+import java.util.Objects;
+
+public final class AccountService {
+
+    private final PermissionPolicy permissionPolicy;
+    private final UserRepository userRepository;
+    private final PasswordHasher passwordHasher;
+
+    public AccountService(
+            PermissionPolicy permissionPolicy,
+            UserRepository userRepository,
+            PasswordHasher passwordHasher) {
+        this.permissionPolicy = Objects.requireNonNull(permissionPolicy, "permissionPolicy");
+        this.userRepository = Objects.requireNonNull(userRepository, "userRepository");
+        this.passwordHasher = Objects.requireNonNull(passwordHasher, "passwordHasher");
+    }
+
+    /*
+     * Account management UC orchestration stays here so the controller can remain
+     * a system-operation adapter when the admin account methods are implemented.
+     */
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/DeletedIssueService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/DeletedIssueService.java
@@ -1,0 +1,66 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.IssueRepository;
+import java.util.List;
+import java.util.Objects;
+
+public final class DeletedIssueService {
+
+    private static final int MAX_DELETED_ISSUES_PER_PROJECT = 30;
+
+    private final IssueRepository issueRepository;
+    private final PermissionPolicy permissionPolicy;
+    private final Clock clock;
+
+    public DeletedIssueService(
+            IssueRepository issueRepository,
+            PermissionPolicy permissionPolicy,
+            Clock clock
+    ) {
+        this.issueRepository = Objects.requireNonNull(issueRepository, "issueRepository");
+        this.permissionPolicy = Objects.requireNonNull(permissionPolicy, "permissionPolicy");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    public List<Issue> viewDeletedIssues(long projectId, User actor) {
+        requireDeletedIssuePermission(actor, projectId);
+        return issueRepository.findDeletedByProject(projectId);
+    }
+
+    public Issue deleteIssue(long issueId, String comment, User actor) {
+        Issue issue = findIssue(issueId);
+        permissionPolicy.assertCanManageDeletedIssue(actor, issue);
+
+        Issue deletedIssue = issueRepository.softDelete(issueId, actor.getLoginId(), comment, clock.now());
+        issueRepository.purgeDeletedBeyondLimit(deletedIssue.projectId(), MAX_DELETED_ISSUES_PER_PROJECT);
+        return deletedIssue;
+    }
+
+    public Issue restoreIssue(long issueId, String comment, User actor) {
+        Issue issue = findIssue(issueId);
+        permissionPolicy.assertCanManageDeletedIssue(actor, issue);
+        return issueRepository.restore(issueId, actor.getLoginId(), comment, clock.now());
+    }
+
+    public int purgeOverflow(long projectId, User actor) {
+        requireDeletedIssuePermission(actor, projectId);
+        return issueRepository.purgeDeletedBeyondLimit(projectId, MAX_DELETED_ISSUES_PER_PROJECT);
+    }
+
+    private Issue findIssue(long issueId) {
+        return issueRepository.findById(issueId)
+                .orElseThrow(() -> new IllegalArgumentException("Issue was not found: " + issueId));
+    }
+
+    private void requireDeletedIssuePermission(User actor, long projectId) {
+        /*
+         * The permission check lives with the repository operation so future review can
+         * audit deleted-issue side effects without jumping back into the controller.
+         */
+        if (!permissionPolicy.verifyPermission(actor, "MANAGE_DELETED_ISSUE", projectId)) {
+            throw new SecurityException("Only PL or ADMIN can manage deleted issues.");
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/StatisticsService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/StatisticsService.java
@@ -1,0 +1,58 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.StatisticsReport;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.StatisticsRepository;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Objects;
+
+public final class StatisticsService {
+
+    private final PermissionPolicy permissionPolicy;
+    private final StatisticsRepository statisticsRepository;
+
+    public StatisticsService(
+            PermissionPolicy permissionPolicy,
+            StatisticsRepository statisticsRepository
+    ) {
+        this.permissionPolicy = Objects.requireNonNull(permissionPolicy, "permissionPolicy");
+        this.statisticsRepository = Objects.requireNonNull(statisticsRepository, "statisticsRepository");
+    }
+
+    public StatisticsReport viewStatistics(
+            long projectId,
+            LocalDate dailyFromInclusive,
+            LocalDate dailyToInclusive,
+            YearMonth monthlyFromInclusive,
+            YearMonth monthlyToInclusive,
+            User actor
+    ) {
+        /*
+         * Range validation is part of the statistics use-case boundary, not controller
+         * plumbing, so repository query inputs are guarded in one place.
+         */
+        permissionPolicy.assertCanViewStatistics(actor, projectId);
+        requireOrderedRange(dailyFromInclusive, dailyToInclusive, "dailyFromInclusive", "dailyToInclusive");
+        requireOrderedRange(monthlyFromInclusive, monthlyToInclusive, "monthlyFromInclusive", "monthlyToInclusive");
+
+        return statisticsRepository.buildReport(
+                projectId,
+                dailyFromInclusive,
+                dailyToInclusive,
+                monthlyFromInclusive,
+                monthlyToInclusive
+        );
+    }
+
+    private static <T extends Comparable<T>> void requireOrderedRange(
+            T fromInclusive,
+            T toInclusive,
+            String fromName,
+            String toName
+    ) {
+        if (fromInclusive != null && toInclusive != null && fromInclusive.compareTo(toInclusive) > 0) {
+            throw new IllegalArgumentException(fromName + " must be <= " + toName);
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerCoverageTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerCoverageTest.java
@@ -24,11 +24,14 @@ import com.github.marcellokim.issuetracker.repository.IssueRepository;
 import com.github.marcellokim.issuetracker.repository.ProjectRepository;
 import com.github.marcellokim.issuetracker.repository.StatisticsRepository;
 import com.github.marcellokim.issuetracker.repository.UserRepository;
+import com.github.marcellokim.issuetracker.service.AccountService;
 import com.github.marcellokim.issuetracker.service.AssignmentRecommendationService;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
 import com.github.marcellokim.issuetracker.service.Clock;
+import com.github.marcellokim.issuetracker.service.DeletedIssueService;
 import com.github.marcellokim.issuetracker.service.PermissionPolicy;
 import com.github.marcellokim.issuetracker.service.ProjectService;
+import com.github.marcellokim.issuetracker.service.StatisticsService;
 import com.github.marcellokim.issuetracker.technical.PasswordHasher;
 import com.github.marcellokim.issuetracker.technical.SessionStore;
 import java.time.LocalDate;
@@ -60,8 +63,7 @@ class ControllerCoverageTest {
 
         StatisticsController controller = new StatisticsController(
                 auth.service(),
-                new PermissionPolicy(),
-                statistics);
+                new StatisticsService(new PermissionPolicy(), statistics));
 
         StatisticsReport actualReport = controller.viewStatistics(
                 PROJECT_ID,
@@ -81,14 +83,12 @@ class ControllerCoverageTest {
     void statisticsControllerRejectsInvalidAccessOrRange() {
         StatisticsController anonymousController = new StatisticsController(
                 anonymousAuth(),
-                new PermissionPolicy(),
-                new FakeStatisticsRepository());
+                new StatisticsService(new PermissionPolicy(), new FakeStatisticsRepository()));
         assertThrows(SecurityException.class, () -> anonymousController.viewStatistics(PROJECT_ID));
 
         StatisticsController controller = new StatisticsController(
                 authenticated(Role.PL).service(),
-                new PermissionPolicy(),
-                new FakeStatisticsRepository());
+                new StatisticsService(new PermissionPolicy(), new FakeStatisticsRepository()));
         assertThrows(
                 IllegalArgumentException.class,
                 () -> controller.viewStatistics(
@@ -116,9 +116,7 @@ class ControllerCoverageTest {
         FakeIssueRepository issues = new FakeIssueRepository(activeIssue, deletedIssue);
         DeletedIssueController controller = new DeletedIssueController(
                 auth.service(),
-                new PermissionPolicy(),
-                issues,
-                new Clock());
+                new DeletedIssueService(issues, new PermissionPolicy(), new Clock()));
 
         List<Issue> deletedIssues = controller.viewDeletedIssues(PROJECT_ID);
         Issue softDeleted = controller.deleteIssue(activeIssue.id(), "remove from demo");
@@ -140,23 +138,17 @@ class ControllerCoverageTest {
         FakeIssueRepository issues = new FakeIssueRepository(issue(101L, PROJECT_ID, IssueStatus.NEW));
         DeletedIssueController anonymousController = new DeletedIssueController(
                 anonymousAuth(),
-                new PermissionPolicy(),
-                issues,
-                new Clock());
+                new DeletedIssueService(issues, new PermissionPolicy(), new Clock()));
         assertThrows(SecurityException.class, () -> anonymousController.viewDeletedIssues(PROJECT_ID));
 
         DeletedIssueController adminController = new DeletedIssueController(
                 authenticated(Role.ADMIN).service(),
-                new PermissionPolicy(),
-                issues,
-                new Clock());
+                new DeletedIssueService(issues, new PermissionPolicy(), new Clock()));
         assertThrows(SecurityException.class, () -> adminController.deleteIssue(101L, "admin cannot delete"));
 
         DeletedIssueController plController = new DeletedIssueController(
                 authenticated(Role.PL).service(),
-                new PermissionPolicy(),
-                issues,
-                new Clock());
+                new DeletedIssueService(issues, new PermissionPolicy(), new Clock()));
         assertThrows(IllegalArgumentException.class, () -> plController.restoreIssue(999L, "missing"));
     }
 
@@ -268,7 +260,9 @@ class ControllerCoverageTest {
         PermissionPolicy policy = new PermissionPolicy();
         Clock clock = new Clock();
 
-        assertDoesNotThrow(() -> new AccountController(auth.service(), policy, users, new PasswordHasher()));
+        assertDoesNotThrow(() -> new AccountController(
+                auth.service(),
+                new AccountService(policy, users, new PasswordHasher())));
         assertDoesNotThrow(() -> new IssueController(
                 auth.service(),
                 new com.github.marcellokim.issuetracker.service.IssueService(projects, issues, users, policy, clock)));

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/ArchitectureBoundaryTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/ArchitectureBoundaryTest.java
@@ -27,12 +27,6 @@ class ArchitectureBoundaryTest {
      * when that flow moves behind the intended service/presenter boundary.
      */
     private static final Set<AllowedImport> TEMPORARY_ALLOWED_IMPORTS = Set.of(
-            new AllowedImport("controller/AccountController.java", ROOT_PACKAGE + ".repository.UserRepository"),
-            new AllowedImport("controller/DeletedIssueController.java", ROOT_PACKAGE + ".repository.IssueRepository"),
-            new AllowedImport(
-                    "controller/StatisticsController.java",
-                    ROOT_PACKAGE + ".repository.StatisticsRepository"
-            ),
             new AllowedImport("ui/DemoDashboardPresenter.java", ROOT_PACKAGE + ".repository.IssueRepository"),
             new AllowedImport("ui/DemoDashboardPresenter.java", ROOT_PACKAGE + ".repository.ProjectRepository"),
             new AllowedImport("ui/DemoDashboardPresenter.java", ROOT_PACKAGE + ".repository.StatisticsRepository"),


### PR DESCRIPTION
## 요약
- `AccountController`, `DeletedIssueController`, `StatisticsController`의 repository 직접 의존을 service 계층 뒤로 이동했습니다.
- `AccountService`, `DeletedIssueService`, `StatisticsService`를 추가해 controller가 system operation 수신과 service 위임만 담당하게 했습니다.
- `ArchitectureBoundaryTest`의 controller 임시 예외 3개를 제거하고 DCD 문서의 예외 목록을 갱신했습니다.

## 검증
- `./gradlew test --tests 'com.github.marcellokim.issuetracker.setup.ArchitectureBoundaryTest' --tests 'com.github.marcellokim.issuetracker.controller.ControllerCoverageTest' --console=plain --rerun-tasks`
- `./gradlew check --console=plain`
- push pre-push hook: test + repository setup 검증 통과

## 관련 PR
- 이전 PR: #124

## 관련 이슈
- Refs #95
