### PR TITLE
refactor: dashboard repository 조회를 service 뒤로 이동

### DIFF
--- a/docs/uml/dcd/dcd_implementation_details.md
+++ b/docs/uml/dcd/dcd_implementation_details.md
@@ -170,16 +170,11 @@ Controller가 repository, policy, clock, recommendation service를 직접 들고
 - `controller`는 `repository`, `persistence`, `ui`를 import하지 않는다.
 - `ui`는 `repository`, `persistence`를 import하지 않는다.
 
-현재 dev 구현에는 다음 임시 예외가 있다.
-
-- `ui/DemoDashboardPresenter.java` -> `IssueRepository`
-- `ui/DemoDashboardPresenter.java` -> `ProjectRepository`
-- `ui/DemoDashboardPresenter.java` -> `StatisticsRepository`
-- `ui/DemoDashboardPresenter.java` -> `UserRepository`
-
-이 예외는 영구 설계가 아니라 debt marker이다. 이후 clean-code slice에서 해당 흐름이 service 또는 presenter boundary 뒤로 이동하면 예외 항목을 하나씩 제거해야 한다.
+현재 dev 구현에는 임시 예외가 없다. 예외는 영구 설계가 아니라 debt marker로만 허용하며, 새 예외를 추가해야 할 때는 해당 clean-code slice에서 제거 계획을 같이 남긴다.
 
 Controller layer의 repository 직접 의존 예외는 clean-code slice에서 `AccountService`, `DeletedIssueService`, `StatisticsService`로 이동했다. 이 상태를 유지하기 위해 신규 controller는 repository interface를 직접 import하지 않는다.
+
+UI layer의 repository 직접 의존 예외는 clean-code slice에서 `DashboardSummaryService` 뒤로 이동했다. 이 상태를 유지하기 위해 신규 JavaFX presenter/view는 repository interface를 직접 import하지 않는다.
 
 Review comment 정책은 다음 기준을 따른다.
 

--- a/src/main/java/com/github/marcellokim/issuetracker/config/ApplicationContext.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/config/ApplicationContext.java
@@ -4,6 +4,7 @@ import com.github.marcellokim.issuetracker.persistence.DatabaseInitializer;
 import com.github.marcellokim.issuetracker.persistence.DriverManagerConnectionProvider;
 import com.github.marcellokim.issuetracker.persistence.jdbc.JdbcRepositoryFactory;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
 import com.github.marcellokim.issuetracker.ui.DemoDashboardPresenter;
 import java.io.IOException;
 import java.sql.SQLException;
@@ -28,12 +29,12 @@ public record ApplicationContext(
         var repositories = new JdbcRepositoryFactory(connectionProvider);
         return new ApplicationContext(
                 new AuthenticationService(repositories.users()),
-                new DemoDashboardPresenter(
+                new DemoDashboardPresenter(new DashboardSummaryService(
                         repositories.projects(),
                         repositories.issues(),
                         repositories.statistics(),
                         repositories.users()
-                )
+                ))
         );
     }
 

--- a/src/main/java/com/github/marcellokim/issuetracker/service/DashboardProjectSummary.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/DashboardProjectSummary.java
@@ -1,0 +1,24 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import java.util.Map;
+import java.util.Objects;
+
+public record DashboardProjectSummary(
+        String projectName,
+        int memberCount,
+        int projectLeaderCount,
+        int developerCount,
+        int testerCount,
+        int visibleIssueCount,
+        int deletedIssueCount,
+        Map<IssueStatus, Integer> statusCounts
+) {
+
+    public DashboardProjectSummary {
+        if (projectName == null || projectName.isBlank()) {
+            throw new IllegalArgumentException("projectName must not be blank");
+        }
+        statusCounts = Map.copyOf(Objects.requireNonNull(statusCounts, "statusCounts"));
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/DashboardSummaryService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/DashboardSummaryService.java
@@ -1,0 +1,46 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.repository.IssueRepository;
+import com.github.marcellokim.issuetracker.repository.ProjectRepository;
+import com.github.marcellokim.issuetracker.repository.StatisticsRepository;
+import com.github.marcellokim.issuetracker.repository.UserRepository;
+import java.util.List;
+import java.util.Objects;
+
+public final class DashboardSummaryService {
+
+    private final ProjectRepository projectRepository;
+    private final IssueRepository issueRepository;
+    private final StatisticsRepository statisticsRepository;
+    private final UserRepository userRepository;
+
+    public DashboardSummaryService(
+            ProjectRepository projectRepository,
+            IssueRepository issueRepository,
+            StatisticsRepository statisticsRepository,
+            UserRepository userRepository) {
+        this.projectRepository = Objects.requireNonNull(projectRepository, "projectRepository");
+        this.issueRepository = Objects.requireNonNull(issueRepository, "issueRepository");
+        this.statisticsRepository = Objects.requireNonNull(statisticsRepository, "statisticsRepository");
+        this.userRepository = Objects.requireNonNull(userRepository, "userRepository");
+    }
+
+    public List<DashboardProjectSummary> projectSummaries() {
+        /*
+         * The dashboard is a read model over several repositories. Keeping those reads
+         * here lets the JavaFX presenter format data without knowing persistence ports.
+         */
+        return projectRepository.findAll().stream()
+                .map(project -> new DashboardProjectSummary(
+                        project.getName(),
+                        projectRepository.findParticipants(project.getId()).size(),
+                        userRepository.findActiveByRole(project.getId(), Role.PL).size(),
+                        userRepository.findActiveByRole(project.getId(), Role.DEV).size(),
+                        userRepository.findActiveByRole(project.getId(), Role.TESTER).size(),
+                        issueRepository.findByProject(project.getId()).size(),
+                        issueRepository.findDeletedByProject(project.getId()).size(),
+                        statisticsRepository.countByStatus(project.getId())))
+                .toList();
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/DemoDashboardPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/DemoDashboardPresenter.java
@@ -1,31 +1,17 @@
 package com.github.marcellokim.issuetracker.ui;
 
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
-import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.User;
-import com.github.marcellokim.issuetracker.repository.IssueRepository;
-import com.github.marcellokim.issuetracker.repository.ProjectRepository;
-import com.github.marcellokim.issuetracker.repository.StatisticsRepository;
-import com.github.marcellokim.issuetracker.repository.UserRepository;
+import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 public final class DemoDashboardPresenter {
 
-    private final ProjectRepository projects;
-    private final IssueRepository issues;
-    private final StatisticsRepository statistics;
-    private final UserRepository users;
+    private final DashboardSummaryService dashboardSummaryService;
 
-    public DemoDashboardPresenter(
-            ProjectRepository projects,
-            IssueRepository issues,
-            StatisticsRepository statistics,
-            UserRepository users) {
-        this.projects = Objects.requireNonNull(projects, "projects");
-        this.issues = Objects.requireNonNull(issues, "issues");
-        this.statistics = Objects.requireNonNull(statistics, "statistics");
-        this.users = Objects.requireNonNull(users, "users");
+    public DemoDashboardPresenter(DashboardSummaryService dashboardSummaryService) {
+        this.dashboardSummaryService = Objects.requireNonNull(dashboardSummaryService, "dashboardSummaryService");
     }
 
     public String buildSummary(User user) {
@@ -38,21 +24,20 @@ public final class DemoDashboardPresenter {
                 .append(System.lineSeparator())
                 .append(System.lineSeparator());
 
-        for (var project : projects.findAll()) {
-            var statusCounts = statistics.countByStatus(project.getId());
-            String statusText = statusCounts.entrySet().stream()
+        for (var project : dashboardSummaryService.projectSummaries()) {
+            String statusText = project.statusCounts().entrySet().stream()
                     .sorted(java.util.Map.Entry.comparingByKey())
                     .map(entry -> entry.getKey() + "=" + entry.getValue())
                     .collect(Collectors.joining(", "));
 
-            summary.append(project.getName()).append(System.lineSeparator())
-                    .append("  members=").append(projects.findParticipants(project.getId()).size())
-                    .append(", PL=").append(users.findActiveByRole(project.getId(), Role.PL).size())
-                    .append(", DEV=").append(users.findActiveByRole(project.getId(), Role.DEV).size())
-                    .append(", TESTER=").append(users.findActiveByRole(project.getId(), Role.TESTER).size())
+            summary.append(project.projectName()).append(System.lineSeparator())
+                    .append("  members=").append(project.memberCount())
+                    .append(", PL=").append(project.projectLeaderCount())
+                    .append(", DEV=").append(project.developerCount())
+                    .append(", TESTER=").append(project.testerCount())
                     .append(System.lineSeparator())
-                    .append("  visible issues=").append(issues.findByProject(project.getId()).size())
-                    .append(", deleted bin=").append(issues.findDeletedByProject(project.getId()).size())
+                    .append("  visible issues=").append(project.visibleIssueCount())
+                    .append(", deleted bin=").append(project.deletedIssueCount())
                     .append(System.lineSeparator())
                     .append("  status=").append(statusText.isBlank() ? IssueStatus.NEW + "=0" : statusText)
                     .append(System.lineSeparator())

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/ArchitectureBoundaryTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/ArchitectureBoundaryTest.java
@@ -26,12 +26,7 @@ class ArchitectureBoundaryTest {
      * Temporary architecture debt marker: later clean-code slices must remove each exception
      * when that flow moves behind the intended service/presenter boundary.
      */
-    private static final Set<AllowedImport> TEMPORARY_ALLOWED_IMPORTS = Set.of(
-            new AllowedImport("ui/DemoDashboardPresenter.java", ROOT_PACKAGE + ".repository.IssueRepository"),
-            new AllowedImport("ui/DemoDashboardPresenter.java", ROOT_PACKAGE + ".repository.ProjectRepository"),
-            new AllowedImport("ui/DemoDashboardPresenter.java", ROOT_PACKAGE + ".repository.StatisticsRepository"),
-            new AllowedImport("ui/DemoDashboardPresenter.java", ROOT_PACKAGE + ".repository.UserRepository")
-    );
+    private static final Set<AllowedImport> TEMPORARY_ALLOWED_IMPORTS = Set.of();
 
     @Test
     @DisplayName("domain package does not depend on outer layers")


### PR DESCRIPTION
## 요약
- `DemoDashboardPresenter`의 repository 직접 의존을 제거하고 `DashboardSummaryService` read model 뒤로 이동했습니다.
- `DashboardProjectSummary`를 추가해 UI presenter가 formatting만 담당하게 했습니다.
- `ArchitectureBoundaryTest`의 남은 임시 예외를 모두 제거하고 DCD 문서를 `임시 예외 없음` 상태로 갱신했습니다.

## 검증
- `./gradlew test --tests 'com.github.marcellokim.issuetracker.setup.ArchitectureBoundaryTest' --console=plain --rerun-tasks`
- `./gradlew check --console=plain`
- push pre-push hook: test + repository setup 검증 통과

## 관련 PR
- 이전 PR: #125

## 관련 이슈
- Refs #95
