### PR TITLE
refactor: CLI repository summary를 service 뒤로 이동

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/Main.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/Main.java
@@ -1,10 +1,11 @@
 package com.github.marcellokim.issuetracker;
 
-import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.persistence.DatabaseInitializer;
 import com.github.marcellokim.issuetracker.persistence.DriverManagerConnectionProvider;
 import com.github.marcellokim.issuetracker.persistence.jdbc.JdbcRepositoryFactory;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.RepositoryDemoSummary;
+import com.github.marcellokim.issuetracker.service.RepositoryDemoSummaryService;
 import com.github.marcellokim.issuetracker.technical.ConsoleOutput;
 import com.github.marcellokim.issuetracker.ui.IssueTrackerApplication;
 import java.io.IOException;
@@ -37,7 +38,13 @@ public final class Main {
         try {
             var connectionProvider = DriverManagerConnectionProvider.fromEnvironment();
             DatabaseInitializer.initialize(connectionProvider);
-            printRepositorySummary(new JdbcRepositoryFactory(connectionProvider));
+            var repositories = new JdbcRepositoryFactory(connectionProvider);
+            printRepositorySummary(new RepositoryDemoSummaryService(
+                    repositories.users(),
+                    repositories.projects(),
+                    repositories.issues(),
+                    repositories.statistics(),
+                    repositories.assignmentRecommendations()).summarizeSeedDemo());
         } catch (IOException | SQLException | RuntimeException exception) {
             printLine("Oracle repository demo failed.");
             printLine("Cause: " + exception.getMessage());
@@ -134,37 +141,28 @@ public final class Main {
         }
     }
 
-    private static void printRepositorySummary(JdbcRepositoryFactory repositories) {
-        var admin = repositories.users().findByLoginId("admin");
-        var project = repositories.projects().findByName("project1");
-
+    private static void printRepositorySummary(RepositoryDemoSummary summary) {
         printLine("Oracle repository demo ready.");
-        admin.ifPresentOrElse(
+        summary.admin().ifPresentOrElse(
                 user -> printLine(
-                        "Admin: " + user.getLoginId() + " / " + user.getRole() + " / active=" + user.isActive()),
+                        "Admin: " + user.loginId() + " / " + user.role() + " / active=" + user.active()),
                 () -> printLine("Admin: missing"));
 
-        project.ifPresentOrElse(
-                value -> printProjectSummary(repositories, value.getId(), value.getName()),
+        summary.project().ifPresentOrElse(
+                Main::printProjectSummary,
                 () -> printLine("Project: project1 missing"));
     }
 
-    private static void printProjectSummary(JdbcRepositoryFactory repositories, long projectId, String projectName) {
-        var issues = repositories.issues().findByProject(projectId);
-        var statusCounts = repositories.statistics().countByStatus(projectId);
-        var priorityCounts = repositories.statistics().countByPriority(projectId);
-        var devCandidates = repositories.assignmentRecommendations().findDevAssigneeCandidates(projectId);
-        var testerCandidates = repositories.assignmentRecommendations().findTesterVerifierCandidates(projectId);
-
-        printLine("Project: " + projectName);
-        printLine("Members: " + repositories.projects().findParticipants(projectId).size());
-        printLine("Active devs: " + repositories.users().findActiveByRole(projectId, Role.DEV).size());
-        printLine("Active testers: " + repositories.users().findActiveByRole(projectId, Role.TESTER).size());
-        printLine("Issues: " + issues.size());
-        printLine("Status counts: " + statusCounts);
-        printLine("Priority counts: " + priorityCounts);
-        printLine("Dev recommendation candidates: " + devCandidates.size());
-        printLine("Tester recommendation candidates: " + testerCandidates.size());
+    private static void printProjectSummary(RepositoryDemoSummary.ProjectSummary summary) {
+        printLine("Project: " + summary.projectName());
+        printLine("Members: " + summary.memberCount());
+        printLine("Active devs: " + summary.activeDevCount());
+        printLine("Active testers: " + summary.activeTesterCount());
+        printLine("Issues: " + summary.issueCount());
+        printLine("Status counts: " + summary.statusCounts());
+        printLine("Priority counts: " + summary.priorityCounts());
+        printLine("Dev recommendation candidates: " + summary.devRecommendationCandidateCount());
+        printLine("Tester recommendation candidates: " + summary.testerRecommendationCandidateCount());
     }
 
     private static void printLine(String message) {

--- a/src/main/java/com/github/marcellokim/issuetracker/service/RepositoryDemoSummary.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/RepositoryDemoSummary.java
@@ -1,0 +1,50 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Role;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public record RepositoryDemoSummary(
+        Optional<AdminAccount> admin,
+        Optional<ProjectSummary> project
+) {
+
+    public RepositoryDemoSummary {
+        admin = Objects.requireNonNull(admin, "admin");
+        project = Objects.requireNonNull(project, "project");
+    }
+
+    public record AdminAccount(String loginId, Role role, boolean active) {
+
+        public AdminAccount {
+            if (loginId == null || loginId.isBlank()) {
+                throw new IllegalArgumentException("loginId must not be blank");
+            }
+            role = Objects.requireNonNull(role, "role");
+        }
+    }
+
+    public record ProjectSummary(
+            String projectName,
+            int memberCount,
+            int activeDevCount,
+            int activeTesterCount,
+            int issueCount,
+            Map<IssueStatus, Integer> statusCounts,
+            Map<Priority, Integer> priorityCounts,
+            int devRecommendationCandidateCount,
+            int testerRecommendationCandidateCount
+    ) {
+
+        public ProjectSummary {
+            if (projectName == null || projectName.isBlank()) {
+                throw new IllegalArgumentException("projectName must not be blank");
+            }
+            statusCounts = Map.copyOf(Objects.requireNonNull(statusCounts, "statusCounts"));
+            priorityCounts = Map.copyOf(Objects.requireNonNull(priorityCounts, "priorityCounts"));
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/RepositoryDemoSummaryService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/RepositoryDemoSummaryService.java
@@ -1,0 +1,68 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.Project;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.AssignmentRecommendationRepository;
+import com.github.marcellokim.issuetracker.repository.IssueRepository;
+import com.github.marcellokim.issuetracker.repository.ProjectRepository;
+import com.github.marcellokim.issuetracker.repository.StatisticsRepository;
+import com.github.marcellokim.issuetracker.repository.UserRepository;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class RepositoryDemoSummaryService {
+
+    private static final String DEMO_ADMIN_LOGIN_ID = "admin";
+    private static final String DEMO_PROJECT_NAME = "project1";
+
+    private final UserRepository userRepository;
+    private final ProjectRepository projectRepository;
+    private final IssueRepository issueRepository;
+    private final StatisticsRepository statisticsRepository;
+    private final AssignmentRecommendationRepository assignmentRecommendationRepository;
+
+    public RepositoryDemoSummaryService(
+            UserRepository userRepository,
+            ProjectRepository projectRepository,
+            IssueRepository issueRepository,
+            StatisticsRepository statisticsRepository,
+            AssignmentRecommendationRepository assignmentRecommendationRepository
+    ) {
+        this.userRepository = Objects.requireNonNull(userRepository, "userRepository");
+        this.projectRepository = Objects.requireNonNull(projectRepository, "projectRepository");
+        this.issueRepository = Objects.requireNonNull(issueRepository, "issueRepository");
+        this.statisticsRepository = Objects.requireNonNull(statisticsRepository, "statisticsRepository");
+        this.assignmentRecommendationRepository =
+                Objects.requireNonNull(assignmentRecommendationRepository, "assignmentRecommendationRepository");
+    }
+
+    public RepositoryDemoSummary summarizeSeedDemo() {
+        /*
+         * Main owns process flow and console output. Repository aggregation lives here
+         * so the CLI demo follows the same service boundary as controller/UI flows.
+         */
+        return new RepositoryDemoSummary(
+                userRepository.findByLoginId(DEMO_ADMIN_LOGIN_ID).map(RepositoryDemoSummaryService::toAdminAccount),
+                projectRepository.findByName(DEMO_PROJECT_NAME).map(this::toProjectSummary)
+        );
+    }
+
+    private static RepositoryDemoSummary.AdminAccount toAdminAccount(User user) {
+        return new RepositoryDemoSummary.AdminAccount(user.getLoginId(), user.getRole(), user.isActive());
+    }
+
+    private RepositoryDemoSummary.ProjectSummary toProjectSummary(Project project) {
+        long projectId = project.getId();
+        return new RepositoryDemoSummary.ProjectSummary(
+                project.getName(),
+                projectRepository.findParticipants(projectId).size(),
+                userRepository.findActiveByRole(projectId, Role.DEV).size(),
+                userRepository.findActiveByRole(projectId, Role.TESTER).size(),
+                issueRepository.findByProject(projectId).size(),
+                statisticsRepository.countByStatus(projectId),
+                statisticsRepository.countByPriority(projectId),
+                assignmentRecommendationRepository.findDevAssigneeCandidates(projectId).size(),
+                assignmentRecommendationRepository.findTesterVerifierCandidates(projectId).size());
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/service/RepositoryDemoSummaryServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/RepositoryDemoSummaryServiceTest.java
@@ -1,0 +1,323 @@
+package com.github.marcellokim.issuetracker.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.domain.AssignmentCandidate;
+import com.github.marcellokim.issuetracker.domain.DailyIssueCount;
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueSearchCriteria;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.MonthlyIssueCount;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Project;
+import com.github.marcellokim.issuetracker.domain.ProjectMember;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.StatisticsReport;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.AssignmentRecommendationRepository;
+import com.github.marcellokim.issuetracker.repository.IssueRepository;
+import com.github.marcellokim.issuetracker.repository.ProjectRepository;
+import com.github.marcellokim.issuetracker.repository.StatisticsRepository;
+import com.github.marcellokim.issuetracker.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Repository demo summary service")
+class RepositoryDemoSummaryServiceTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 21, 15, 0);
+    private static final long PROJECT_ID = 10L;
+
+    @Test
+    @DisplayName("builds the CLI demo summary without exposing repository calls to Main")
+    void summarizesSeedRepositoryState() {
+        User admin = user("admin", Role.ADMIN, true);
+        User dev = user("dev1", Role.DEV, true);
+        User tester = user("tester1", Role.TESTER, true);
+        Project project = Project.create(PROJECT_ID, "project1", "Demo", "admin", NOW, NOW);
+        Issue issue = issue(101L, IssueStatus.NEW);
+
+        RepositoryDemoSummaryService service = new RepositoryDemoSummaryService(
+                new FakeUserRepository(List.of(admin, dev, tester)),
+                new FakeProjectRepository(project, List.of(
+                        ProjectMember.create(PROJECT_ID, admin.getLoginId(), NOW),
+                        ProjectMember.create(PROJECT_ID, dev.getLoginId(), NOW),
+                        ProjectMember.create(PROJECT_ID, tester.getLoginId(), NOW))),
+                new FakeIssueRepository(List.of(issue)),
+                new FakeStatisticsRepository(),
+                new FakeAssignmentRecommendationRepository(dev, tester));
+
+        RepositoryDemoSummary summary = service.summarizeSeedDemo();
+
+        assertTrue(summary.admin().isPresent());
+        assertEquals("admin", summary.admin().orElseThrow().loginId());
+        assertEquals(Role.ADMIN, summary.admin().orElseThrow().role());
+        assertTrue(summary.admin().orElseThrow().active());
+
+        RepositoryDemoSummary.ProjectSummary projectSummary = summary.project().orElseThrow();
+        assertEquals("project1", projectSummary.projectName());
+        assertEquals(3, projectSummary.memberCount());
+        assertEquals(1, projectSummary.activeDevCount());
+        assertEquals(1, projectSummary.activeTesterCount());
+        assertEquals(1, projectSummary.issueCount());
+        assertEquals(2, projectSummary.statusCounts().get(IssueStatus.NEW));
+        assertEquals(1, projectSummary.priorityCounts().get(Priority.MAJOR));
+        assertEquals(1, projectSummary.devRecommendationCandidateCount());
+        assertEquals(1, projectSummary.testerRecommendationCandidateCount());
+    }
+
+    private static User user(String loginId, Role role, boolean active) {
+        return User.create(loginId, loginId, "hash", role, active, NOW, NOW);
+    }
+
+    private static Issue issue(long id, IssueStatus status) {
+        return Issue.fromPersistence(Issue.persistedState(
+                        PROJECT_ID,
+                        "Issue " + id,
+                        "Demo issue",
+                        user("reporter", Role.DEV, true))
+                .id(id)
+                .issueId("ISSUE-" + id)
+                .reportedDate(NOW)
+                .priority(Priority.MAJOR)
+                .status(status)
+                .updatedAt(NOW));
+    }
+
+    private static final class FakeUserRepository implements UserRepository {
+
+        private final List<User> users;
+
+        private FakeUserRepository(List<User> users) {
+            this.users = List.copyOf(users);
+        }
+
+        @Override
+        public Optional<User> findById(String userId) {
+            return findByLoginId(userId);
+        }
+
+        @Override
+        public Optional<User> findByLoginId(String loginId) {
+            return users.stream()
+                    .filter(user -> user.getLoginId().equals(loginId))
+                    .findFirst();
+        }
+
+        @Override
+        public List<User> findAll() {
+            return users;
+        }
+
+        @Override
+        public List<User> findActiveByRole(long projectId, Role role) {
+            return users.stream()
+                    .filter(User::isActive)
+                    .filter(user -> user.getRole() == role)
+                    .toList();
+        }
+
+        @Override
+        public User save(User user) {
+            throw new UnsupportedOperationException("save is not needed by RepositoryDemoSummaryServiceTest.");
+        }
+
+        @Override
+        public void deactivate(String loginId) {
+            throw new UnsupportedOperationException("deactivate is not needed by RepositoryDemoSummaryServiceTest.");
+        }
+    }
+
+    private static final class FakeProjectRepository implements ProjectRepository {
+
+        private final Project project;
+        private final List<ProjectMember> members;
+
+        private FakeProjectRepository(Project project, List<ProjectMember> members) {
+            this.project = project;
+            this.members = List.copyOf(members);
+        }
+
+        @Override
+        public Optional<Project> findById(long projectId) {
+            return project.getId() == projectId ? Optional.of(project) : Optional.empty();
+        }
+
+        @Override
+        public Optional<Project> findByName(String name) {
+            return project.getName().equals(name) ? Optional.of(project) : Optional.empty();
+        }
+
+        @Override
+        public List<Project> findAll() {
+            return List.of(project);
+        }
+
+        @Override
+        public Project save(Project project) {
+            throw new UnsupportedOperationException("save is not needed by RepositoryDemoSummaryServiceTest.");
+        }
+
+        @Override
+        public void deleteById(long projectId) {
+            throw new UnsupportedOperationException("deleteById is not needed by RepositoryDemoSummaryServiceTest.");
+        }
+
+        @Override
+        public void addParticipant(long projectId, String userLoginId) {
+            throw new UnsupportedOperationException("addParticipant is not needed by RepositoryDemoSummaryServiceTest.");
+        }
+
+        @Override
+        public void removeParticipant(long projectId, String userLoginId) {
+            throw new UnsupportedOperationException(
+                    "removeParticipant is not needed by RepositoryDemoSummaryServiceTest.");
+        }
+
+        @Override
+        public List<ProjectMember> findParticipants(long projectId) {
+            return project.getId() == projectId ? members : List.of();
+        }
+    }
+
+    private static final class FakeIssueRepository implements IssueRepository {
+
+        private final List<Issue> issues;
+
+        private FakeIssueRepository(List<Issue> issues) {
+            this.issues = List.copyOf(issues);
+        }
+
+        @Override
+        public Optional<Issue> findById(long issueId) {
+            return issues.stream()
+                    .filter(issue -> issue.id() == issueId)
+                    .findFirst();
+        }
+
+        @Override
+        public List<Issue> findByProject(long projectId) {
+            return issues.stream()
+                    .filter(issue -> issue.projectId() == projectId)
+                    .toList();
+        }
+
+        @Override
+        public List<Issue> findDeletedByProject(long projectId) {
+            return List.of();
+        }
+
+        @Override
+        public List<Issue> findByCriteria(IssueSearchCriteria criteria) {
+            return issues;
+        }
+
+        @Override
+        public Issue save(Issue issue) {
+            throw new UnsupportedOperationException("save is not needed by RepositoryDemoSummaryServiceTest.");
+        }
+
+        @Override
+        public Issue softDelete(long issueId, String changedById, String message, LocalDateTime changedDate) {
+            throw new UnsupportedOperationException("softDelete is not needed by RepositoryDemoSummaryServiceTest.");
+        }
+
+        @Override
+        public Issue restore(long issueId, String changedById, String message, LocalDateTime changedDate) {
+            throw new UnsupportedOperationException("restore is not needed by RepositoryDemoSummaryServiceTest.");
+        }
+
+        @Override
+        public int purgeDeletedBeyondLimit(long projectId, int maxDeletedIssues) {
+            throw new UnsupportedOperationException(
+                    "purgeDeletedBeyondLimit is not needed by RepositoryDemoSummaryServiceTest.");
+        }
+
+        @Override
+        public void purge(long issueId) {
+            throw new UnsupportedOperationException("purge is not needed by RepositoryDemoSummaryServiceTest.");
+        }
+    }
+
+    private static final class FakeStatisticsRepository implements StatisticsRepository {
+
+        @Override
+        public Map<IssueStatus, Integer> countByStatus(long projectId) {
+            Map<IssueStatus, Integer> counts = new EnumMap<>(IssueStatus.class);
+            counts.put(IssueStatus.NEW, 2);
+            return counts;
+        }
+
+        @Override
+        public Map<Priority, Integer> countByPriority(long projectId) {
+            Map<Priority, Integer> counts = new EnumMap<>(Priority.class);
+            counts.put(Priority.MAJOR, 1);
+            return counts;
+        }
+
+        @Override
+        public List<DailyIssueCount> countReportedIssuesByDay(long projectId) {
+            return List.of();
+        }
+
+        @Override
+        public List<DailyIssueCount> countReportedIssuesByDay(
+                long projectId,
+                LocalDate fromInclusive,
+                LocalDate toInclusive) {
+            return List.of();
+        }
+
+        @Override
+        public List<MonthlyIssueCount> countReportedIssuesByMonth(long projectId) {
+            return List.of();
+        }
+
+        @Override
+        public List<MonthlyIssueCount> countReportedIssuesByMonth(
+                long projectId,
+                YearMonth fromInclusive,
+                YearMonth toInclusive) {
+            return List.of();
+        }
+
+        @Override
+        public StatisticsReport buildReport(
+                long projectId,
+                LocalDate dailyFromInclusive,
+                LocalDate dailyToInclusive,
+                YearMonth monthlyFromInclusive,
+                YearMonth monthlyToInclusive) {
+            throw new UnsupportedOperationException("buildReport is not needed by RepositoryDemoSummaryServiceTest.");
+        }
+    }
+
+    private static final class FakeAssignmentRecommendationRepository implements AssignmentRecommendationRepository {
+
+        private final User dev;
+        private final User tester;
+
+        private FakeAssignmentRecommendationRepository(User dev, User tester) {
+            this.dev = dev;
+            this.tester = tester;
+        }
+
+        @Override
+        public List<AssignmentCandidate> findDevAssigneeCandidates(long projectId) {
+            return List.of(AssignmentCandidate.create(dev, 1));
+        }
+
+        @Override
+        public List<AssignmentCandidate> findTesterVerifierCandidates(long projectId) {
+            return List.of(AssignmentCandidate.create(tester, 1));
+        }
+    }
+}


### PR DESCRIPTION
## 요약
- `Main`의 CLI demo repository aggregation을 `RepositoryDemoSummaryService`로 이동했습니다.
- `RepositoryDemoSummary` read model을 추가해 console 출력과 repository 조회를 분리했습니다.
- `Main`은 process flow와 console output만 담당하도록 축소했습니다.

## 검증
- `./gradlew test --tests 'com.github.marcellokim.issuetracker.service.RepositoryDemoSummaryServiceTest' --console=plain --rerun-tasks`
- `git diff --check`
- `./gradlew check --console=plain`
- pre-commit `verifyRepositorySetup`
- pre-push `test + verifyRepositorySetup`

## 관련 PR
- 이전 PR: #126

## 관련 이슈
- Refs #95
