### PR TITLE
refactor: login check를 service 뒤로 이동

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/Main.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/Main.java
@@ -3,7 +3,8 @@ package com.github.marcellokim.issuetracker;
 import com.github.marcellokim.issuetracker.persistence.DatabaseInitializer;
 import com.github.marcellokim.issuetracker.persistence.DriverManagerConnectionProvider;
 import com.github.marcellokim.issuetracker.persistence.jdbc.JdbcRepositoryFactory;
-import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.LoginCheckResult;
+import com.github.marcellokim.issuetracker.service.LoginCheckService;
 import com.github.marcellokim.issuetracker.service.RepositoryDemoSummary;
 import com.github.marcellokim.issuetracker.service.RepositoryDemoSummaryService;
 import com.github.marcellokim.issuetracker.technical.ConsoleOutput;
@@ -103,15 +104,14 @@ public final class Main {
             printConnectionContext(connectionProvider);
 
             var repositories = new JdbcRepositoryFactory(connectionProvider);
-            var user = repositories.users().findByLoginId(normalizedLoginId);
-            var result = new AuthenticationService(repositories.users()).login(normalizedLoginId, password);
+            LoginCheckResult result = new LoginCheckService(repositories.users()).checkLogin(normalizedLoginId, password);
 
-            printLine("Login ID: " + normalizedLoginId);
-            user.ifPresentOrElse(
+            printLine("Login ID: " + result.loginId());
+            result.account().ifPresentOrElse(
                     value -> {
                         printLine("Account: found");
-                        printLine("Role: " + value.getRole());
-                        printLine("Active: " + value.isActive());
+                        printLine("Role: " + value.role());
+                        printLine("Active: " + value.active());
                     },
                     () -> printLine("Account: missing"));
             printLine("Login result: " + (result.success() ? "SUCCESS" : "FAILURE"));

--- a/src/main/java/com/github/marcellokim/issuetracker/service/LoginCheckResult.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/LoginCheckResult.java
@@ -1,0 +1,26 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.Role;
+import java.util.Objects;
+import java.util.Optional;
+
+public record LoginCheckResult(
+        String loginId,
+        Optional<AccountSummary> account,
+        boolean success,
+        String message
+) {
+
+    public LoginCheckResult {
+        loginId = Objects.requireNonNull(loginId, "loginId");
+        account = Objects.requireNonNull(account, "account");
+        message = Objects.requireNonNull(message, "message");
+    }
+
+    public record AccountSummary(Role role, boolean active) {
+
+        public AccountSummary {
+            role = Objects.requireNonNull(role, "role");
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/LoginCheckService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/LoginCheckService.java
@@ -1,0 +1,39 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.UserRepository;
+import java.util.Objects;
+
+public final class LoginCheckService {
+
+    private final UserRepository userRepository;
+    private final AuthenticationService authenticationService;
+
+    public LoginCheckService(UserRepository userRepository) {
+        this(userRepository, new AuthenticationService(userRepository));
+    }
+
+    public LoginCheckService(UserRepository userRepository, AuthenticationService authenticationService) {
+        this.userRepository = Objects.requireNonNull(userRepository, "userRepository");
+        this.authenticationService = Objects.requireNonNull(authenticationService, "authenticationService");
+    }
+
+    public LoginCheckResult checkLogin(String loginId, String password) {
+        /*
+         * Main owns CLI argument handling and console output. Login-check account
+         * lookup and authentication stay here so the CLI path follows service rules.
+         */
+        String normalizedLoginId = loginId == null ? "" : loginId.trim();
+        AuthenticationResult authenticationResult = authenticationService.login(normalizedLoginId, password);
+        return new LoginCheckResult(
+                normalizedLoginId,
+                userRepository.findByLoginId(normalizedLoginId).map(LoginCheckService::toAccountSummary),
+                authenticationResult.success(),
+                authenticationResult.message());
+    }
+
+    private static LoginCheckResult.AccountSummary toAccountSummary(User user) {
+        return new LoginCheckResult.AccountSummary(user.getRole(), user.isActive());
+    }
+
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/service/LoginCheckServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/LoginCheckServiceTest.java
@@ -1,0 +1,54 @@
+package com.github.marcellokim.issuetracker.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.technical.PasswordHasher;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Login check service")
+class LoginCheckServiceTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 21, 15, 30);
+    private static final PasswordHasher PASSWORD_HASHER = new PasswordHasher();
+    private static final String PASSWORD = "DemoLocalAdmin!";
+
+    @Test
+    @DisplayName("builds login-check output data without exposing repository calls to Main")
+    void checksLoginAndAccountSummary() {
+        User admin = user("admin", PASSWORD, Role.ADMIN, true);
+        var service = new LoginCheckService(new InMemoryUserRepository(admin));
+
+        LoginCheckResult result = service.checkLogin(" admin ", PASSWORD);
+
+        assertEquals("admin", result.loginId());
+        assertTrue(result.account().isPresent());
+        assertEquals(Role.ADMIN, result.account().orElseThrow().role());
+        assertTrue(result.account().orElseThrow().active());
+        assertTrue(result.success());
+        assertEquals("Login succeeded.", result.message());
+    }
+
+    @Test
+    @DisplayName("keeps blank login id on the authentication failure path")
+    void checksBlankLoginIdWithoutThrowing() {
+        var service = new LoginCheckService(new InMemoryUserRepository());
+
+        LoginCheckResult result = service.checkLogin(" ", PASSWORD);
+
+        assertEquals("", result.loginId());
+        assertTrue(result.account().isEmpty());
+        assertFalse(result.success());
+        assertEquals("ID and password are required.", result.message());
+    }
+
+    private static User user(String loginId, String password, Role role, boolean active) {
+        return User.create(loginId, loginId, PASSWORD_HASHER.hash(password), role, active, NOW, NOW);
+    }
+}


### PR DESCRIPTION
## 요약
- `Main.runLoginCheck`의 account lookup/authentication 조합을 `LoginCheckService`로 이동했습니다.
- CLI 출력에 필요한 `LoginCheckResult` read model을 추가했습니다.
- blank login id는 기존처럼 authentication failure path로 흘러가도록 회귀 테스트를 추가했습니다.

## 검증
- RED: `./gradlew test --tests 'com.github.marcellokim.issuetracker.service.LoginCheckServiceTest' --console=plain --rerun-tasks` failed on missing `LoginCheckService` / `LoginCheckResult`
- RED: blank login id regression failed with `IllegalArgumentException: loginId must not be blank`
- GREEN: `./gradlew test --tests 'com.github.marcellokim.issuetracker.service.LoginCheckServiceTest' --console=plain --rerun-tasks`
- `git diff --check`
- `./gradlew check --console=plain`
- pre-commit `verifyRepositorySetup`
- pre-push `test + verifyRepositorySetup`

## 관련 PR
- 이전 PR: #127

## 관련 이슈
- Refs #95
