### PR TITLE
refactor: DB 환경 설정을 값 객체로 중앙화

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/Main.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/Main.java
@@ -1,6 +1,7 @@
 package com.github.marcellokim.issuetracker;
 
 import com.github.marcellokim.issuetracker.persistence.DatabaseInitializer;
+import com.github.marcellokim.issuetracker.persistence.DatabaseEnvironment;
 import com.github.marcellokim.issuetracker.persistence.DriverManagerConnectionProvider;
 import com.github.marcellokim.issuetracker.persistence.jdbc.JdbcRepositoryFactory;
 import com.github.marcellokim.issuetracker.service.LoginCheckResult;
@@ -37,7 +38,8 @@ public final class Main {
         }
 
         try {
-            var connectionProvider = DriverManagerConnectionProvider.fromEnvironment();
+            DatabaseEnvironment environment = DatabaseEnvironment.fromSystem();
+            var connectionProvider = DriverManagerConnectionProvider.from(environment);
             DatabaseInitializer.initialize(connectionProvider);
             var repositories = new JdbcRepositoryFactory(connectionProvider);
             printRepositorySummary(new RepositoryDemoSummaryService(
@@ -62,13 +64,7 @@ public final class Main {
     }
 
     private static boolean hasDatabaseEnvironment() {
-        return hasText(System.getenv("ITS_DB_URL"))
-                && hasText(System.getenv("ITS_DB_USER"))
-                && hasText(System.getenv("ITS_DB_PASSWORD"));
-    }
-
-    private static boolean hasText(String value) {
-        return value != null && !value.isBlank();
+        return DatabaseEnvironment.isSystemConfigured();
     }
 
     private static void printDatabaseSetupGuide() {
@@ -99,9 +95,10 @@ public final class Main {
         String normalizedLoginId = loginId.trim();
 
         try {
-            var connectionProvider = DriverManagerConnectionProvider.fromEnvironment();
+            DatabaseEnvironment environment = DatabaseEnvironment.fromSystem();
+            var connectionProvider = DriverManagerConnectionProvider.from(environment);
             DatabaseInitializer.initialize(connectionProvider);
-            printConnectionContext(connectionProvider);
+            printConnectionContext(environment, connectionProvider);
 
             var repositories = new JdbcRepositoryFactory(connectionProvider);
             LoginCheckResult result = new LoginCheckService(repositories.users()).checkLogin(normalizedLoginId, password);
@@ -122,9 +119,12 @@ public final class Main {
         }
     }
 
-    private static void printConnectionContext(DriverManagerConnectionProvider connectionProvider) throws SQLException {
-        printLine("DB URL: " + System.getenv().getOrDefault("ITS_DB_URL", ""));
-        printLine("DB user: " + System.getenv().getOrDefault("ITS_DB_USER", ""));
+    private static void printConnectionContext(
+            DatabaseEnvironment environment,
+            DriverManagerConnectionProvider connectionProvider
+    ) throws SQLException {
+        printLine("DB URL: " + environment.url());
+        printLine("DB user: " + environment.user());
 
         String sql = """
                 select sys_context('USERENV', 'CURRENT_SCHEMA') as current_schema,

--- a/src/main/java/com/github/marcellokim/issuetracker/config/ApplicationContext.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/config/ApplicationContext.java
@@ -1,6 +1,7 @@
 package com.github.marcellokim.issuetracker.config;
 
 import com.github.marcellokim.issuetracker.persistence.DatabaseInitializer;
+import com.github.marcellokim.issuetracker.persistence.DatabaseEnvironment;
 import com.github.marcellokim.issuetracker.persistence.DriverManagerConnectionProvider;
 import com.github.marcellokim.issuetracker.persistence.jdbc.JdbcRepositoryFactory;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
@@ -15,15 +16,8 @@ public record ApplicationContext(
 ) {
 
     public static ApplicationContext fromEnvironment() throws IOException, SQLException {
-        if (!hasText(System.getenv("ITS_DB_URL"))
-                || !hasText(System.getenv("ITS_DB_USER"))
-                || !hasText(System.getenv("ITS_DB_PASSWORD"))) {
-            throw new IllegalStateException(
-                    "Oracle environment is missing. Set ITS_DB_URL, ITS_DB_USER, ITS_DB_PASSWORD."
-            );
-        }
-
-        var connectionProvider = DriverManagerConnectionProvider.fromEnvironment();
+        DatabaseEnvironment environment = DatabaseEnvironment.fromSystem();
+        var connectionProvider = DriverManagerConnectionProvider.from(environment);
         DatabaseInitializer.initialize(connectionProvider);
 
         var repositories = new JdbcRepositoryFactory(connectionProvider);
@@ -38,7 +32,4 @@ public record ApplicationContext(
         );
     }
 
-    private static boolean hasText(String value) {
-        return value != null && !value.isBlank();
-    }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/DatabaseEnvironment.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/DatabaseEnvironment.java
@@ -1,0 +1,60 @@
+package com.github.marcellokim.issuetracker.persistence;
+
+import java.util.Map;
+import java.util.Objects;
+
+public record DatabaseEnvironment(String url, String user, String password) {
+
+    public static final String URL_VARIABLE = "ITS_DB_URL";
+    public static final String USER_VARIABLE = "ITS_DB_USER";
+    public static final String PASSWORD_VARIABLE = "ITS_DB_PASSWORD";
+    public static final String MISSING_MESSAGE =
+            "Oracle environment is missing. Set ITS_DB_URL, ITS_DB_USER, ITS_DB_PASSWORD.";
+
+    public DatabaseEnvironment {
+        url = requireText(url, "url");
+        user = requireText(user, "user");
+        password = requireText(password, "password");
+    }
+
+    public static boolean isSystemConfigured() {
+        return isConfigured(System.getenv());
+    }
+
+    public static boolean isConfigured(Map<String, String> environment) {
+        Objects.requireNonNull(environment, "environment");
+        return hasText(environment.get(URL_VARIABLE))
+                && hasText(environment.get(USER_VARIABLE))
+                && hasText(environment.get(PASSWORD_VARIABLE));
+    }
+
+    public static DatabaseEnvironment fromSystem() {
+        return requireConfigured(System.getenv());
+    }
+
+    public static DatabaseEnvironment requireConfigured(Map<String, String> environment) {
+        Objects.requireNonNull(environment, "environment");
+        if (!isConfigured(environment)) {
+            throw new IllegalStateException(MISSING_MESSAGE);
+        }
+        /*
+         * Keep Oracle application environment parsing in one value object so CLI,
+         * JavaFX startup, and JDBC provider creation share the same readiness rule.
+         */
+        return new DatabaseEnvironment(
+                environment.get(URL_VARIABLE),
+                environment.get(USER_VARIABLE),
+                environment.get(PASSWORD_VARIABLE));
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private static String requireText(String value, String fieldName) {
+        if (!hasText(value)) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProvider.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProvider.java
@@ -20,10 +20,12 @@ public final class DriverManagerConnectionProvider implements DatabaseConnection
     }
 
     public static DriverManagerConnectionProvider fromEnvironment() {
-        String url = readRequiredEnvironment("ITS_DB_URL");
-        String user = readRequiredEnvironment("ITS_DB_USER");
-        String password = readRequiredEnvironment("ITS_DB_PASSWORD");
-        return new DriverManagerConnectionProvider(url, user, password);
+        return from(DatabaseEnvironment.fromSystem());
+    }
+
+    public static DriverManagerConnectionProvider from(DatabaseEnvironment environment) {
+        Objects.requireNonNull(environment, "environment");
+        return new DriverManagerConnectionProvider(environment.url(), environment.user(), environment.password());
     }
 
     public static DriverManagerConnectionProvider fromIntegrationTestEnvironment() {

--- a/src/test/java/com/github/marcellokim/issuetracker/persistence/DatabaseEnvironmentTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/persistence/DatabaseEnvironmentTest.java
@@ -1,0 +1,57 @@
+package com.github.marcellokim.issuetracker.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Database environment")
+class DatabaseEnvironmentTest {
+
+    @Test
+    @DisplayName("requires URL, user, and password for application database setup")
+    void checksDatabaseEnvironmentReadiness() {
+        assertFalse(DatabaseEnvironment.isConfigured(Map.of()));
+        assertFalse(DatabaseEnvironment.isConfigured(Map.of(
+                "ITS_DB_URL", "jdbc:oracle:thin:@//localhost:1521/XEPDB1",
+                "ITS_DB_USER", "ITS_USER",
+                "ITS_DB_PASSWORD", " "
+        )));
+        assertTrue(DatabaseEnvironment.isConfigured(databaseEnvironment()));
+    }
+
+    @Test
+    @DisplayName("creates immutable connection settings from configured values")
+    void createsDatabaseEnvironmentFromConfiguredValues() {
+        DatabaseEnvironment environment = DatabaseEnvironment.requireConfigured(databaseEnvironment());
+
+        assertEquals("jdbc:oracle:thin:@//localhost:1521/XEPDB1", environment.url());
+        assertEquals("ITS_USER", environment.user());
+        assertEquals("secret", environment.password());
+    }
+
+    @Test
+    @DisplayName("uses one clear missing-environment message")
+    void rejectsMissingDatabaseEnvironment() {
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> DatabaseEnvironment.requireConfigured(Map.of())
+        );
+
+        assertEquals(
+                "Oracle environment is missing. Set ITS_DB_URL, ITS_DB_USER, ITS_DB_PASSWORD.",
+                exception.getMessage());
+    }
+
+    private static Map<String, String> databaseEnvironment() {
+        return Map.of(
+                "ITS_DB_URL", "jdbc:oracle:thin:@//localhost:1521/XEPDB1",
+                "ITS_DB_USER", "ITS_USER",
+                "ITS_DB_PASSWORD", "secret"
+        );
+    }
+}


### PR DESCRIPTION
## 요약
- Oracle 애플리케이션 환경 변수 해석을 `DatabaseEnvironment` 값 객체로 중앙화했습니다.
- `Main`, `ApplicationContext`, `DriverManagerConnectionProvider`가 같은 DB readiness rule을 공유하도록 정리했습니다.
- CLI login-check의 DB URL/user 출력은 `System.getenv()` 직접 조회 대신 `DatabaseEnvironment` 값을 사용하도록 바꿨습니다.

## 검증
- RED: `./gradlew test --tests 'com.github.marcellokim.issuetracker.persistence.DatabaseEnvironmentTest' --console=plain --rerun-tasks` failed on missing `DatabaseEnvironment`
- GREEN: `./gradlew test --tests 'com.github.marcellokim.issuetracker.persistence.DatabaseEnvironmentTest' --console=plain --rerun-tasks`
- `./gradlew test --tests 'com.github.marcellokim.issuetracker.persistence.DatabaseEnvironmentTest' --tests 'com.github.marcellokim.issuetracker.MainSmokeTest' --console=plain --rerun-tasks`
- `git diff --check`
- `./gradlew check --console=plain`
- pre-commit `verifyRepositorySetup`
- pre-push `test + verifyRepositorySetup`

## 관련 PR
- 이전 PR: #128

## 관련 이슈
- Refs #95
