### PR TITLE
refactor: 리뷰용 주석을 한국어로 정리

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/DatabaseEnvironment.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/DatabaseEnvironment.java
@@ -38,8 +38,8 @@ public record DatabaseEnvironment(String url, String user, String password) {
             throw new IllegalStateException(MISSING_MESSAGE);
         }
         /*
-         * Keep Oracle application environment parsing in one value object so CLI,
-         * JavaFX startup, and JDBC provider creation share the same readiness rule.
+         * Oracle application 환경 해석을 하나의 value object에 모아 CLI, JavaFX startup,
+         * JDBC provider 생성이 같은 준비 상태 규칙을 공유하게 한다.
          */
         return new DatabaseEnvironment(
                 environment.get(URL_VARIABLE),

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueRepository.java
@@ -606,7 +606,7 @@ public final class JdbcIssueRepository implements IssueRepository {
         try {
             connection.rollback();
         } catch (SQLException ignored) {
-            // Keep the original repository failure.
+            // 원래 repository 실패 원인을 유지한다.
         }
     }
 

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcProjectRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcProjectRepository.java
@@ -243,7 +243,7 @@ public final class JdbcProjectRepository implements ProjectRepository {
         try {
             connection.rollback();
         } catch (SQLException ignored) {
-            // Keep the original repository failure.
+            // 원래 repository 실패 원인을 유지한다.
         }
     }
 

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcUserRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcUserRepository.java
@@ -245,7 +245,7 @@ public final class JdbcUserRepository implements UserRepository {
         try {
             connection.setAutoCommit(autoCommit);
         } catch (SQLException ignored) {
-            // Keep the original repository failure.
+            // 원래 repository 실패 원인을 유지한다.
         }
     }
 
@@ -253,7 +253,7 @@ public final class JdbcUserRepository implements UserRepository {
         try {
             connection.rollback();
         } catch (SQLException ignored) {
-            // Keep the original repository failure.
+            // 원래 repository 실패 원인을 유지한다.
         }
     }
 

--- a/src/main/java/com/github/marcellokim/issuetracker/service/AccountService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/AccountService.java
@@ -20,7 +20,7 @@ public final class AccountService {
     }
 
     /*
-     * Account management UC orchestration stays here so the controller can remain
-     * a system-operation adapter when the admin account methods are implemented.
+     * Admin account UC 조율은 service에 둔다. 이후 계정 관리 메서드가 추가되어도
+     * controller는 system operation adapter 역할만 유지한다.
      */
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/service/DashboardSummaryService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/DashboardSummaryService.java
@@ -28,8 +28,8 @@ public final class DashboardSummaryService {
 
     public List<DashboardProjectSummary> projectSummaries() {
         /*
-         * The dashboard is a read model over several repositories. Keeping those reads
-         * here lets the JavaFX presenter format data without knowing persistence ports.
+         * 대시보드는 여러 repository를 합친 read model이다. 이 조회 조합을 service에 두어
+         * JavaFX presenter가 persistence port를 몰라도 화면 데이터를 포맷하게 한다.
          */
         return projectRepository.findAll().stream()
                 .map(project -> new DashboardProjectSummary(

--- a/src/main/java/com/github/marcellokim/issuetracker/service/DeletedIssueService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/DeletedIssueService.java
@@ -56,8 +56,8 @@ public final class DeletedIssueService {
 
     private void requireDeletedIssuePermission(User actor, long projectId) {
         /*
-         * The permission check lives with the repository operation so future review can
-         * audit deleted-issue side effects without jumping back into the controller.
+         * 삭제 이슈 권한 확인을 repository 작업과 같은 service 경계에 두어
+         * 이후 리뷰에서 삭제 부수효과를 controller까지 추적하지 않게 한다.
          */
         if (!permissionPolicy.verifyPermission(actor, "MANAGE_DELETED_ISSUE", projectId)) {
             throw new SecurityException("Only PL or ADMIN can manage deleted issues.");

--- a/src/main/java/com/github/marcellokim/issuetracker/service/LoginCheckService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/LoginCheckService.java
@@ -20,8 +20,8 @@ public final class LoginCheckService {
 
     public LoginCheckResult checkLogin(String loginId, String password) {
         /*
-         * Main owns CLI argument handling and console output. Login-check account
-         * lookup and authentication stay here so the CLI path follows service rules.
+         * Main은 CLI 진입 흐름과 콘솔 출력을 담당한다. 계정 조회와 인증 판정은 service에 두어
+         * CLI 경로도 service 규칙을 따르게 한다.
          */
         String normalizedLoginId = loginId == null ? "" : loginId.trim();
         AuthenticationResult authenticationResult = authenticationService.login(normalizedLoginId, password);

--- a/src/main/java/com/github/marcellokim/issuetracker/service/RepositoryDemoSummaryService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/RepositoryDemoSummaryService.java
@@ -39,8 +39,8 @@ public final class RepositoryDemoSummaryService {
 
     public RepositoryDemoSummary summarizeSeedDemo() {
         /*
-         * Main owns process flow and console output. Repository aggregation lives here
-         * so the CLI demo follows the same service boundary as controller/UI flows.
+         * Main은 CLI 진입 흐름과 콘솔 출력을 담당한다. repository 집계는 여기에서 수행해
+         * CLI demo도 controller/UI 흐름과 같은 service 경계를 따르게 한다.
          */
         return new RepositoryDemoSummary(
                 userRepository.findByLoginId(DEMO_ADMIN_LOGIN_ID).map(RepositoryDemoSummaryService::toAdminAccount),

--- a/src/main/java/com/github/marcellokim/issuetracker/service/StatisticsService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/StatisticsService.java
@@ -29,8 +29,8 @@ public final class StatisticsService {
             User actor
     ) {
         /*
-         * Range validation is part of the statistics use-case boundary, not controller
-         * plumbing, so repository query inputs are guarded in one place.
+         * 기간 검증은 statistics use-case 경계의 책임이다. repository query input은
+         * service 한 곳에서 보호한다.
          */
         permissionPolicy.assertCanViewStatistics(actor, projectId);
         requireOrderedRange(dailyFromInclusive, dailyToInclusive, "dailyFromInclusive", "dailyToInclusive");

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/ArchitectureBoundaryTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/ArchitectureBoundaryTest.java
@@ -23,8 +23,8 @@ class ArchitectureBoundaryTest {
     private static final Pattern IMPORT_PATTERN = Pattern.compile("^import\\s+(?:static\\s+)?([\\w.]+)(?:\\.\\*)?;");
 
     /*
-     * Temporary architecture debt marker: later clean-code slices must remove each exception
-     * when that flow moves behind the intended service/presenter boundary.
+     * 임시 아키텍처 부채 표시자: 이후 clean-code slice에서 각 흐름이
+     * 의도한 service/presenter 경계로 이동하면 예외를 제거한다.
      */
     private static final Set<AllowedImport> TEMPORARY_ALLOWED_IMPORTS = Set.of();
 


### PR DESCRIPTION
## 요약
- 리뷰를 돕는 architecture/service/persistence 주석을 한국어로 정리했습니다.
- 동작 변경 없이 주석 언어와 설명 기준만 맞췄습니다.
- 기존 clean-code service boundary 의도는 그대로 유지했습니다.

## 검증
- `./gradlew test --tests ArchitectureBoundaryTest --console=plain`
- `git diff --check`
- `./gradlew check --console=plain`

## 관련 PR
- 이전 PR: #129

## 관련 이슈
- Refs #95
