### PR TITLE
feat: reject-fix 상태 전이를 IssueStateService로 연결

### DIFF
--- a/docs/uml/dcd/dcd_implementation_details.md
+++ b/docs/uml/dcd/dcd_implementation_details.md
@@ -125,7 +125,7 @@ IssueStateService
 - comment 기록
 - 변경된 issue 저장
 
-#43 Tester reject fix도 같은 구조로 확장하는 것이 자연스럽다. 단, operation 이름은 새로 만들지 않고 `changeStatus(issueId, targetStatus=ASSIGNED, comment)` branch로 유지한다.
+#43 Tester reject fix는 같은 구조로 구현한다. 별도 operation 이름을 만들지 않고 `changeStatus(issueId, targetStatus=ASSIGNED, comment)` branch에서 `Issue.rejectFix`를 호출한다.
 
 ## 구현 가이드라인
 

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java
@@ -36,6 +36,7 @@ public final class IssueStateService {
         switch (requiredTargetStatus) {
             case FIXED -> markFixed(issue, actor, requiredComment);
             case RESOLVED -> resolve(issue, actor, requiredComment);
+            case ASSIGNED -> rejectFix(issue, actor, requiredComment);
             case CLOSED -> close(issue, actor, requiredComment);
             default -> throw new UnsupportedOperationException("Unsupported target status: " + requiredTargetStatus);
         }
@@ -47,30 +48,32 @@ public final class IssueStateService {
         permissionPolicy.assertCanChangeStatus(actor, issue, IssueStatus.FIXED);
         LocalDateTime changedAt = now();
         issue.markFixed(actor, comment, changedAt);
-        issue.addComment(
-                CommentIdGenerator.nextCommentId(),
-                comment,
-                actor,
-                changedAt,
-                CommentPurpose.STATUS_CHANGE_REASON);
+        recordStatusChangeReason(issue, actor, comment, changedAt);
     }
 
     private void resolve(Issue issue, User actor, String comment) {
         permissionPolicy.assertCanChangeStatus(actor, issue, IssueStatus.RESOLVED);
         LocalDateTime changedAt = now();
         issue.resolve(actor, comment, changedAt);
-        issue.addComment(
-                CommentIdGenerator.nextCommentId(),
-                comment,
-                actor,
-                changedAt,
-                CommentPurpose.STATUS_CHANGE_REASON);
+        recordStatusChangeReason(issue, actor, comment, changedAt);
+    }
+
+    private void rejectFix(Issue issue, User actor, String comment) {
+        permissionPolicy.assertCanChangeStatus(actor, issue, IssueStatus.ASSIGNED);
+        LocalDateTime changedAt = now();
+        issue.rejectFix(actor, comment, changedAt);
+        recordStatusChangeReason(issue, actor, comment, changedAt);
     }
 
     private void close(Issue issue, User actor, String comment) {
         permissionPolicy.assertCanChangeStatus(actor, issue, IssueStatus.CLOSED);
         LocalDateTime changedAt = now();
         issue.close(actor, comment, changedAt);
+        recordStatusChangeReason(issue, actor, comment, changedAt);
+    }
+
+    private void recordStatusChangeReason(Issue issue, User actor, String comment, LocalDateTime changedAt) {
+        // 도메인 전이가 성공한 뒤에만 사유 댓글을 남겨 실패 전이의 부수효과를 막는다.
         issue.addComment(
                 CommentIdGenerator.nextCommentId(),
                 comment,

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
@@ -68,6 +68,26 @@ class IssueStateServiceTest {
     }
 
     @Test
+    @DisplayName("verifier rejects fixed issue back to assigned")
+    void rejectFixedIssueBackToAssigned() {
+        var issue = fixedIssue();
+        var service = service(issue);
+
+        var result = service.changeStatus(ISSUE_ID, IssueStatus.ASSIGNED, "Fix is incomplete", verifier.getLoginId());
+
+        assertEquals(IssueStatus.ASSIGNED, result.status());
+        assertSame(assignee, issue.getAssignee());
+        assertSame(verifier, issue.getVerifier());
+        assertSame(assignee, issue.getFixer());
+        assertNull(issue.getResolver());
+        assertEquals(1, issue.getComments().size());
+        assertEquals("Fix is incomplete", issue.getComments().getFirst().getContent());
+        assertEquals(CommentPurpose.STATUS_CHANGE_REASON, issue.getComments().getFirst().getPurpose());
+        assertEquals(ActionType.COMMENTED, issue.getHistories().getLast().getAction());
+        assertStatusChangedThenCommented(issue);
+    }
+
+    @Test
     @DisplayName("PL closes resolved issue and clears active assignment")
     void closeResolvedIssue() {
         var issue = resolvedIssue();
@@ -116,7 +136,7 @@ class IssueStateServiceTest {
         var service = service(issue);
 
         assertThrows(UnsupportedOperationException.class,
-                () -> service.changeStatus(ISSUE_ID, IssueStatus.REOPENED, "Needs more work", pl.getLoginId()));
+                () -> service.changeStatus(ISSUE_ID, IssueStatus.DELETED, "Delete through deleted service", pl.getLoginId()));
     }
 
     @Test


### PR DESCRIPTION
## 요약
- `changeStatus(..., ASSIGNED, ...)` 흐름을 `Issue.rejectFix` 경로로 연결했습니다.
- 성공한 domain transition 뒤에 mandatory status-change comment가 기록되는 순서를 유지했습니다.
- #43 기준 DCD 구현 메모를 갱신했습니다.

## 검증
- `./gradlew test --tests IssueStateServiceTest --console=plain`
- `git diff --check`
- `./gradlew check --console=plain`

## 관련 PR
- 이전 PR: #130

## 관련 이슈
- Refs #43
