### PR TITLE
feat: reopen 상태 전이를 IssueStateService로 연결

### DIFF
--- a/docs/uml/dcd/dcd_implementation_details.md
+++ b/docs/uml/dcd/dcd_implementation_details.md
@@ -121,11 +121,13 @@ IssueStateService
 - 현재 사용자 조회
 - target status별 권한 검사
 - 필수 comment 검증
-- `Issue.markFixed`, `Issue.resolve`, `Issue.close` 등 domain operation 호출
+- `Issue.markFixed`, `Issue.resolve`, `Issue.rejectFix`, `Issue.close`, `Issue.reopen` domain operation 호출
 - comment 기록
 - 변경된 issue 저장
 
 #43 Tester reject fix는 같은 구조로 구현한다. 별도 operation 이름을 만들지 않고 `changeStatus(issueId, targetStatus=ASSIGNED, comment)` branch에서 `Issue.rejectFix`를 호출한다.
+
+#47 Reopen은 같은 `changeStatus(issueId, targetStatus=REOPENED, comment)` route에서 구현한다. `Issue.reopen`이 assignee/verifier 제거와 fixer/resolver 보존 정책을 소유하고, PL 권한 검사는 `PermissionPolicy`가 담당한다.
 
 ## 구현 가이드라인
 

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java
@@ -38,6 +38,7 @@ public final class IssueStateService {
             case RESOLVED -> resolve(issue, actor, requiredComment);
             case ASSIGNED -> rejectFix(issue, actor, requiredComment);
             case CLOSED -> close(issue, actor, requiredComment);
+            case REOPENED -> reopen(issue, actor, requiredComment);
             default -> throw new UnsupportedOperationException("Unsupported target status: " + requiredTargetStatus);
         }
         issueRepository.save(issue);
@@ -69,6 +70,13 @@ public final class IssueStateService {
         permissionPolicy.assertCanChangeStatus(actor, issue, IssueStatus.CLOSED);
         LocalDateTime changedAt = now();
         issue.close(actor, comment, changedAt);
+        recordStatusChangeReason(issue, actor, comment, changedAt);
+    }
+
+    private void reopen(Issue issue, User actor, String comment) {
+        permissionPolicy.assertCanChangeStatus(actor, issue, IssueStatus.REOPENED);
+        LocalDateTime changedAt = now();
+        issue.reopen(actor, comment, changedAt);
         recordStatusChangeReason(issue, actor, comment, changedAt);
     }
 

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
@@ -108,6 +108,46 @@ class IssueStateServiceTest {
     }
 
     @Test
+    @DisplayName("PL reopens resolved issue and clears active assignment")
+    void reopenResolvedIssue() {
+        var issue = resolvedIssue();
+        var service = service(issue);
+
+        var result = service.changeStatus(ISSUE_ID, IssueStatus.REOPENED, "Needs more work", pl.getLoginId());
+
+        assertEquals(IssueStatus.REOPENED, result.status());
+        assertNull(issue.getAssignee());
+        assertNull(issue.getVerifier());
+        assertSame(assignee, issue.getFixer());
+        assertSame(verifier, issue.getResolver());
+        assertEquals(1, issue.getComments().size());
+        assertEquals("Needs more work", issue.getComments().getFirst().getContent());
+        assertEquals(CommentPurpose.STATUS_CHANGE_REASON, issue.getComments().getFirst().getPurpose());
+        assertEquals(ActionType.COMMENTED, issue.getHistories().getLast().getAction());
+        assertStatusChangedThenCommented(issue);
+    }
+
+    @Test
+    @DisplayName("PL reopens closed issue and preserves fixer and resolver")
+    void reopenClosedIssue() {
+        var issue = closedIssue();
+        var service = service(issue);
+
+        var result = service.changeStatus(ISSUE_ID, IssueStatus.REOPENED, "Regression found", pl.getLoginId());
+
+        assertEquals(IssueStatus.REOPENED, result.status());
+        assertNull(issue.getAssignee());
+        assertNull(issue.getVerifier());
+        assertSame(assignee, issue.getFixer());
+        assertSame(verifier, issue.getResolver());
+        assertEquals(1, issue.getComments().size());
+        assertEquals("Regression found", issue.getComments().getFirst().getContent());
+        assertEquals(CommentPurpose.STATUS_CHANGE_REASON, issue.getComments().getFirst().getPurpose());
+        assertEquals(ActionType.COMMENTED, issue.getHistories().getLast().getAction());
+        assertStatusChangedThenCommented(issue);
+    }
+
+    @Test
     @DisplayName("blank comment or wrong actor fails status change")
     void rejectBlankCommentAndWrongParticipant() {
         var issue = assignedIssue();
@@ -198,6 +238,12 @@ class IssueStateServiceTest {
     private Issue resolvedIssue() {
         var issue = fixedIssue();
         issue.resolve(verifier, "Verified", createdAt().plusMinutes(30));
+        return issue;
+    }
+
+    private Issue closedIssue() {
+        var issue = resolvedIssue();
+        issue.close(pl, "Release completed", createdAt().plusMinutes(40));
         return issue;
     }
 


### PR DESCRIPTION
## 요약
- `changeStatus(..., REOPENED, ...)` 흐름을 `Issue.reopen` 경로로 연결했습니다.
- assignee/verifier clearing과 fixer/resolver retention 정책을 유지했습니다.
- #47 기준 DCD 구현 메모를 갱신했습니다.

## 검증
- `./gradlew test --tests IssueStateServiceTest --console=plain`
- `./gradlew test --tests ArchitectureBoundaryTest --console=plain`
- `./gradlew check --console=plain`
- `git diff --check`

## 관련 PR
- 이전 PR: #131

## 관련 이슈
- Refs #47
