### PR TITLE
feat: dependency workflow service 추가

### DIFF
--- a/docs/uml/dcd/dcd_implementation_details.md
+++ b/docs/uml/dcd/dcd_implementation_details.md
@@ -129,6 +129,41 @@ IssueStateService
 
 #47 Reopen은 같은 `changeStatus(issueId, targetStatus=REOPENED, comment)` route에서 구현한다. `Issue.reopen`이 assignee/verifier 제거와 fixer/resolver 보존 정책을 소유하고, PL 권한 검사는 `PermissionPolicy`가 담당한다.
 
+### Issue Dependency Flow
+
+현재 #45 dependency workflow 구조는 다음과 같다.
+text
+IssueDependencyController
+  -> AuthenticationService
+  -> IssueDependencyService
+
+IssueDependencyService
+  -> IssueRepository
+  -> IssueDependencyRepository
+  -> IssueDependencyChangeRepository
+  -> UserRepository
+  -> PermissionPolicy
+  -> Clock
+
+`IssueDependencyController`의 책임은 다음이다.
+
+- 현재 로그인 사용자 확인
+- `addDependency(blockingIssueId, blockedIssueId)`, `listDependencies(issueId)`, `removeDependency(dependencyId)` system operation 수신
+- 로그인 사용자의 `loginId`를 `IssueDependencyService`로 전달
+
+`IssueDependencyService`의 책임은 다음이다.
+
+- blocking issue, blocked issue, 현재 사용자, 저장된 dependency 조회
+- `PermissionPolicy.assertCanManageDependency`를 통한 PL 권한 검사
+- 자기 의존성, 저장소 기준 중복, 저장소 edge 기반 cycle 검사
+- `Issue.addDependency`와 `Issue.recordDependencyRemoved`를 통한 aggregate-local dependency history 기록
+- `IssueDependencyRepository`를 통한 dependency 조회, 목록, 중복, cycle 검사
+- `IssueDependencyChangeRepository`를 통한 dependency 저장/삭제와 blocked issue history 저장
+
+`IssueDependencyChangeRepository`는 dependency relation row와 blocked issue의 `DEPENDENCY_CHANGED` history를 하나의 persistence operation으로 묶는 write contract이다. JDBC 구현에서는 같은 connection에서 autocommit을 끄고 dependency insert/update 또는 delete와 transient history insert를 같은 transaction으로 commit한다. 삭제 경로는 stale dependency id가 이력만 남기는 것을 막기 위해 정확히 1개 row가 삭제된 경우에만 removal history를 insert한다. 따라서 service는 dependency 저장/삭제 뒤에 `IssueRepository.save(blockedIssue)`를 별도로 호출하지 않는다.
+
+이 경계에서 `Priority.BLOCKER`는 dependency workflow와 분리한다. BLOCKER priority는 우선순위 값이고, #45의 dependency 추가/목록/삭제는 `IssueDependency` 관계와 `DEPENDENCY_CHANGED` 이력만 다룬다. FIXED -> RESOLVED dependency guard(#98)는 이 slice에 포함하지 않고 status workflow/service 쪽 정책으로 남긴다.
+
 ## 구현 가이드라인
 
 앞으로 구현할 때는 다음 기준을 따른다.

--- a/src/main/java/com/github/marcellokim/issuetracker/controller/IssueDependencyController.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/controller/IssueDependencyController.java
@@ -1,0 +1,42 @@
+package com.github.marcellokim.issuetracker.controller;
+
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.IssueDependencyResult;
+import com.github.marcellokim.issuetracker.service.IssueDependencyService;
+import java.util.List;
+import java.util.Objects;
+
+public final class IssueDependencyController {
+
+    private final AuthenticationService authenticationService;
+    private final IssueDependencyService issueDependencyService;
+
+    public IssueDependencyController(
+            AuthenticationService authenticationService,
+            IssueDependencyService issueDependencyService
+    ) {
+        this.authenticationService = Objects.requireNonNull(authenticationService, "authenticationService");
+        this.issueDependencyService = Objects.requireNonNull(issueDependencyService, "issueDependencyService");
+    }
+
+    public IssueDependencyResult addDependency(long blockingIssueId, long blockedIssueId) {
+        User user = requireCurrentUser();
+        return issueDependencyService.addDependency(blockingIssueId, blockedIssueId, user.getLoginId());
+    }
+
+    public List<IssueDependencyResult> listDependencies(long issueId) {
+        User user = requireCurrentUser();
+        return issueDependencyService.listDependencies(issueId, user.getLoginId());
+    }
+
+    public void removeDependency(long dependencyId) {
+        User user = requireCurrentUser();
+        issueDependencyService.removeDependency(dependencyId, user.getLoginId());
+    }
+
+    private User requireCurrentUser() {
+        return authenticationService.currentUser()
+                .orElseThrow(() -> new SecurityException("Login is required."));
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Issue.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Issue.java
@@ -362,6 +362,21 @@ public class Issue {
         return dependency;
     }
 
+    public void recordDependencyRemoved(IssueDependency dependency, User changedBy, LocalDateTime changedDate) {
+        Objects.requireNonNull(dependency, "dependency must not be null");
+        Objects.requireNonNull(changedBy, CHANGED_BY_REQUIRED);
+        Objects.requireNonNull(changedDate, CHANGED_DATE_REQUIRED);
+        // Repository 삭제는 service/repository 책임이고, aggregate는 삭제 이력의 일관성만 소유한다.
+        recordHistory(
+                ActionType.DEPENDENCY_CHANGED,
+                dependency.getDependencyId(),
+                null,
+                "Dependency removed",
+                changedBy,
+                changedDate
+        );
+    }
+
     public Comment addComment(String commentId, String content, User writer, LocalDateTime createdDate) {
         return addComment(commentId, content, writer, createdDate, CommentPurpose.GENERAL);
     }

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueDependencyRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueDependencyRepository.java
@@ -1,7 +1,10 @@
 package com.github.marcellokim.issuetracker.persistence.jdbc;
 
+import com.github.marcellokim.issuetracker.domain.Issue;
 import com.github.marcellokim.issuetracker.domain.IssueDependency;
+import com.github.marcellokim.issuetracker.domain.IssueHistory;
 import com.github.marcellokim.issuetracker.persistence.DatabaseConnectionProvider;
+import com.github.marcellokim.issuetracker.repository.IssueDependencyChangeRepository;
 import com.github.marcellokim.issuetracker.repository.IssueDependencyRepository;
 import com.github.marcellokim.issuetracker.repository.RepositoryException;
 import java.sql.Connection;
@@ -12,7 +15,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-public final class JdbcIssueDependencyRepository implements IssueDependencyRepository {
+public final class JdbcIssueDependencyRepository
+        implements IssueDependencyRepository, IssueDependencyChangeRepository {
 
     private static final String BASE_SELECT =
             "select id, dependency_id, blocking_issue_id, blocked_issue_id, discovered_date from issue_dependencies";
@@ -102,21 +106,62 @@ public final class JdbcIssueDependencyRepository implements IssueDependencyRepos
 
     @Override
     public IssueDependency save(IssueDependency dependency) {
-        if (dependency.id() == 0L) {
-            return insert(dependency);
+        try (Connection connection = connectionProvider.getConnection()) {
+            return save(connection, dependency);
+        } catch (SQLException exception) {
+            throw new RepositoryException("Failed to save issue dependency.", exception);
         }
-        return update(dependency);
+    }
+
+    @Override
+    public IssueDependency saveWithBlockedIssueHistory(IssueDependency dependency, Issue blockedIssue) {
+        try (Connection connection = connectionProvider.getConnection()) {
+            boolean originalAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            try {
+                IssueDependency saved = save(connection, dependency);
+                // 의존성 row와 blocked issue 이력은 같은 트랜잭션에서만 일관성을 보장한다.
+                insertTransientHistories(connection, blockedIssue.id(), blockedIssue.getHistories());
+                connection.commit();
+                connection.setAutoCommit(originalAutoCommit);
+                return saved;
+            } catch (SQLException | RuntimeException exception) {
+                rollback(connection);
+                connection.setAutoCommit(originalAutoCommit);
+                throw exception;
+            }
+        } catch (SQLException exception) {
+            throw new RepositoryException("Failed to save dependency with blocked issue history.", exception);
+        }
     }
 
     @Override
     public void deleteById(long dependencyId) {
-        String sql = "delete from issue_dependencies where id = ?";
-        try (Connection connection = connectionProvider.getConnection();
-             PreparedStatement statement = connection.prepareStatement(sql)) {
-            statement.setLong(1, dependencyId);
-            statement.executeUpdate();
+        try (Connection connection = connectionProvider.getConnection()) {
+            deleteById(connection, dependencyId);
         } catch (SQLException exception) {
             throw new RepositoryException("Failed to delete issue dependency.", exception);
+        }
+    }
+
+    @Override
+    public void deleteWithBlockedIssueHistory(IssueDependency dependency, Issue blockedIssue) {
+        try (Connection connection = connectionProvider.getConnection()) {
+            boolean originalAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            try {
+                deleteExactlyOneById(connection, dependency.id());
+                // 의존성 삭제와 제거 이력 저장은 하나의 persistence operation으로 취급한다.
+                insertTransientHistories(connection, blockedIssue.id(), blockedIssue.getHistories());
+                connection.commit();
+                connection.setAutoCommit(originalAutoCommit);
+            } catch (SQLException | RuntimeException exception) {
+                rollback(connection);
+                connection.setAutoCommit(originalAutoCommit);
+                throw exception;
+            }
+        } catch (SQLException exception) {
+            throw new RepositoryException("Failed to delete dependency with blocked issue history.", exception);
         }
     }
 
@@ -133,26 +178,30 @@ public final class JdbcIssueDependencyRepository implements IssueDependencyRepos
         }
     }
 
-    private IssueDependency insert(IssueDependency dependency) {
+    private IssueDependency save(Connection connection, IssueDependency dependency) throws SQLException {
+        if (dependency.id() == 0L) {
+            return insert(connection, dependency);
+        }
+        return update(connection, dependency);
+    }
+
+    private IssueDependency insert(Connection connection, IssueDependency dependency) throws SQLException {
         String sql = """
                 insert into issue_dependencies (dependency_id, blocking_issue_id, blocked_issue_id, discovered_date)
                 values (?, ?, ?, coalesce(?, current_timestamp))
                 """;
-        try (Connection connection = connectionProvider.getConnection();
-             PreparedStatement statement = JdbcSupport.prepareInsertReturningId(connection, sql)) {
+        try (PreparedStatement statement = JdbcSupport.prepareInsertReturningId(connection, sql)) {
             statement.setString(1, dependency.getDependencyId());
             statement.setLong(2, dependency.blockingIssueId());
             statement.setLong(3, dependency.blockedIssueId());
             JdbcSupport.setNullableTimestamp(statement, 4, dependency.discoveredDate());
             statement.executeUpdate();
-            return findById(JdbcSupport.generatedId(statement))
+            return findById(connection, JdbcSupport.generatedId(statement))
                     .orElseThrow(() -> new RepositoryException("Inserted dependency was not found.", null));
-        } catch (SQLException exception) {
-            throw new RepositoryException("Failed to insert issue dependency.", exception);
         }
     }
 
-    private IssueDependency update(IssueDependency dependency) {
+    private IssueDependency update(Connection connection, IssueDependency dependency) throws SQLException {
         String sql = """
                 update issue_dependencies
                 set dependency_id = ?,
@@ -161,18 +210,76 @@ public final class JdbcIssueDependencyRepository implements IssueDependencyRepos
                     discovered_date = coalesce(?, discovered_date)
                 where id = ?
                 """;
-        try (Connection connection = connectionProvider.getConnection();
-             PreparedStatement statement = connection.prepareStatement(sql)) {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, dependency.getDependencyId());
             statement.setLong(2, dependency.blockingIssueId());
             statement.setLong(3, dependency.blockedIssueId());
             JdbcSupport.setNullableTimestamp(statement, 4, dependency.discoveredDate());
             statement.setLong(5, dependency.id());
             statement.executeUpdate();
-            return findById(dependency.id())
+            return findById(connection, dependency.id())
                     .orElseThrow(() -> new RepositoryException("Updated dependency was not found.", null));
-        } catch (SQLException exception) {
-            throw new RepositoryException("Failed to update issue dependency.", exception);
+        }
+    }
+
+    private Optional<IssueDependency> findById(Connection connection, long dependencyId) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(FIND_BY_ID_SQL)) {
+            statement.setLong(1, dependencyId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return Optional.of(mapDependency(resultSet));
+                }
+                return Optional.empty();
+            }
+        }
+    }
+
+    private static void deleteExactlyOneById(Connection connection, long dependencyId) throws SQLException {
+        int affectedRows = deleteById(connection, dependencyId);
+        if (affectedRows != 1) {
+            throw new SQLException("Expected to delete exactly one issue dependency but deleted " + affectedRows + ".");
+        }
+    }
+
+    private static int deleteById(Connection connection, long dependencyId) throws SQLException {
+        String sql = "delete from issue_dependencies where id = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, dependencyId);
+            return statement.executeUpdate();
+        }
+    }
+
+    private static void insertTransientHistories(Connection connection, long issueId, List<IssueHistory> histories)
+            throws SQLException {
+        String sql = """
+                insert into issue_history (
+                    issue_id, changed_by_login_id, action_type, previous_value, new_value, message, changed_date
+                )
+                values (?, ?, ?, ?, ?, ?, coalesce(?, current_timestamp))
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            for (IssueHistory history : histories) {
+                if (history.id() != 0L) {
+                    continue;
+                }
+                statement.setLong(1, issueId);
+                statement.setString(2, history.changedById());
+                statement.setString(3, history.actionType().name());
+                JdbcSupport.setNullableString(statement, 4, history.previousValue());
+                JdbcSupport.setNullableString(statement, 5, history.newValue());
+                statement.setString(6, history.message());
+                JdbcSupport.setNullableTimestamp(statement, 7, history.changedDate());
+                statement.addBatch();
+            }
+            statement.executeBatch();
+        }
+    }
+
+    private static void rollback(Connection connection) {
+        try {
+            connection.rollback();
+        } catch (SQLException ignored) {
+            // 원래 repository 실패 원인을 유지한다.
         }
     }
 

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcRepositoryFactory.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcRepositoryFactory.java
@@ -4,6 +4,7 @@ import com.github.marcellokim.issuetracker.persistence.DatabaseConnectionProvide
 import com.github.marcellokim.issuetracker.persistence.DriverManagerConnectionProvider;
 import com.github.marcellokim.issuetracker.repository.AssignmentRecommendationRepository;
 import com.github.marcellokim.issuetracker.repository.CommentRepository;
+import com.github.marcellokim.issuetracker.repository.IssueDependencyChangeRepository;
 import com.github.marcellokim.issuetracker.repository.IssueDependencyRepository;
 import com.github.marcellokim.issuetracker.repository.IssueHistoryRepository;
 import com.github.marcellokim.issuetracker.repository.IssueRepository;
@@ -44,6 +45,10 @@ public final class JdbcRepositoryFactory {
     }
 
     public IssueDependencyRepository issueDependencies() {
+        return new JdbcIssueDependencyRepository(connectionProvider);
+    }
+
+    public IssueDependencyChangeRepository issueDependencyChanges() {
         return new JdbcIssueDependencyRepository(connectionProvider);
     }
 

--- a/src/main/java/com/github/marcellokim/issuetracker/repository/IssueDependencyChangeRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/repository/IssueDependencyChangeRepository.java
@@ -1,0 +1,11 @@
+package com.github.marcellokim.issuetracker.repository;
+
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueDependency;
+
+public interface IssueDependencyChangeRepository {
+
+    IssueDependency saveWithBlockedIssueHistory(IssueDependency dependency, Issue blockedIssue);
+
+    void deleteWithBlockedIssueHistory(IssueDependency dependency, Issue blockedIssue);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueDependencyResult.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueDependencyResult.java
@@ -1,0 +1,24 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.IssueDependency;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record IssueDependencyResult(
+        long id,
+        String dependencyId,
+        long blockingIssueId,
+        long blockedIssueId,
+        LocalDateTime discoveredDate
+) {
+
+    public static IssueDependencyResult from(IssueDependency dependency) {
+        IssueDependency target = Objects.requireNonNull(dependency, "dependency");
+        return new IssueDependencyResult(
+                target.id(),
+                target.getDependencyId(),
+                target.blockingIssueId(),
+                target.blockedIssueId(),
+                target.discoveredDate());
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueDependencyService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueDependencyService.java
@@ -1,0 +1,134 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueDependency;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.IssueDependencyChangeRepository;
+import com.github.marcellokim.issuetracker.repository.IssueDependencyRepository;
+import com.github.marcellokim.issuetracker.repository.IssueRepository;
+import com.github.marcellokim.issuetracker.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+public final class IssueDependencyService {
+
+    private final IssueRepository issueRepository;
+    private final IssueDependencyRepository dependencyRepository;
+    private final IssueDependencyChangeRepository dependencyChangeRepository;
+    private final UserRepository userRepository;
+    private final PermissionPolicy permissionPolicy;
+    private final Clock clock;
+
+    public IssueDependencyService(
+            IssueRepository issueRepository,
+            IssueDependencyRepository dependencyRepository,
+            IssueDependencyChangeRepository dependencyChangeRepository,
+            UserRepository userRepository,
+            PermissionPolicy permissionPolicy,
+            Clock clock
+    ) {
+        this.issueRepository = Objects.requireNonNull(issueRepository, "issueRepository");
+        this.dependencyRepository = Objects.requireNonNull(dependencyRepository, "dependencyRepository");
+        this.dependencyChangeRepository = Objects.requireNonNull(
+                dependencyChangeRepository,
+                "dependencyChangeRepository");
+        this.userRepository = Objects.requireNonNull(userRepository, "userRepository");
+        this.permissionPolicy = Objects.requireNonNull(permissionPolicy, "permissionPolicy");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    public IssueDependencyResult addDependency(long blockingIssueId, long blockedIssueId, String currentUserId) {
+        Issue blockingIssue = findIssue(blockingIssueId);
+        Issue blockedIssue = findIssue(blockedIssueId);
+        User actor = findUser(currentUserId);
+        permissionPolicy.assertCanManageDependency(actor, blockedIssue);
+        rejectSelfDependency(blockingIssueId, blockedIssueId);
+        rejectStoredDuplicate(blockingIssueId, blockedIssueId);
+        rejectCycle(blockingIssueId, blockedIssueId);
+
+        String dependencyKey = IssueDependency.dependencyIdFor(blockingIssue.id(), blockedIssue.id());
+        IssueDependency dependency = blockedIssue.addDependency(dependencyKey, blockingIssue, actor, now());
+        IssueDependency savedDependency = dependencyChangeRepository.saveWithBlockedIssueHistory(
+                dependency,
+                blockedIssue);
+        return IssueDependencyResult.from(savedDependency);
+    }
+
+    public List<IssueDependencyResult> listDependencies(long issueId, String currentUserId) {
+        Issue issue = findIssue(issueId);
+        User actor = findUser(currentUserId);
+        permissionPolicy.assertCanManageDependency(actor, issue);
+        return dependencyRepository.findByIssueId(issueId).stream()
+                .map(IssueDependencyResult::from)
+                .toList();
+    }
+
+    public void removeDependency(long dependencyId, String currentUserId) {
+        IssueDependency dependency = findDependency(dependencyId);
+        Issue blockedIssue = findIssue(dependency.blockedIssueId());
+        User actor = findUser(currentUserId);
+        permissionPolicy.assertCanManageDependency(actor, blockedIssue);
+        blockedIssue.recordDependencyRemoved(dependency, actor, now());
+        dependencyChangeRepository.deleteWithBlockedIssueHistory(dependency, blockedIssue);
+    }
+
+    private void rejectSelfDependency(long blockingIssueId, long blockedIssueId) {
+        if (blockingIssueId == blockedIssueId) {
+            throw new IllegalArgumentException("Issue cannot depend on itself");
+        }
+    }
+
+    private void rejectStoredDuplicate(long blockingIssueId, long blockedIssueId) {
+        if (dependencyRepository.existsByPair(blockingIssueId, blockedIssueId)) {
+            throw new IllegalArgumentException("Dependency already exists");
+        }
+    }
+
+    private void rejectCycle(long blockingIssueId, long blockedIssueId) {
+        if (reaches(blockedIssueId, blockingIssueId)) {
+            throw new IllegalArgumentException("Dependency cycle is not allowed");
+        }
+    }
+
+    private boolean reaches(long startIssueId, long targetIssueId) {
+        Set<Long> visitedIssueIds = new HashSet<>();
+        ArrayDeque<Long> pendingIssueIds = new ArrayDeque<>();
+        pendingIssueIds.add(startIssueId);
+        while (!pendingIssueIds.isEmpty()) {
+            long currentIssueId = pendingIssueIds.removeFirst();
+            if (!visitedIssueIds.add(currentIssueId)) {
+                continue;
+            }
+            if (currentIssueId == targetIssueId) {
+                return true;
+            }
+            dependencyRepository.findByBlockingIssueId(currentIssueId).stream()
+                    .map(IssueDependency::blockedIssueId)
+                    .forEach(pendingIssueIds::addLast);
+        }
+        return false;
+    }
+
+    private Issue findIssue(long issueId) {
+        return issueRepository.findById(issueId)
+                .orElseThrow(() -> new IllegalArgumentException("Issue not found: " + issueId));
+    }
+
+    private IssueDependency findDependency(long dependencyId) {
+        return dependencyRepository.findById(dependencyId)
+                .orElseThrow(() -> new IllegalArgumentException("Dependency not found: " + dependencyId));
+    }
+
+    private User findUser(String userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+    }
+
+    private LocalDateTime now() {
+        return clock.now();
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerCoverageTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerCoverageTest.java
@@ -32,6 +32,7 @@ import com.github.marcellokim.issuetracker.service.DeletedIssueService;
 import com.github.marcellokim.issuetracker.service.PermissionPolicy;
 import com.github.marcellokim.issuetracker.service.ProjectService;
 import com.github.marcellokim.issuetracker.service.StatisticsService;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueDependencyRepository;
 import com.github.marcellokim.issuetracker.technical.PasswordHasher;
 import com.github.marcellokim.issuetracker.technical.SessionStore;
 import java.time.LocalDate;
@@ -269,6 +270,15 @@ class ControllerCoverageTest {
         assertDoesNotThrow(() -> new IssueStateController(
                 auth.service(),
                 new com.github.marcellokim.issuetracker.service.IssueStateService(issues, users, policy, clock)));
+        assertDoesNotThrow(() -> new IssueDependencyController(
+                auth.service(),
+                new com.github.marcellokim.issuetracker.service.IssueDependencyService(
+                        issues,
+                        new InMemoryIssueDependencyRepository(),
+                        new InMemoryIssueDependencyRepository(),
+                        users,
+                        policy,
+                        clock)));
     }
 
     private static AuthFixture authenticated(Role role) {

--- a/src/test/java/com/github/marcellokim/issuetracker/controller/IssueDependencyControllerTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/controller/IssueDependencyControllerTest.java
@@ -1,0 +1,116 @@
+package com.github.marcellokim.issuetracker.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueDependency;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.Clock;
+import com.github.marcellokim.issuetracker.service.IssueDependencyResult;
+import com.github.marcellokim.issuetracker.service.IssueDependencyService;
+import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueDependencyRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.technical.PasswordHasher;
+import com.github.marcellokim.issuetracker.technical.SessionStore;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Issue dependency controller")
+class IssueDependencyControllerTest {
+
+    private static final long PROJECT_ID = 10L;
+    private static final String PASSWORD = "pass123";
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 21, 10, 0);
+
+    private final PasswordHasher hasher = new PasswordHasher();
+    private final User reporter = User.create("tester1", "Tester One", hasher.hash(PASSWORD), Role.TESTER, true,
+            NOW, NOW);
+    private final User pl = User.create("pl1", "PL One", hasher.hash(PASSWORD), Role.PL, true, NOW, NOW);
+
+    @Test
+    @DisplayName("authenticated PL adds, lists, and removes dependency")
+    void authenticatedAddListRemove() {
+        Issue blocking = issue(101L);
+        Issue blocked = issue(102L);
+        InMemoryIssueDependencyRepository dependencies = new InMemoryIssueDependencyRepository();
+        IssueDependencyController controller = authenticatedController(dependencies, blocking, blocked);
+
+        IssueDependencyResult added = controller.addDependency(blocking.id(), blocked.id());
+        List<IssueDependencyResult> listed = controller.listDependencies(blocked.id());
+        controller.removeDependency(added.id());
+
+        assertEquals(blocking.id(), added.blockingIssueId());
+        assertEquals(blocked.id(), added.blockedIssueId());
+        assertEquals(List.of(added.id()), listed.stream().map(IssueDependencyResult::id).toList());
+        assertEquals(List.of(), dependencies.findAll());
+    }
+
+    @Test
+    @DisplayName("unauthenticated add, list, and remove are rejected")
+    void rejectUnauthenticated() {
+        Issue blocking = issue(101L);
+        Issue blocked = issue(102L);
+        IssueDependency dependency = IssueDependency.fromPersistence(1L, blocking.id(), blocked.id(), NOW);
+        IssueDependencyController controller = unauthenticatedController(
+                new InMemoryIssueDependencyRepository(dependency),
+                blocking,
+                blocked);
+
+        assertThrows(SecurityException.class, () -> controller.addDependency(blocking.id(), blocked.id()));
+        assertThrows(SecurityException.class, () -> controller.listDependencies(blocked.id()));
+        assertThrows(SecurityException.class, () -> controller.removeDependency(dependency.id()));
+    }
+
+    private IssueDependencyController authenticatedController(
+            InMemoryIssueDependencyRepository dependencies,
+            Issue... issues
+    ) {
+        InMemoryUserRepository users = new InMemoryUserRepository(reporter, pl);
+        SessionStore sessionStore = new SessionStore();
+        AuthenticationService authService = new AuthenticationService(users, hasher, sessionStore);
+        authService.login(pl.getLoginId(), PASSWORD);
+        return new IssueDependencyController(authService, dependencyService(users, dependencies, issues));
+    }
+
+    private IssueDependencyController unauthenticatedController(
+            InMemoryIssueDependencyRepository dependencies,
+            Issue... issues
+    ) {
+        InMemoryUserRepository users = new InMemoryUserRepository(reporter, pl);
+        AuthenticationService authService = new AuthenticationService(users, hasher, new SessionStore());
+        return new IssueDependencyController(authService, dependencyService(users, dependencies, issues));
+    }
+
+    private IssueDependencyService dependencyService(
+            InMemoryUserRepository users,
+            InMemoryIssueDependencyRepository dependencies,
+            Issue... issues
+    ) {
+        return new IssueDependencyService(
+                new InMemoryIssueRepository(issues),
+                dependencies,
+                dependencies,
+                users,
+                new PermissionPolicy(),
+                new Clock());
+    }
+
+    private Issue issue(long id) {
+        return Issue.fromPersistence(Issue.persistedState(PROJECT_ID, "Issue " + id, "Dependency test", reporter)
+                .id(id)
+                .issueId("ISSUE-" + id)
+                .reportedDate(NOW)
+                .priority(Priority.MAJOR)
+                .status(IssueStatus.NEW)
+                .updatedAt(NOW));
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/persistence/OracleRepositoryIntegrationTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/persistence/OracleRepositoryIntegrationTest.java
@@ -687,6 +687,133 @@ class OracleRepositoryIntegrationTest {
     }
 
     @Test
+    @DisplayName("IssueDependency change repository saves dependency and blocked issue history atomically")
+    void issueDependencyChangeRepositorySavesDependencyAndHistory() {
+        var project = repositories.projects().findByName("project1").orElseThrow();
+        Issue blocking = createIssue(project.getId(), uniqueId("change_save_blocking_issue"));
+        Issue blocked = createIssue(project.getId(), uniqueId("change_save_blocked_issue"));
+        IssueDependency dependency = null;
+
+        try {
+            dependency = blocked.addDependency(
+                    IssueDependency.dependencyIdFor(blocking.id(), blocked.id()),
+                    blocking,
+                    user("pl1"),
+                    LocalDateTime.now());
+
+            IssueDependency saved = repositories.issueDependencyChanges()
+                    .saveWithBlockedIssueHistory(dependency, blocked);
+
+            assertEquals(saved.id(), repositories.issueDependencies().findById(saved.id()).orElseThrow().id());
+            assertEquals(1, dependencyHistoryCount(blocked.id(), saved.getDependencyId(), "Dependency added"));
+        } finally {
+            if (dependency != null && dependency.id() != 0L) {
+                repositories.issueDependencies().deleteById(dependency.id());
+            }
+            repositories.issueDependencies().deleteByIssueId(blocked.id());
+            repositories.issues().purge(blocked.id());
+            repositories.issues().purge(blocking.id());
+        }
+    }
+
+    @Test
+    @DisplayName("IssueDependency change repository rolls back duplicate dependency history")
+    void issueDependencyChangeRepositoryRollsBackDuplicateHistory() {
+        var project = repositories.projects().findByName("project1").orElseThrow();
+        Issue blocking = createIssue(project.getId(), uniqueId("change_duplicate_blocking_issue"));
+        Issue blocked = createIssue(project.getId(), uniqueId("change_duplicate_blocked_issue"));
+
+        try {
+            IssueDependency dependency = blocked.addDependency(
+                    IssueDependency.dependencyIdFor(blocking.id(), blocked.id()),
+                    blocking,
+                    user("pl1"),
+                    LocalDateTime.now());
+            IssueDependency saved = repositories.issueDependencyChanges()
+                    .saveWithBlockedIssueHistory(dependency, blocked);
+            int historyCountBeforeDuplicate = dependencyHistoryCount(
+                    blocked.id(),
+                    saved.getDependencyId(),
+                    "Dependency added");
+
+            Issue duplicateBlocked = copyIssueForDependencyChange(blocked);
+            IssueDependency duplicate = duplicateBlocked.addDependency(
+                    IssueDependency.dependencyIdFor(blocking.id(), duplicateBlocked.id()),
+                    blocking,
+                    user("pl1"),
+                    LocalDateTime.now());
+
+            assertThrows(RepositoryException.class,
+                    () -> repositories.issueDependencyChanges()
+                            .saveWithBlockedIssueHistory(duplicate, duplicateBlocked));
+
+            assertEquals(1, repositories.issueDependencies().findByIssueId(blocked.id()).size());
+            assertEquals(historyCountBeforeDuplicate,
+                    dependencyHistoryCount(blocked.id(), saved.getDependencyId(), "Dependency added"));
+        } finally {
+            repositories.issueDependencies().deleteByIssueId(blocked.id());
+            repositories.issues().purge(blocked.id());
+            repositories.issues().purge(blocking.id());
+        }
+    }
+
+    @Test
+    @DisplayName("IssueDependency change repository deletes dependency and records removal history atomically")
+    void issueDependencyChangeRepositoryDeletesDependencyAndHistory() {
+        var project = repositories.projects().findByName("project1").orElseThrow();
+        Issue blocking = createIssue(project.getId(), uniqueId("change_delete_blocking_issue"));
+        Issue blocked = createIssue(project.getId(), uniqueId("change_delete_blocked_issue"));
+
+        try {
+            IssueDependency saved = repositories.issueDependencies().save(IssueDependency.fromPersistence(
+                    0L,
+                    blocking.id(),
+                    blocked.id(),
+                    LocalDateTime.now()));
+            blocked.recordDependencyRemoved(saved, user("pl1"), LocalDateTime.now());
+
+            repositories.issueDependencyChanges().deleteWithBlockedIssueHistory(saved, blocked);
+
+            assertTrue(repositories.issueDependencies().findById(saved.id()).isEmpty());
+            assertEquals(1, dependencyHistoryCount(blocked.id(), saved.getDependencyId(), "Dependency removed"));
+        } finally {
+            repositories.issueDependencies().deleteByIssueId(blocked.id());
+            repositories.issues().purge(blocked.id());
+            repositories.issues().purge(blocking.id());
+        }
+    }
+
+    @Test
+    @DisplayName("IssueDependency change repository rejects stale delete without removal history")
+    void issueDependencyChangeRepositoryRejectsStaleDeleteWithoutHistory() {
+        var project = repositories.projects().findByName("project1").orElseThrow();
+        Issue blocking = createIssue(project.getId(), uniqueId("change_stale_delete_blocking_issue"));
+        Issue blocked = createIssue(project.getId(), uniqueId("change_stale_delete_blocked_issue"));
+        IssueDependency saved = null;
+
+        try {
+            saved = repositories.issueDependencies().save(IssueDependency.fromPersistence(
+                    0L,
+                    blocking.id(),
+                    blocked.id(),
+                    LocalDateTime.now()));
+            repositories.issueDependencies().deleteById(saved.id());
+            blocked.recordDependencyRemoved(saved, user("pl1"), LocalDateTime.now());
+
+            IssueDependency staleDependency = saved;
+            assertThrows(RepositoryException.class,
+                    () -> repositories.issueDependencyChanges()
+                            .deleteWithBlockedIssueHistory(staleDependency, blocked));
+
+            assertEquals(0, dependencyHistoryCount(blocked.id(), saved.getDependencyId(), "Dependency removed"));
+        } finally {
+            repositories.issueDependencies().deleteByIssueId(blocked.id());
+            repositories.issues().purge(blocked.id());
+            repositories.issues().purge(blocking.id());
+        }
+    }
+
+    @Test
     @DisplayName("Statistics and recommendation repositories reflect saved resolved issues")
     void statisticsAndRecommendationRepositoriesReflectSavedResolvedIssues() {
         var project = repositories.projects().findByName("project1").orElseThrow();
@@ -788,6 +915,33 @@ class OracleRepositoryIntegrationTest {
         }
 
         return repositories.issues().save(Issue.newForPersistence(state));
+    }
+
+    private static Issue copyIssueForDependencyChange(Issue issue) {
+        return Issue.fromPersistence(Issue.persistedState(
+                issue.projectId(),
+                issue.title(),
+                issue.description(),
+                issue.getReporter())
+                .id(issue.id())
+                .issueId(issue.getIssueId())
+                .reportedDate(issue.reportedDate())
+                .priority(issue.priority())
+                .status(issue.status())
+                .assignee(issue.getAssignee())
+                .verifier(issue.getVerifier())
+                .fixer(issue.getFixer())
+                .resolver(issue.getResolver())
+                .updatedAt(issue.updatedAt()));
+    }
+
+    private static int dependencyHistoryCount(long issueId, String dependencyId, String message) {
+        return (int) repositories.issueHistory().findByIssueId(issueId).stream()
+                .filter(history -> history.actionType() == ActionType.DEPENDENCY_CHANGED)
+                .filter(history -> dependencyId.equals(history.previousValue())
+                        || dependencyId.equals(history.newValue()))
+                .filter(history -> message.equals(history.message()))
+                .count();
     }
 
     private static User user(String loginId) {

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueDependencyServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueDependencyServiceTest.java
@@ -1,0 +1,339 @@
+package com.github.marcellokim.issuetracker.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.marcellokim.issuetracker.domain.ActionType;
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueDependency;
+import com.github.marcellokim.issuetracker.domain.IssueHistory;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.IssueDependencyChangeRepository;
+import com.github.marcellokim.issuetracker.repository.IssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueDependencyRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Issue dependency service")
+class IssueDependencyServiceTest {
+
+    private static final long PROJECT_ID = 10L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 21, 10, 0);
+
+    private final User reporter = User.create("tester1", "Tester One", "hash", Role.TESTER, true, NOW, NOW);
+    private final User pl = User.create("pl1", "PL One", "hash", Role.PL, true, NOW, NOW);
+    private final User dev = User.create("dev1", "Dev One", "hash", Role.DEV, true, NOW, NOW);
+
+    @Test
+    @DisplayName("PL adds dependency with blocking and blocked direction and dependency history")
+    void plAddsDependencyWithDirectionAndHistory() {
+        Issue blocking = issue(101L);
+        Issue blocked = issue(102L);
+        InMemoryIssueDependencyRepository dependencies = new InMemoryIssueDependencyRepository();
+        IssueDependencyService service = service(new InMemoryIssueRepository(blocking, blocked), dependencies);
+
+        IssueDependencyResult result = service.addDependency(blocking.id(), blocked.id(), pl.getLoginId());
+
+        assertEquals(1L, result.id());
+        assertEquals(IssueDependency.dependencyIdFor(blocking.id(), blocked.id()), result.dependencyId());
+        assertEquals(blocking.id(), result.blockingIssueId());
+        assertEquals(blocked.id(), result.blockedIssueId());
+        assertEquals(List.of(blocking.id()), dependencies.findByIssueId(blocked.id()).stream()
+                .map(IssueDependency::blockingIssueId)
+                .toList());
+
+        IssueHistory history = dependencyHistory(blocked);
+        assertEquals(ActionType.DEPENDENCY_CHANGED, history.getAction());
+        assertNull(history.getPreviousValue());
+        assertEquals(result.dependencyId(), history.getNewValue());
+        assertEquals("Dependency added", history.getMessage());
+    }
+
+    @Test
+    @DisplayName("add delegates relation and blocked issue history write to change repository")
+    void addDelegatesWriteThroughChangeRepository() {
+        Issue blocking = issue(101L);
+        Issue blocked = issue(102L);
+        TrackingIssueRepository issues = new TrackingIssueRepository(blocking, blocked);
+        InMemoryIssueDependencyRepository dependencies = new InMemoryIssueDependencyRepository();
+        SpyDependencyChangeRepository changes = new SpyDependencyChangeRepository(dependencies);
+        IssueDependencyService service = service(issues, dependencies, changes);
+
+        IssueDependencyResult result = service.addDependency(blocking.id(), blocked.id(), pl.getLoginId());
+
+        assertEquals(result.dependencyId(), changes.savedDependency.getDependencyId());
+        assertEquals(blocked, changes.savedBlockedIssue);
+        assertEquals(1, changes.saveCalls);
+        assertEquals(0, issues.saveCalls);
+    }
+
+    @Test
+    @DisplayName("list includes incoming and outgoing dependencies for an issue")
+    void listIncludesIncomingAndOutgoingDependencies() {
+        Issue a = issue(101L);
+        Issue b = issue(102L);
+        Issue c = issue(103L);
+        InMemoryIssueDependencyRepository dependencies = new InMemoryIssueDependencyRepository(
+                persistedDependency(1L, a.id(), b.id()),
+                persistedDependency(2L, b.id(), c.id()));
+        IssueDependencyService service = service(new InMemoryIssueRepository(a, b, c), dependencies);
+
+        List<IssueDependencyResult> results = service.listDependencies(b.id(), pl.getLoginId());
+
+        assertEquals(List.of(1L, 2L), results.stream().map(IssueDependencyResult::id).toList());
+        assertEquals(List.of(a.id(), b.id()), results.stream().map(IssueDependencyResult::blockingIssueId).toList());
+        assertEquals(List.of(b.id(), c.id()), results.stream().map(IssueDependencyResult::blockedIssueId).toList());
+    }
+
+    @Test
+    @DisplayName("self dependency is rejected before save and has no history side effect")
+    void rejectSelfDependencyBeforeSaveAndHistory() {
+        Issue issue = issue(101L);
+        InMemoryIssueDependencyRepository dependencies = new InMemoryIssueDependencyRepository();
+        IssueDependencyService service = service(new InMemoryIssueRepository(issue), dependencies);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.addDependency(issue.id(), issue.id(), pl.getLoginId()));
+
+        assertEquals(List.of(), dependencies.findAll());
+        assertFalse(hasDependencyHistory(issue));
+    }
+
+    @Test
+    @DisplayName("stored duplicate is rejected even without hydrated aggregate dependency")
+    void rejectStoredDuplicateWithoutHydratedAggregateDependency() {
+        Issue blocking = issue(101L);
+        Issue blocked = issue(102L);
+        InMemoryIssueDependencyRepository dependencies = new InMemoryIssueDependencyRepository(
+                persistedDependency(1L, blocking.id(), blocked.id()));
+        IssueDependencyService service = service(new InMemoryIssueRepository(blocking, blocked), dependencies);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.addDependency(blocking.id(), blocked.id(), pl.getLoginId()));
+
+        assertEquals(1, dependencies.findAll().size());
+        assertFalse(hasDependencyHistory(blocked));
+    }
+
+    @Test
+    @DisplayName("existing A -> B -> C chain rejects C -> A cycle")
+    void rejectCycleAcrossExistingRepositoryEdges() {
+        Issue a = issue(101L);
+        Issue b = issue(102L);
+        Issue c = issue(103L);
+        InMemoryIssueDependencyRepository dependencies = new InMemoryIssueDependencyRepository(
+                persistedDependency(1L, a.id(), b.id()),
+                persistedDependency(2L, b.id(), c.id()));
+        IssueDependencyService service = service(new InMemoryIssueRepository(a, b, c), dependencies);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.addDependency(c.id(), a.id(), pl.getLoginId()));
+
+        assertEquals(2, dependencies.findAll().size());
+        assertFalse(hasDependencyHistory(a));
+    }
+
+    @Test
+    @DisplayName("remove deletes dependency and records blocked issue dependency history")
+    void removeDeletesAndRecordsBlockedIssueHistory() {
+        Issue blocking = issue(101L);
+        Issue blocked = issue(102L);
+        IssueDependency dependency = persistedDependency(1L, blocking.id(), blocked.id());
+        InMemoryIssueDependencyRepository dependencies = new InMemoryIssueDependencyRepository(dependency);
+        IssueDependencyService service = service(new InMemoryIssueRepository(blocking, blocked), dependencies);
+
+        service.removeDependency(dependency.id(), pl.getLoginId());
+
+        assertEquals(List.of(), dependencies.findAll());
+        IssueHistory history = dependencyHistory(blocked);
+        assertEquals(ActionType.DEPENDENCY_CHANGED, history.getAction());
+        assertEquals(dependency.getDependencyId(), history.getPreviousValue());
+        assertNull(history.getNewValue());
+        assertEquals("Dependency removed", history.getMessage());
+    }
+
+    @Test
+    @DisplayName("remove delegates relation delete and blocked issue history write to change repository")
+    void removeDelegatesWriteThroughChangeRepository() {
+        Issue blocking = issue(101L);
+        Issue blocked = issue(102L);
+        IssueDependency dependency = persistedDependency(1L, blocking.id(), blocked.id());
+        TrackingIssueRepository issues = new TrackingIssueRepository(blocking, blocked);
+        InMemoryIssueDependencyRepository dependencies = new InMemoryIssueDependencyRepository(dependency);
+        SpyDependencyChangeRepository changes = new SpyDependencyChangeRepository(dependencies);
+        IssueDependencyService service = service(issues, dependencies, changes);
+
+        service.removeDependency(dependency.id(), pl.getLoginId());
+
+        assertEquals(dependency.getDependencyId(), changes.deletedDependency.getDependencyId());
+        assertEquals(blocked, changes.deletedBlockedIssue);
+        assertEquals(1, changes.deleteCalls);
+        assertEquals(0, issues.saveCalls);
+    }
+
+    @Test
+    @DisplayName("non-PL cannot add or list dependencies")
+    void rejectNonPlAddAndList() {
+        Issue blocking = issue(101L);
+        Issue blocked = issue(102L);
+        IssueDependencyService service = service(new InMemoryIssueRepository(blocking, blocked),
+                new InMemoryIssueDependencyRepository());
+
+        assertThrows(SecurityException.class,
+                () -> service.addDependency(blocking.id(), blocked.id(), dev.getLoginId()));
+        assertThrows(SecurityException.class,
+                () -> service.listDependencies(blocked.id(), dev.getLoginId()));
+    }
+
+    private IssueDependencyService service(
+            InMemoryIssueRepository issues,
+            InMemoryIssueDependencyRepository dependencies
+    ) {
+        return service(issues, dependencies, dependencies);
+    }
+
+    private IssueDependencyService service(
+            IssueRepository issues,
+            InMemoryIssueDependencyRepository dependencies,
+            IssueDependencyChangeRepository changes
+    ) {
+        return new IssueDependencyService(
+                issues,
+                dependencies,
+                changes,
+                new InMemoryUserRepository(reporter, pl, dev),
+                new PermissionPolicy(),
+                new Clock());
+    }
+
+    private Issue issue(long id) {
+        return Issue.fromPersistence(Issue.persistedState(PROJECT_ID, "Issue " + id, "Dependency test", reporter)
+                .id(id)
+                .issueId("ISSUE-" + id)
+                .reportedDate(NOW)
+                .priority(Priority.MAJOR)
+                .status(IssueStatus.NEW)
+                .updatedAt(NOW));
+    }
+
+    private static IssueDependency persistedDependency(long id, long blockingIssueId, long blockedIssueId) {
+        return IssueDependency.fromPersistence(id, blockingIssueId, blockedIssueId, NOW);
+    }
+
+    private static IssueHistory dependencyHistory(Issue issue) {
+        return issue.getHistories().stream()
+                .filter(history -> history.getAction() == ActionType.DEPENDENCY_CHANGED)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Dependency history not found"));
+    }
+
+    private static boolean hasDependencyHistory(Issue issue) {
+        return issue.getHistories().stream()
+                .anyMatch(history -> history.getAction() == ActionType.DEPENDENCY_CHANGED);
+    }
+
+    private static final class SpyDependencyChangeRepository implements IssueDependencyChangeRepository {
+
+        private final InMemoryIssueDependencyRepository delegate;
+        private IssueDependency savedDependency;
+        private Issue savedBlockedIssue;
+        private IssueDependency deletedDependency;
+        private Issue deletedBlockedIssue;
+        private int saveCalls;
+        private int deleteCalls;
+
+        private SpyDependencyChangeRepository(InMemoryIssueDependencyRepository delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public IssueDependency saveWithBlockedIssueHistory(IssueDependency dependency, Issue blockedIssue) {
+            saveCalls++;
+            savedDependency = dependency;
+            savedBlockedIssue = blockedIssue;
+            return delegate.save(dependency);
+        }
+
+        @Override
+        public void deleteWithBlockedIssueHistory(IssueDependency dependency, Issue blockedIssue) {
+            deleteCalls++;
+            deletedDependency = dependency;
+            deletedBlockedIssue = blockedIssue;
+            delegate.deleteById(dependency.id());
+        }
+    }
+
+    private static final class TrackingIssueRepository implements IssueRepository {
+
+        private final Map<Long, Issue> issues = new LinkedHashMap<>();
+        private int saveCalls;
+
+        private TrackingIssueRepository(Issue... issues) {
+            for (Issue issue : issues) {
+                this.issues.put(issue.id(), issue);
+            }
+        }
+
+        @Override
+        public Optional<Issue> findById(long issueId) {
+            return Optional.ofNullable(issues.get(issueId));
+        }
+
+        @Override
+        public List<Issue> findByProject(long projectId) {
+            return issues.values().stream()
+                    .filter(issue -> issue.projectId() == projectId)
+                    .toList();
+        }
+
+        @Override
+        public List<Issue> findDeletedByProject(long projectId) {
+            return List.of();
+        }
+
+        @Override
+        public List<Issue> findByCriteria(com.github.marcellokim.issuetracker.domain.IssueSearchCriteria criteria) {
+            return new ArrayList<>(issues.values());
+        }
+
+        @Override
+        public Issue save(Issue issue) {
+            saveCalls++;
+            issues.put(issue.id(), issue);
+            return issue;
+        }
+
+        @Override
+        public Issue softDelete(long issueId, String changedById, String message, LocalDateTime changedDate) {
+            throw new UnsupportedOperationException("softDelete is not needed by these service tests");
+        }
+
+        @Override
+        public Issue restore(long issueId, String changedById, String message, LocalDateTime changedDate) {
+            throw new UnsupportedOperationException("restore is not needed by these service tests");
+        }
+
+        @Override
+        public int purgeDeletedBeyondLimit(long projectId, int maxDeletedIssues) {
+            return 0;
+        }
+
+        @Override
+        public void purge(long issueId) {
+            issues.remove(issueId);
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/support/InMemoryIssueDependencyRepository.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/support/InMemoryIssueDependencyRepository.java
@@ -1,0 +1,101 @@
+package com.github.marcellokim.issuetracker.support;
+
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueDependency;
+import com.github.marcellokim.issuetracker.repository.IssueDependencyChangeRepository;
+import com.github.marcellokim.issuetracker.repository.IssueDependencyRepository;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public final class InMemoryIssueDependencyRepository
+        implements IssueDependencyRepository, IssueDependencyChangeRepository {
+
+    private final Map<Long, IssueDependency> dependencies = new LinkedHashMap<>();
+    private long nextId = 1L;
+
+    public InMemoryIssueDependencyRepository(IssueDependency... dependencies) {
+        for (IssueDependency dependency : dependencies) {
+            save(dependency);
+        }
+    }
+
+    @Override
+    public Optional<IssueDependency> findById(long dependencyId) {
+        return Optional.ofNullable(dependencies.get(dependencyId));
+    }
+
+    @Override
+    public List<IssueDependency> findByIssueId(long issueId) {
+        return dependencies.values().stream()
+                .filter(dependency -> dependency.blockingIssueId() == issueId || dependency.blockedIssueId() == issueId)
+                .toList();
+    }
+
+    @Override
+    public List<IssueDependency> findByBlockingIssueId(long blockingIssueId) {
+        return dependencies.values().stream()
+                .filter(dependency -> dependency.blockingIssueId() == blockingIssueId)
+                .toList();
+    }
+
+    @Override
+    public List<IssueDependency> findByBlockedIssueId(long blockedIssueId) {
+        return dependencies.values().stream()
+                .filter(dependency -> dependency.blockedIssueId() == blockedIssueId)
+                .toList();
+    }
+
+    @Override
+    public boolean existsByPair(long blockingIssueId, long blockedIssueId) {
+        return dependencies.values().stream()
+                .anyMatch(dependency -> dependency.blockingIssueId() == blockingIssueId
+                        && dependency.blockedIssueId() == blockedIssueId);
+    }
+
+    @Override
+    public IssueDependency save(IssueDependency dependency) {
+        IssueDependency saved = dependency.id() == 0L
+                ? IssueDependency.fromPersistence(
+                        nextId++,
+                        dependency.getDependencyId(),
+                        dependency.blockingIssueId(),
+                        dependency.blockedIssueId(),
+                        dependency.discoveredDate())
+                : dependency;
+        dependencies.put(saved.id(), saved);
+        if (saved.id() >= nextId) {
+            nextId = saved.id() + 1L;
+        }
+        return saved;
+    }
+
+    @Override
+    public IssueDependency saveWithBlockedIssueHistory(IssueDependency dependency, Issue blockedIssue) {
+        return save(dependency);
+    }
+
+    @Override
+    public void deleteById(long dependencyId) {
+        dependencies.remove(dependencyId);
+    }
+
+    @Override
+    public void deleteWithBlockedIssueHistory(IssueDependency dependency, Issue blockedIssue) {
+        deleteById(dependency.id());
+    }
+
+    @Override
+    public void deleteByIssueId(long issueId) {
+        new ArrayList<>(dependencies.values()).stream()
+                .filter(dependency -> dependency.blockingIssueId() == issueId || dependency.blockedIssueId() == issueId)
+                .map(IssueDependency::id)
+                .forEach(dependencies::remove);
+    }
+
+    public List<IssueDependency> findAll() {
+        return List.copyOf(dependencies.values());
+    }
+}


### PR DESCRIPTION
## 요약
- UC7 dependency add/list/remove 흐름을 `IssueDependencyController -> IssueDependencyService` 경계로 추가했습니다.
- 자기 의존성, 저장소 기준 중복 dependency, 순환 dependency를 service 계층에서 검증합니다.
- dependency row와 blocked issue의 `DEPENDENCY_CHANGED` 이력을 `IssueDependencyChangeRepository`의 atomic persistence 경로로 저장하도록 분리했습니다.
- `Priority.BLOCKER`는 우선순위 값으로만 유지하고 dependency edge와 섞지 않는다는 구현 메모를 문서에 반영했습니다.

## 검증
- `./gradlew test --tests com.github.marcellokim.issuetracker.service.IssueDependencyServiceTest --tests com.github.marcellokim.issuetracker.controller.IssueDependencyControllerTest --tests com.github.marcellokim.issuetracker.domain.IssueDependencyTest --tests com.github.marcellokim.issuetracker.controller.ControllerCoverageTest --console=plain`
- `./gradlew test --tests com.github.marcellokim.issuetracker.persistence.OracleRepositoryIntegrationTest --console=plain` (로컬에서는 `ITS_DB_INTEGRATION_TESTS=true`가 없어 Oracle integration test가 compile 후 skip됨)
- `git diff --check`
- `./gradlew check --console=plain`

## 관련 PR
- 이전 PR: #132

## 관련 이슈
- Refs #45
