### PR TITLE
feat: dependency resolve guard 추가

### DIFF
--- a/docs/uml/dcd/dcd_implementation_details.md
+++ b/docs/uml/dcd/dcd_implementation_details.md
@@ -108,6 +108,7 @@ IssueStateService
   -> IssueRepository
   -> UserRepository
   -> PermissionPolicy
+  -> IssueResolutionGuard
   -> Clock
 `IssueStateController`의 책임은 다음이다.
 
@@ -121,6 +122,7 @@ IssueStateService
 - 현재 사용자 조회
 - target status별 권한 검사
 - 필수 comment 검증
+- `targetStatus=RESOLVED`일 때만 `IssueResolutionGuard` 호출
 - `Issue.markFixed`, `Issue.resolve`, `Issue.rejectFix`, `Issue.close`, `Issue.reopen` domain operation 호출
 - comment 기록
 - 변경된 issue 저장
@@ -128,6 +130,8 @@ IssueStateService
 #43 Tester reject fix는 같은 구조로 구현한다. 별도 operation 이름을 만들지 않고 `changeStatus(issueId, targetStatus=ASSIGNED, comment)` branch에서 `Issue.rejectFix`를 호출한다.
 
 #47 Reopen은 같은 `changeStatus(issueId, targetStatus=REOPENED, comment)` route에서 구현한다. `Issue.reopen`이 assignee/verifier 제거와 fixer/resolver 보존 정책을 소유하고, PL 권한 검사는 `PermissionPolicy`가 담당한다.
+
+#98 dependency-based resolve guard는 `IssueStateService`의 RESOLVED branch에서만 실행한다. `DependencyResolutionGuard`는 blocked issue의 dependency edge를 `IssueDependencyRepository.findByBlockedIssueId(issue.id())`로 읽고, 각 blocking issue를 `IssueRepository`에서 조회한다. 모든 blocker가 `RESOLVED` 또는 `CLOSED` 상태일 때만 FIXED -> RESOLVED 전이를 허용하며, 누락되었거나 아직 완료되지 않은 blocker가 있으면 domain mutation과 status-change comment 기록 전에 실패한다. 이 정책은 `BLOCK`/`BLOCKED` 상태를 추가하지 않고, `Priority.BLOCKER`도 사용하지 않는다.
 
 ### Issue Dependency Flow
 
@@ -162,7 +166,7 @@ IssueDependencyService
 
 `IssueDependencyChangeRepository`는 dependency relation row와 blocked issue의 `DEPENDENCY_CHANGED` history를 하나의 persistence operation으로 묶는 write contract이다. JDBC 구현에서는 같은 connection에서 autocommit을 끄고 dependency insert/update 또는 delete와 transient history insert를 같은 transaction으로 commit한다. 삭제 경로는 stale dependency id가 이력만 남기는 것을 막기 위해 정확히 1개 row가 삭제된 경우에만 removal history를 insert한다. 따라서 service는 dependency 저장/삭제 뒤에 `IssueRepository.save(blockedIssue)`를 별도로 호출하지 않는다.
 
-이 경계에서 `Priority.BLOCKER`는 dependency workflow와 분리한다. BLOCKER priority는 우선순위 값이고, #45의 dependency 추가/목록/삭제는 `IssueDependency` 관계와 `DEPENDENCY_CHANGED` 이력만 다룬다. FIXED -> RESOLVED dependency guard(#98)는 이 slice에 포함하지 않고 status workflow/service 쪽 정책으로 남긴다.
+이 경계에서 `Priority.BLOCKER`는 dependency workflow와 분리한다. BLOCKER priority는 우선순위 값이고, #45의 dependency 추가/목록/삭제는 `IssueDependency` 관계와 `DEPENDENCY_CHANGED` 이력만 다룬다. FIXED -> RESOLVED dependency guard(#98)는 dependency CRUD를 변경하지 않고 status workflow/service 쪽 resolve eligibility 정책으로 둔다.
 
 ## 구현 가이드라인
 

--- a/src/main/java/com/github/marcellokim/issuetracker/service/DependencyResolutionGuard.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/DependencyResolutionGuard.java
@@ -1,0 +1,39 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.repository.IssueDependencyRepository;
+import com.github.marcellokim.issuetracker.repository.IssueRepository;
+import java.util.Objects;
+
+public final class DependencyResolutionGuard implements IssueResolutionGuard {
+
+    private final IssueRepository issueRepository;
+    private final IssueDependencyRepository dependencyRepository;
+
+    public DependencyResolutionGuard(
+            IssueRepository issueRepository,
+            IssueDependencyRepository dependencyRepository
+    ) {
+        this.issueRepository = Objects.requireNonNull(issueRepository, "issueRepository");
+        this.dependencyRepository = Objects.requireNonNull(dependencyRepository, "dependencyRepository");
+    }
+
+    @Override
+    public void assertCanResolve(Issue issue) {
+        Objects.requireNonNull(issue, "issue");
+        for (var dependency : dependencyRepository.findByBlockedIssueId(issue.id())) {
+            Issue blockingIssue = issueRepository.findById(dependency.blockingIssueId())
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Blocking issue not found: " + dependency.blockingIssueId()));
+            if (!isCompleted(blockingIssue)) {
+                throw new IllegalStateException("Blocking issue is not completed: " + blockingIssue.id());
+            }
+        }
+    }
+
+    private static boolean isCompleted(Issue issue) {
+        // dependency edge는 Priority.BLOCKER가 아니며, 이 guard는 RESOLVED 전이 가능 여부만 확인한다.
+        return issue.status() == IssueStatus.RESOLVED || issue.status() == IssueStatus.CLOSED;
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueResolutionGuard.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueResolutionGuard.java
@@ -1,0 +1,14 @@
+package com.github.marcellokim.issuetracker.service;
+
+import com.github.marcellokim.issuetracker.domain.Issue;
+
+@FunctionalInterface
+public interface IssueResolutionGuard {
+
+    void assertCanResolve(Issue issue);
+
+    static IssueResolutionGuard none() {
+        return issue -> {
+        };
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java
@@ -15,6 +15,7 @@ public final class IssueStateService {
     private final UserRepository userRepository;
     private final PermissionPolicy permissionPolicy;
     private final Clock clock;
+    private final IssueResolutionGuard resolutionGuard;
 
     public IssueStateService(
             IssueRepository issueRepository,
@@ -22,10 +23,21 @@ public final class IssueStateService {
             PermissionPolicy permissionPolicy,
             Clock clock
     ) {
+        this(issueRepository, userRepository, permissionPolicy, clock, IssueResolutionGuard.none());
+    }
+
+    public IssueStateService(
+            IssueRepository issueRepository,
+            UserRepository userRepository,
+            PermissionPolicy permissionPolicy,
+            Clock clock,
+            IssueResolutionGuard resolutionGuard
+    ) {
         this.issueRepository = Objects.requireNonNull(issueRepository, "issueRepository");
         this.userRepository = Objects.requireNonNull(userRepository, "userRepository");
         this.permissionPolicy = Objects.requireNonNull(permissionPolicy, "permissionPolicy");
         this.clock = Objects.requireNonNull(clock, "clock");
+        this.resolutionGuard = Objects.requireNonNull(resolutionGuard, "resolutionGuard");
     }
 
     public IssueStateResult changeStatus(long issueId, IssueStatus targetStatus, String comment, String currentUserId) {
@@ -54,6 +66,7 @@ public final class IssueStateService {
 
     private void resolve(Issue issue, User actor, String comment) {
         permissionPolicy.assertCanChangeStatus(actor, issue, IssueStatus.RESOLVED);
+        resolutionGuard.assertCanResolve(issue);
         LocalDateTime changedAt = now();
         issue.resolve(actor, comment, changedAt);
         recordStatusChangeReason(issue, actor, comment, changedAt);

--- a/src/test/java/com/github/marcellokim/issuetracker/service/DependencyResolutionGuardTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/DependencyResolutionGuardTest.java
@@ -1,0 +1,91 @@
+package com.github.marcellokim.issuetracker.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueDependency;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueDependencyRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Dependency resolution guard")
+class DependencyResolutionGuardTest {
+
+    private static final long PROJECT_ID = 10L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 21, 10, 0);
+    private final User reporter = User.create("tester1", "Tester One", "hash", Role.TESTER, true, NOW, NOW);
+    private final User assignee = User.create("dev1", "Dev One", "hash", Role.DEV, true, NOW, NOW);
+    private final User verifier = User.create("tester2", "Tester Two", "hash", Role.TESTER, true, NOW, NOW);
+    private final User pl = User.create("pl1", "PL One", "hash", Role.PL, true, NOW, NOW);
+
+    @Test
+    @DisplayName("unresolved blocking issue rejects resolve")
+    void unresolvedBlockingIssueRejectsResolve() {
+        Issue blocked = issue(1L, IssueStatus.FIXED);
+        Issue blocking = issue(2L, IssueStatus.FIXED);
+        var guard = guard(new InMemoryIssueRepository(blocked, blocking),
+                new InMemoryIssueDependencyRepository(dependency(1L, blocking.id(), blocked.id())));
+
+        assertThrows(IllegalStateException.class, () -> guard.assertCanResolve(blocked));
+    }
+
+    @Test
+    @DisplayName("resolved and closed blockers allow resolve")
+    void resolvedAndClosedBlockersAllowResolve() {
+        Issue blocked = issue(1L, IssueStatus.FIXED);
+        Issue resolvedBlocking = issue(2L, IssueStatus.RESOLVED);
+        Issue closedBlocking = issue(3L, IssueStatus.CLOSED);
+        var guard = guard(new InMemoryIssueRepository(blocked, resolvedBlocking, closedBlocking),
+                new InMemoryIssueDependencyRepository(
+                        dependency(1L, resolvedBlocking.id(), blocked.id()),
+                        dependency(2L, closedBlocking.id(), blocked.id())));
+
+        assertDoesNotThrow(() -> guard.assertCanResolve(blocked));
+    }
+
+    @Test
+    @DisplayName("missing blocking issue rejects resolve")
+    void missingBlockingIssueRejectsResolve() {
+        Issue blocked = issue(1L, IssueStatus.FIXED);
+        var guard = guard(new InMemoryIssueRepository(blocked),
+                new InMemoryIssueDependencyRepository(dependency(1L, 999L, blocked.id())));
+
+        assertThrows(IllegalStateException.class, () -> guard.assertCanResolve(blocked));
+    }
+
+    private DependencyResolutionGuard guard(
+            InMemoryIssueRepository issues,
+            InMemoryIssueDependencyRepository dependencies
+    ) {
+        return new DependencyResolutionGuard(issues, dependencies);
+    }
+
+    private IssueDependency dependency(long id, long blockingIssueId, long blockedIssueId) {
+        return IssueDependency.fromPersistence(id, blockingIssueId, blockedIssueId, NOW);
+    }
+
+    private Issue issue(long id, IssueStatus status) {
+        var builder = Issue.persistedState(PROJECT_ID, "Issue " + id, "Dependency guard test", reporter)
+                .id(id)
+                .issueId("ISSUE-" + id)
+                .reportedDate(NOW)
+                .priority(Priority.MAJOR)
+                .status(status)
+                .updatedAt(NOW);
+        if (status == IssueStatus.FIXED) {
+            builder.assignee(assignee).verifier(verifier).fixer(assignee);
+        } else if (status == IssueStatus.RESOLVED) {
+            builder.assignee(assignee).verifier(verifier).fixer(assignee).resolver(verifier);
+        } else if (status == IssueStatus.CLOSED) {
+            builder.fixer(assignee).resolver(verifier);
+        }
+        return Issue.fromPersistence(builder);
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
@@ -12,10 +12,12 @@ import org.junit.jupiter.api.Test;
 import com.github.marcellokim.issuetracker.domain.ActionType;
 import com.github.marcellokim.issuetracker.domain.CommentPurpose;
 import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueDependency;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.Priority;
 import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueDependencyRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
 
@@ -195,6 +197,43 @@ class IssueStateServiceTest {
     }
 
     @Test
+    @DisplayName("unresolved blocker prevents resolve before status comment or history side effects")
+    void unresolvedBlockerPreventsResolveWithoutSideEffects() {
+        var blocked = fixedIssue();
+        var blocking = fixedIssue(2L);
+        int commentCount = blocked.getComments().size();
+        int historyCount = blocked.getHistories().size();
+        var dependencyRepository = new InMemoryIssueDependencyRepository(
+                IssueDependency.fromPersistence(1L, blocking.id(), blocked.id(), createdAt()));
+        var guard = new DependencyResolutionGuard(
+                new InMemoryIssueRepository(blocked, blocking),
+                dependencyRepository);
+        var service = service(blocked, guard);
+
+        assertThrows(IllegalStateException.class,
+                () -> service.changeStatus(ISSUE_ID, IssueStatus.RESOLVED, "Verified", verifier.getLoginId()));
+
+        assertEquals(IssueStatus.FIXED, blocked.status());
+        assertNull(blocked.getResolver());
+        assertEquals(commentCount, blocked.getComments().size());
+        assertEquals(historyCount, blocked.getHistories().size());
+    }
+
+    @Test
+    @DisplayName("resolution guard does not run for non-resolved transitions")
+    void resolutionGuardDoesNotRunForNonResolvedTransition() {
+        var issue = assignedIssue();
+        IssueResolutionGuard failingGuard = ignored -> {
+            throw new AssertionError("guard should only run for RESOLVED target");
+        };
+        var service = service(issue, failingGuard);
+
+        var result = service.changeStatus(ISSUE_ID, IssueStatus.FIXED, "Fix completed", assignee.getLoginId());
+
+        assertEquals(IssueStatus.FIXED, result.status());
+    }
+
+    @Test
     @DisplayName("target status is required")
     void rejectNullTargetStatus() {
         var issue = assignedIssue();
@@ -205,11 +244,16 @@ class IssueStateServiceTest {
     }
 
     private IssueStateService service(Issue issue) {
+        return service(issue, IssueResolutionGuard.none());
+    }
+
+    private IssueStateService service(Issue issue, IssueResolutionGuard resolutionGuard) {
         return new IssueStateService(
                 new InMemoryIssueRepository(issue),
                 new InMemoryUserRepository(reporter, assignee, verifier, pl, otherDev),
                 new PermissionPolicy(),
-                new Clock()
+                new Clock(),
+                resolutionGuard
         );
     }
 
@@ -230,7 +274,21 @@ class IssueStateServiceTest {
     }
 
     private Issue fixedIssue() {
+        return fixedIssue(ISSUE_ID);
+    }
+
+    private Issue fixedIssue(long id) {
         var issue = assignedIssue();
+        if (id != ISSUE_ID) {
+            issue = Issue.fromPersistence(Issue.persistedState(PROJECT_ID, "Login fails " + id, "Cannot log in", reporter)
+                    .id(id)
+                    .issueId("ISSUE-" + id)
+                    .reportedDate(createdAt())
+                    .priority(Priority.MAJOR)
+                    .status(IssueStatus.NEW)
+                    .updatedAt(createdAt()));
+            issue.assignFromNew(assignee, verifier, pl, createdAt().plusMinutes(10));
+        }
         issue.markFixed(assignee, "Fix completed", createdAt().plusMinutes(20));
         return issue;
     }


### PR DESCRIPTION
## 요약
- blocked issue의 `FIXED -> RESOLVED` 전이에만 적용되는 dependency guard를 추가했습니다.
- 모든 blocking issue가 `RESOLVED` 또는 `CLOSED`가 아니면 resolve를 거부합니다.
- guard를 domain 상태 변경과 status-change comment 기록 전에 실행해 실패 전이의 부수효과를 막았습니다.
- `BLOCK`/`BLOCKED` status를 추가하지 않고 `Priority.BLOCKER`도 dependency 판단에 사용하지 않도록 문서화했습니다.

## 검증
- `./gradlew test --tests com.github.marcellokim.issuetracker.service.DependencyResolutionGuardTest --tests com.github.marcellokim.issuetracker.service.IssueStateServiceTest --tests com.github.marcellokim.issuetracker.service.IssueWorkflowServiceTest --tests com.github.marcellokim.issuetracker.controller.ControllerCoverageTest --console=plain`
- `git diff --check`
- `./gradlew check --console=plain`

## 관련 PR
- 이전 PR: #133

## 관련 이슈
- Refs #98
