### PR TITLE
ci: Oracle integration test environment 구성

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Gradle Wrapper 검증
-        uses: gradle/actions/wrapper-validation@v6
+        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
 
       - name: JDK 21 설정
         uses: actions/setup-java@v5
@@ -33,7 +33,7 @@ jobs:
           java-version: 21
 
       - name: Gradle 캐시 설정
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
 
       - name: 테스트 파이프라인 실행
         run: ./gradlew --stacktrace clean ci
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Gradle Wrapper 검증
-        uses: gradle/actions/wrapper-validation@v6
+        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
 
       - name: JDK 21 설정
         uses: actions/setup-java@v5
@@ -67,7 +67,7 @@ jobs:
           java-version: 21
 
       - name: Gradle 캐시 설정
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
 
       - name: Oracle Docker 통합 테스트 실행
         env:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -46,3 +46,53 @@ jobs:
           path: |
             build/reports/tests/test
             build/test-results/test
+
+  oracle-integration:
+    name: Oracle 통합 테스트
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 40
+
+    steps:
+      - name: 저장소 체크아웃
+        uses: actions/checkout@v6
+
+      - name: Gradle Wrapper 검증
+        uses: gradle/actions/wrapper-validation@v6
+
+      - name: JDK 21 설정
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Gradle 캐시 설정
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Oracle Docker 통합 테스트 실행
+        env:
+          ORACLE_LOCAL_IMAGE: container-registry.oracle.com/database/free:23.26.0.0-lite
+          ORACLE_LOCAL_TIMEOUT: "900"
+          ORACLE_LOCAL_SQL_TIMEOUT: "30"
+          ORACLE_LOCAL_SETTLE_SECONDS: "60"
+          ORACLE_LOCAL_CONNECT_RETRIES: "12"
+          ORACLE_LOCAL_CONNECT_RETRY_DELAY_MS: "5000"
+        run: ./gradlew --stacktrace oracleLocalTest --console=plain
+
+      - name: Oracle 컨테이너 로그 출력
+        if: failure()
+        run: docker compose -f infra/local-oracle/compose.yml logs --no-color oracle-local || true
+
+      - name: Oracle 테스트 리포트 업로드
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: oracle-통합-테스트-리포트
+          path: |
+            build/reports/tests/oracleLocalIntegrationTest
+            build/test-results/oracleLocalIntegrationTest
+          if-no-files-found: ignore
+
+      - name: Oracle 컨테이너 정리
+        if: always()
+        run: docker compose -f infra/local-oracle/compose.yml down -v || true

--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ ls
 ./gradlew check
 ```
 
+Oracle DB까지 포함한 repository 통합 테스트는 Docker 기반 runbook을 따릅니다.
+
+```bash
+./gradlew oracleLocalTest --console=plain
+```
+
+세부 환경변수, 앱 DB 초기화, CI 자동 실행 계약은 [docs/local-oracle-testing.md](docs/local-oracle-testing.md)를 확인합니다.
+
 Windows에서 `python3` 대신 `python` 또는 `py`만 잡히는 경우에는 Gradle 속성으로 실행명을 지정합니다. shell 스크립트는 `python3`, `python`, `py` 순서로 자동 탐색하며, 필요하면 `PYTHON_EXECUTABLE=py`처럼 지정할 수 있습니다.
 
 ```bash

--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,20 @@ def oracleIntegrationTestRequested = {
             }
 }
 
+def oracleLocalPort = providers.environmentVariable('ORACLE_LOCAL_PORT').orElse('1521')
+def oracleLocalPdb = providers.environmentVariable('ORACLE_LOCAL_PDB').orElse('FREEPDB1')
+def oracleLocalUrl = providers.provider {
+    "jdbc:oracle:thin:@//localhost:${oracleLocalPort.get()}/${oracleLocalPdb.get()}"
+}
+def oracleLocalAppUser = providers.environmentVariable('ORACLE_LOCAL_APP_USER').orElse('ITS_USER')
+def oracleLocalAppPassword = providers.environmentVariable('ORACLE_LOCAL_APP_PASSWORD').orElse('ItsLocalDev2026!')
+def oracleLocalTestUser = providers.environmentVariable('ORACLE_LOCAL_TEST_USER').orElse('ITS_TEST_USER')
+def oracleLocalTestPassword = providers.environmentVariable('ORACLE_LOCAL_TEST_PASSWORD').orElse('ItsTestLocal2026!')
+def oracleLocalSqlTimeout = providers.environmentVariable('ORACLE_LOCAL_SQL_TIMEOUT').orElse('30')
+def oracleLocalSettleSeconds = providers.environmentVariable('ORACLE_LOCAL_SETTLE_SECONDS').orElse('60')
+def oracleLocalConnectRetries = providers.environmentVariable('ORACLE_LOCAL_CONNECT_RETRIES').orElse('12')
+def oracleLocalConnectRetryDelayMillis = providers.environmentVariable('ORACLE_LOCAL_CONNECT_RETRY_DELAY_MS').orElse('5000')
+
 tasks.register('oracleIntegrationTest', Test) {
     group = 'verification'
     description = 'Runs Oracle repository integration tests against an isolated test schema. Set ITS_TEST_DB_URL, ITS_TEST_DB_USER, and ITS_TEST_DB_PASSWORD.'
@@ -164,6 +178,107 @@ tasks.register('oracleIntegrationTest', Test) {
     onlyIf {
         oracleIntegrationTestRequested()
     }
+}
+
+def configureOracleLocalScriptTask = { Exec task, String action ->
+    task.group = 'verification'
+    task.description = "Runs scripts/oracle-local for the '${action}' action."
+    task.environment 'ORACLE_LOCAL_PORT', oracleLocalPort.get()
+    task.environment 'ORACLE_LOCAL_PDB', oracleLocalPdb.get()
+    task.environment 'ORACLE_LOCAL_APP_USER', oracleLocalAppUser.get()
+    task.environment 'ORACLE_LOCAL_APP_PASSWORD', oracleLocalAppPassword.get()
+    task.environment 'ORACLE_LOCAL_TEST_USER', oracleLocalTestUser.get()
+    task.environment 'ORACLE_LOCAL_TEST_PASSWORD', oracleLocalTestPassword.get()
+    task.environment 'ORACLE_LOCAL_SQL_TIMEOUT', oracleLocalSqlTimeout.get()
+    task.environment 'ORACLE_LOCAL_SETTLE_SECONDS', oracleLocalSettleSeconds.get()
+
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        task.commandLine 'powershell', '-NoProfile', '-ExecutionPolicy', 'Bypass',
+                '-File', file('scripts/oracle-local.ps1'), action
+    } else {
+        task.commandLine 'bash', file('scripts/oracle-local.sh'), action
+    }
+}
+
+tasks.register('oracleLocalStart', Exec) {
+    configureOracleLocalScriptTask(delegate, 'start')
+}
+
+tasks.register('oracleLocalWait', Exec) {
+    configureOracleLocalScriptTask(delegate, 'wait')
+    dependsOn tasks.named('oracleLocalStart')
+}
+
+tasks.register('oracleLocalBootstrap', Exec) {
+    configureOracleLocalScriptTask(delegate, 'bootstrap')
+    dependsOn tasks.named('oracleLocalWait')
+}
+
+tasks.register('oracleLocalStabilize', Exec) {
+    configureOracleLocalScriptTask(delegate, 'settle')
+    dependsOn tasks.named('oracleLocalBootstrap')
+}
+
+tasks.register('oracleLocalStatus', Exec) {
+    configureOracleLocalScriptTask(delegate, 'status')
+}
+
+tasks.register('oracleLocalStop', Exec) {
+    configureOracleLocalScriptTask(delegate, 'stop')
+}
+
+tasks.register('oracleLocalReset', Exec) {
+    configureOracleLocalScriptTask(delegate, 'reset')
+}
+
+tasks.register('oracleLocalInitializeDatabase', JavaExec) {
+    group = 'verification'
+    description = 'Creates or migrates the Gradle-managed local Docker Oracle application schema without deleting existing data.'
+    dependsOn tasks.named('oracleLocalStabilize')
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'com.github.marcellokim.issuetracker.persistence.DatabaseInitializer'
+    environment 'ITS_DB_URL', oracleLocalUrl.get()
+    environment 'ITS_DB_USER', oracleLocalAppUser.get()
+    environment 'ITS_DB_PASSWORD', oracleLocalAppPassword.get()
+}
+
+tasks.register('oracleLocalResetFixedSeed', JavaExec) {
+    group = 'verification'
+    description = 'Destructively resets the Gradle-managed local Docker Oracle application schema to the fixed demo seed.'
+    dependsOn tasks.named('oracleLocalStabilize')
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'com.github.marcellokim.issuetracker.persistence.DatabaseInitializer'
+    args '--reset-fixed-seed'
+    environment 'ITS_DB_URL', oracleLocalUrl.get()
+    environment 'ITS_DB_USER', oracleLocalAppUser.get()
+    environment 'ITS_DB_PASSWORD', oracleLocalAppPassword.get()
+}
+
+tasks.register('oracleLocalIntegrationTest', Test) {
+    group = 'verification'
+    description = 'Runs Oracle repository integration tests against the Gradle-managed local Docker Oracle TEST schema.'
+    dependsOn tasks.named('oracleLocalStabilize')
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    useJUnitPlatform()
+    include '**/OracleRepositoryIntegrationTest.class'
+    environment 'ITS_DB_INTEGRATION_TESTS', 'true'
+    environment 'ITS_TEST_DB_URL', oracleLocalUrl.get()
+    environment 'ITS_TEST_DB_USER', oracleLocalTestUser.get()
+    environment 'ITS_TEST_DB_PASSWORD', oracleLocalTestPassword.get()
+    environment 'ITS_TEST_DB_CONNECT_RETRIES', oracleLocalConnectRetries.get()
+    environment 'ITS_TEST_DB_CONNECT_RETRY_DELAY_MS', oracleLocalConnectRetryDelayMillis.get()
+    shouldRunAfter tasks.named('oracleIntegrationTest')
+    testLogging {
+        events 'passed', 'skipped', 'failed'
+        exceptionFormat = 'full'
+    }
+}
+
+tasks.register('oracleLocalTest') {
+    group = 'verification'
+    description = 'Starts local Oracle, bootstraps app/test schemas, and runs Oracle repository integration tests.'
+    dependsOn tasks.named('oracleLocalIntegrationTest')
 }
 
 tasks.named('check') {

--- a/docs/local-oracle-testing.md
+++ b/docs/local-oracle-testing.md
@@ -1,0 +1,177 @@
+# 로컬 Oracle Docker 테스트
+
+이 문서는 팀원이 같은 명령으로 Oracle repository 통합 테스트를 재현하고, GitHub Actions에서도 같은 계약으로 Oracle 테스트를 자동 실행하기 위한 runbook이다.
+
+## 빠른 실행
+
+macOS/Linux:
+
+```bash
+./gradlew oracleLocalTest --console=plain
+```
+
+Windows PowerShell:
+
+```powershell
+.\gradlew.bat oracleLocalTest --console=plain
+```
+
+`oracleLocalTest`는 Docker 컨테이너를 시작하고, readiness를 기다린 뒤, 앱 schema와 테스트 schema 계정을 bootstrap하고, Oracle background 작업 안정화 대기 후 `oracleLocalIntegrationTest`를 실행한다. 테스트 schema의 실제 table drop/schema/seed reset은 `OracleRepositoryIntegrationTest`가 `ITS_TEST_DB_*`로 연결한 schema에서 직접 수행한다.
+
+## 기본 연결값
+
+| 항목 | 기본값 |
+| --- | --- |
+| 컨테이너 | `se-issue-tracker-oracle` |
+| 이미지 | `container-registry.oracle.com/database/free:23.26.0.0-lite` |
+| 볼륨 | `se_issue_tracker_oracle_data` |
+| 포트 | `1521` |
+| Docker Free PDB | `FREEPDB1` |
+| Docker JDBC URL | `jdbc:oracle:thin:@//localhost:1521/FREEPDB1` |
+| 앱 schema 사용자 | `ITS_USER` |
+| 앱 schema 비밀번호 | `ItsLocalDev2026!` |
+| 테스트 schema 사용자 | `ITS_TEST_USER` |
+| 테스트 schema 비밀번호 | `ItsTestLocal2026!` |
+| SYS 비밀번호 | `OracleLocal2026!` |
+
+`ITS_USER`와 `ITS_TEST_USER`는 Oracle schema 계정이다. 애플리케이션 로그인 계정이 아니다. seed된 앱 로그인 비밀번호는 [oracleDB-seed-password.md](oracleDB-seed-password.md)에 정리되어 있다.
+
+최신 코드의 일반 Oracle XE 예시는 `XEPDB1`을 사용하지만, 이 Docker Free 경로는 `FREEPDB1`을 명시한다. 로컬 Docker task는 `ITS_DB_URL` 또는 `ITS_TEST_DB_URL`을 자동으로 `FREEPDB1` URL로 맞춘다.
+
+## Gradle task 계약
+
+| 목적 | 명령 | 동작 |
+| --- | --- | --- |
+| 상태 확인 | `./gradlew oracleLocalStatus` | Docker CLI, Compose, 컨테이너, 포트, JDBC URL 확인 |
+| 컨테이너 시작 | `./gradlew oracleLocalStart` | Compose로 Oracle Free 컨테이너 시작 |
+| readiness 대기 | `./gradlew oracleLocalWait` | Oracle 로그와 SQL 연결 준비 확인 |
+| schema 계정 준비 | `./gradlew oracleLocalBootstrap` | 앱/test schema 사용자 생성 또는 unlock |
+| 안정화 대기 | `./gradlew oracleLocalStabilize` | Oracle Free 첫 기동 직후 listener/background 작업 안정화 대기 |
+| 통합 테스트 | `./gradlew oracleLocalTest` | TEST schema에서 Oracle repository 통합 테스트 실행 |
+| 앱 DB 비파괴 초기화 | `./gradlew oracleLocalInitializeDatabase` | `ITS_USER` schema에 schema migration 실행, 최초 실행 때만 seed 삽입 |
+| 앱 DB 고정 seed 리셋 | `./gradlew oracleLocalResetFixedSeed` | `ITS_USER` schema core table drop 후 schema/seed 재생성 |
+| 컨테이너/볼륨 리셋 | `./gradlew oracleLocalReset` | Docker volume 삭제 후 새 컨테이너와 schema 계정 재생성 |
+| 컨테이너 중지 | `./gradlew oracleLocalStop` | Compose down |
+
+`oracleLocalReset`은 Docker 컨테이너와 volume을 지우는 명령이다. `oracleLocalResetFixedSeed`는 앱 schema의 table과 seed를 리셋하는 명령이다. 둘을 같은 의미로 쓰지 않는다.
+
+## 실행 옵션
+
+| 환경변수 | 기본값 | 설명 |
+| --- | --- | --- |
+| `ORACLE_LOCAL_PORT` | `1521` | host Oracle listener port |
+| `ORACLE_LOCAL_PDB` | `FREEPDB1` | Docker Oracle PDB/service name |
+| `ORACLE_LOCAL_IMAGE` | `container-registry.oracle.com/database/free:23.26.0.0-lite` | 실행할 Oracle Free image |
+| `ORACLE_LOCAL_TIMEOUT` | `900` | readiness 전체 대기 시간(초) |
+| `ORACLE_LOCAL_SQL_TIMEOUT` | `30` | readiness/bootstrap SQLPlus probe 1회 제한 시간(초) |
+| `ORACLE_LOCAL_SETTLE_SECONDS` | `60` | bootstrap 후 통합 테스트 전 안정화 대기 시간(초) |
+| `ORACLE_LOCAL_CONNECT_RETRIES` | `12` | Docker test task에서 Oracle listener transient 오류 연결 재시도 횟수 |
+| `ORACLE_LOCAL_CONNECT_RETRY_DELAY_MS` | `5000` | 연결 재시도 간격(ms) |
+
+Oracle Free는 로그에 ready가 찍힌 뒤에도 listener handler가 순간적으로 부족할 수 있다. Docker 경로는 `ORA-12514`, `ORA-12516`, `ORA-12519`, `ORA-12520` 연결 오류를 제한적으로 재시도한다. 그래도 재현되면 Docker 리소스를 늘리거나 `ORACLE_LOCAL_SETTLE_SECONDS`, `ORACLE_LOCAL_CONNECT_RETRIES`를 더 크게 잡는다.
+
+## 앱 실행용 DB 준비
+
+CLI demo 또는 UI를 Docker DB에 연결하려면 앱 schema를 준비하고 `ITS_DB_*`를 설정한다.
+
+macOS/Linux:
+
+```bash
+./gradlew oracleLocalInitializeDatabase --console=plain
+export ITS_DB_URL="jdbc:oracle:thin:@//localhost:1521/FREEPDB1"
+export ITS_DB_USER="ITS_USER"
+export ITS_DB_PASSWORD="ItsLocalDev2026!"
+./gradlew run --args="--cli-demo"
+./gradlew run --args="--login-check admin DemoLocalAdmin!"
+```
+
+Windows PowerShell:
+
+```powershell
+.\gradlew.bat oracleLocalInitializeDatabase --console=plain
+$env:ITS_DB_URL="jdbc:oracle:thin:@//localhost:1521/FREEPDB1"
+$env:ITS_DB_USER="ITS_USER"
+$env:ITS_DB_PASSWORD="ItsLocalDev2026!"
+.\gradlew.bat run --args="--cli-demo"
+.\gradlew.bat run --args="--login-check admin DemoLocalAdmin!"
+```
+
+앱 시작 경로는 `DatabaseInitializer.initializeApplication()`을 호출하므로 기존 앱 데이터가 있으면 seed를 다시 넣지 않는다. 고정 demo seed로 되돌려야 할 때만 `oracleLocalResetFixedSeed`를 사용한다.
+
+## CI 자동 실행
+
+GitHub Actions의 `빌드와 테스트` workflow에는 별도 `Oracle 통합 테스트` job이 있다. 이 job은 표준 `빌드와 테스트` job이 통과한 뒤 다음 순서로 실행된다.
+
+1. `container-registry.oracle.com/database/free:23.26.0.0-lite` 이미지를 사용한다.
+2. `ORACLE_LOCAL_TIMEOUT=900`, `ORACLE_LOCAL_SQL_TIMEOUT=30`, `ORACLE_LOCAL_SETTLE_SECONDS=60`, `ORACLE_LOCAL_CONNECT_RETRIES=12`, `ORACLE_LOCAL_CONNECT_RETRY_DELAY_MS=5000`으로 `./gradlew oracleLocalTest --console=plain`을 실행한다.
+3. 실패 시 Oracle 컨테이너 로그를 출력한다.
+4. `oracleLocalIntegrationTest` 테스트 리포트를 artifact로 업로드한다.
+
+기본 `./gradlew check --console=plain`은 Docker-free 경로를 유지한다. Oracle 환경변수가 없으면 `oracleIntegrationTest`는 skip된다. CI에서 Oracle 자동 실행이 필요한 경우에는 `oracleLocalTest`를 명시적으로 실행한다.
+
+이번 경로는 Oracle integration test 자동 실행을 추가한다. JaCoCo/Sonar coverage report에 `oracleLocalIntegrationTest` 결과를 합산하는 정책은 변경하지 않는다. CI job은 실패 로그와 테스트 리포트 업로드 후 Oracle 컨테이너와 volume을 정리한다.
+
+## Docker Desktop / Colima
+
+이 저장소의 계약은 Docker Desktop이 아니라 Docker CLI와 Compose다. 팀원은 Docker Desktop, Colima, WSL Docker Desktop integration 중 하나를 사용할 수 있다.
+
+macOS에서 Colima를 쓰는 경우:
+
+```bash
+colima start --cpu 4 --memory 8 --disk 80
+./gradlew oracleLocalTest --console=plain
+```
+
+Docker context가 Colima로 잡히지 않는 환경이면 현재 shell에서 `DOCKER_HOST`를 명시한다.
+
+```bash
+export DOCKER_HOST="unix://$HOME/.colima/default/docker.sock"
+./gradlew oracleLocalTest --console=plain
+```
+
+`docker info`가 `docker-credential-osxkeychain` 누락으로 실패하면 Docker credential helper 설정이 깨진 상태다. Docker Desktop/Colima 설정을 고치거나, 현재 shell에서 유효한 Docker config와 `DOCKER_HOST`를 명시한 뒤 다시 실행한다.
+
+Apple Silicon + Colima에서 기본 이미지 pull 또는 실행이 실패하면 Oracle Database Free arm64 tag를 명시한다.
+
+```bash
+ORACLE_LOCAL_IMAGE=container-registry.oracle.com/database/free:23.26.0.0-lite-arm64 \
+  ./gradlew oracleLocalTest --console=plain
+```
+
+## 포트와 이미지 override
+
+로컬 1521 포트가 이미 사용 중이면 `ORACLE_LOCAL_PORT`를 지정한다.
+
+```bash
+ORACLE_LOCAL_PORT=1522 ./gradlew oracleLocalTest --console=plain
+```
+
+이 경우 Docker JDBC URL은 `jdbc:oracle:thin:@//localhost:1522/FREEPDB1`이다. 직접 `oracleIntegrationTest`를 실행할 때도 `ITS_TEST_DB_URL`을 같은 값으로 맞춘다.
+
+이미지 tag 제공 상태나 플랫폼 지원이 바뀌어 pull이 실패하면 `ORACLE_LOCAL_IMAGE`로 override한다.
+
+```bash
+ORACLE_LOCAL_IMAGE=<image> ./gradlew oracleLocalTest --console=plain
+```
+
+## 장애 확인
+
+상태 확인:
+
+```bash
+./gradlew oracleLocalStatus --console=plain
+```
+
+로그 follow:
+
+```bash
+./scripts/oracle-local.sh logs
+```
+
+Windows PowerShell:
+
+```powershell
+.\scripts\oracle-local.ps1 logs
+```
+
+이미지 pull 실패, Docker daemon 미실행, 포트 충돌이면 Docker 설정을 고친 뒤 `oracleLocalTest`를 다시 실행한다. schema/seed 상태가 꼬였다고 판단되면 앱 schema만 되돌릴 때는 `oracleLocalResetFixedSeed`, 컨테이너와 volume까지 새로 만들 때는 `oracleLocalReset`을 사용한다.

--- a/infra/local-oracle/bootstrap.sql
+++ b/infra/local-oracle/bootstrap.sql
@@ -1,0 +1,141 @@
+set define on
+set verify off
+set feedback on
+whenever sqlerror exit sql.sqlcode
+
+define app_user = '&1'
+define app_password = '&2'
+define test_user = '&3'
+define test_password = '&4'
+
+prompt [bootstrap] validating local Oracle arguments
+declare
+    app_user_input constant varchar2(128) := q'[&&app_user]';
+    app_password_input constant varchar2(128) := q'[&&app_password]';
+    test_user_input constant varchar2(128) := q'[&&test_user]';
+    test_password_input constant varchar2(128) := q'[&&test_password]';
+
+    procedure assert_user(value in varchar2, label in varchar2) is
+    begin
+        if not regexp_like(value, '^[A-Za-z][A-Za-z0-9_$#]{0,127}$') then
+            raise_application_error(
+                -20001,
+                '[bootstrap] unsupported ' || label || ': use 1-128 chars, start with a letter, then letters/digits/_/$/# only'
+            );
+        end if;
+    end;
+
+    procedure assert_password(value in varchar2, label in varchar2) is
+    begin
+        if not regexp_like(value, '^[A-Za-z0-9_$#!.\-]{8,128}$') then
+            raise_application_error(
+                -20002,
+                '[bootstrap] unsupported ' || label || ': use 8-128 chars from letters/digits/_/$/#/!/./- only'
+            );
+        end if;
+    end;
+begin
+    assert_user(app_user_input, 'app_user');
+    assert_user(test_user_input, 'test_user');
+    assert_password(app_password_input, 'app_password');
+    assert_password(test_password_input, 'test_password');
+    if upper(app_user_input) = upper(test_user_input) then
+        raise_application_error(
+            -20003,
+            '[bootstrap] app_user and test_user must be different schemas'
+        );
+    end if;
+    if instr(upper(test_user_input), 'TEST') = 0 then
+        raise_application_error(
+            -20004,
+            '[bootstrap] test_user must include TEST because OracleRepositoryIntegrationTest enforces a TEST schema'
+        );
+    end if;
+end;
+/
+
+column app_user_upper new_value app_user_upper noprint
+column test_user_upper new_value test_user_upper noprint
+select upper(q'[&&app_user]') app_user_upper,
+       upper(q'[&&test_user]') test_user_upper
+  from dual;
+
+prompt [bootstrap] ensuring USERS tablespace
+declare
+    tablespace_count number;
+    users_datafile varchar2(512);
+begin
+    select count(*)
+      into tablespace_count
+      from dba_tablespaces
+     where tablespace_name = 'USERS';
+
+    if tablespace_count = 0 then
+        -- Oracle Free arm64 이미지의 PDB에는 USERS tablespace가 없을 수 있어 로컬용으로 보장함.
+        select substr(file_name, 1, instr(file_name, '/', -1)) || 'users01.dbf'
+          into users_datafile
+          from dba_data_files
+         where tablespace_name = 'SYSTEM'
+           and rownum = 1;
+
+        execute immediate 'create tablespace users datafile '''
+                || replace(users_datafile, '''', '''''')
+                || ''' size 100m autoextend on next 50m maxsize unlimited';
+    end if;
+end;
+/
+
+prompt [bootstrap] preparing &&app_user_upper
+declare
+    user_count number;
+begin
+    select count(*)
+      into user_count
+      from dba_users
+     where username = '&&app_user_upper';
+
+    if user_count = 0 then
+        execute immediate 'create user "&&app_user_upper" identified by "&&app_password" default tablespace users quota unlimited on users';
+    else
+        execute immediate 'alter user "&&app_user_upper" identified by "&&app_password" account unlock';
+        execute immediate 'alter user "&&app_user_upper" default tablespace users';
+        execute immediate 'alter user "&&app_user_upper" quota unlimited on users';
+    end if;
+end;
+/
+
+grant create session to "&&app_user_upper";
+grant create table to "&&app_user_upper";
+grant create view to "&&app_user_upper";
+grant create sequence to "&&app_user_upper";
+grant create trigger to "&&app_user_upper";
+grant create procedure to "&&app_user_upper";
+
+prompt [bootstrap] preparing &&test_user_upper
+declare
+    user_count number;
+begin
+    select count(*)
+      into user_count
+      from dba_users
+     where username = '&&test_user_upper';
+
+    if user_count = 0 then
+        execute immediate 'create user "&&test_user_upper" identified by "&&test_password" default tablespace users quota unlimited on users';
+    else
+        execute immediate 'alter user "&&test_user_upper" identified by "&&test_password" account unlock';
+        execute immediate 'alter user "&&test_user_upper" default tablespace users';
+        execute immediate 'alter user "&&test_user_upper" quota unlimited on users';
+    end if;
+end;
+/
+
+grant create session to "&&test_user_upper";
+grant create table to "&&test_user_upper";
+grant create view to "&&test_user_upper";
+grant create sequence to "&&test_user_upper";
+grant create trigger to "&&test_user_upper";
+grant create procedure to "&&test_user_upper";
+
+prompt [bootstrap] local Oracle users are ready
+exit

--- a/infra/local-oracle/compose.yml
+++ b/infra/local-oracle/compose.yml
@@ -1,0 +1,15 @@
+services:
+  oracle-local:
+    image: ${ORACLE_LOCAL_IMAGE:-container-registry.oracle.com/database/free:23.26.0.0-lite}
+    container_name: ${ORACLE_LOCAL_CONTAINER:-se-issue-tracker-oracle}
+    ports:
+      - "${ORACLE_LOCAL_PORT:-1521}:1521"
+    environment:
+      ORACLE_PWD: ${ORACLE_LOCAL_SYS_PASSWORD:-OracleLocal2026!}
+    volumes:
+      - se_issue_tracker_oracle_data:/opt/oracle/oradata
+    restart: unless-stopped
+
+volumes:
+  se_issue_tracker_oracle_data:
+    name: ${ORACLE_LOCAL_VOLUME:-se_issue_tracker_oracle_data}

--- a/scripts/oracle-local.ps1
+++ b/scripts/oracle-local.ps1
@@ -1,0 +1,280 @@
+param(
+    [Parameter(Position = 0)]
+    [string]$Command = "help",
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$RemainingArgs
+)
+
+$ErrorActionPreference = "Stop"
+
+$RootDir = Split-Path -Parent $PSScriptRoot
+$ComposeFile = Join-Path $RootDir "infra/local-oracle/compose.yml"
+$BootstrapSql = Join-Path $RootDir "infra/local-oracle/bootstrap.sql"
+
+$Image = if ($env:ORACLE_LOCAL_IMAGE) { $env:ORACLE_LOCAL_IMAGE } else { "container-registry.oracle.com/database/free:23.26.0.0-lite" }
+$Container = if ($env:ORACLE_LOCAL_CONTAINER) { $env:ORACLE_LOCAL_CONTAINER } else { "se-issue-tracker-oracle" }
+$Volume = if ($env:ORACLE_LOCAL_VOLUME) { $env:ORACLE_LOCAL_VOLUME } else { "se_issue_tracker_oracle_data" }
+$Port = if ($env:ORACLE_LOCAL_PORT) { $env:ORACLE_LOCAL_PORT } else { "1521" }
+$SysPassword = if ($env:ORACLE_LOCAL_SYS_PASSWORD) { $env:ORACLE_LOCAL_SYS_PASSWORD } else { "OracleLocal2026!" }
+$AppUser = if ($env:ORACLE_LOCAL_APP_USER) { $env:ORACLE_LOCAL_APP_USER } else { "ITS_USER" }
+$AppPassword = if ($env:ORACLE_LOCAL_APP_PASSWORD) { $env:ORACLE_LOCAL_APP_PASSWORD } else { "ItsLocalDev2026!" }
+$TestUser = if ($env:ORACLE_LOCAL_TEST_USER) { $env:ORACLE_LOCAL_TEST_USER } else { "ITS_TEST_USER" }
+$TestPassword = if ($env:ORACLE_LOCAL_TEST_PASSWORD) { $env:ORACLE_LOCAL_TEST_PASSWORD } else { "ItsTestLocal2026!" }
+$Pdb = if ($env:ORACLE_LOCAL_PDB) { $env:ORACLE_LOCAL_PDB } else { "FREEPDB1" }
+$TimeoutSeconds = if ($env:ORACLE_LOCAL_TIMEOUT) { [int]$env:ORACLE_LOCAL_TIMEOUT } else { 900 }
+$SqlTimeoutSeconds = if ($env:ORACLE_LOCAL_SQL_TIMEOUT) { [int]$env:ORACLE_LOCAL_SQL_TIMEOUT } else { 30 }
+$SettleSeconds = if ($env:ORACLE_LOCAL_SETTLE_SECONDS) { [int]$env:ORACLE_LOCAL_SETTLE_SECONDS } else { 60 }
+
+$env:ORACLE_LOCAL_IMAGE = $Image
+$env:ORACLE_LOCAL_CONTAINER = $Container
+$env:ORACLE_LOCAL_VOLUME = $Volume
+$env:ORACLE_LOCAL_PORT = $Port
+$env:ORACLE_LOCAL_SYS_PASSWORD = $SysPassword
+
+function Write-ErrorMessage {
+    param([Parameter(Mandatory = $true)][string]$Message)
+    [Console]::Error.WriteLine($Message)
+}
+
+function Get-JdbcUrl {
+    "jdbc:oracle:thin:@//localhost:$Port/$Pdb"
+}
+
+function Invoke-Compose {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$ComposeArgs)
+    & docker compose -f $ComposeFile @ComposeArgs
+    $composeExitCode = $LASTEXITCODE
+    if ($composeExitCode -ne 0) {
+        Write-Error "docker compose failed with exit code $composeExitCode"
+    }
+}
+
+function Require-Docker {
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        Write-Error "[오류] docker CLI를 찾을 수 없습니다."
+    }
+
+    & docker info *> $null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "[오류] Docker 데몬에 연결할 수 없습니다."
+    }
+
+    & docker compose version *> $null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "[오류] docker compose를 사용할 수 없습니다."
+    }
+
+    if (-not (Test-Path -LiteralPath $ComposeFile)) {
+        Write-Error "[오류] Compose 파일을 찾을 수 없습니다: $ComposeFile"
+    }
+}
+
+function Require-BootstrapSql {
+    if (-not (Test-Path -LiteralPath $BootstrapSql)) {
+        Write-Error "[오류] bootstrap SQL을 찾을 수 없습니다: $BootstrapSql"
+    }
+}
+
+function Invoke-SystemSqlPlus {
+    param([Parameter(Mandatory = $true)][string]$SqlText)
+    $SqlText | & docker exec -i $Container timeout "${SqlTimeoutSeconds}s" sqlplus -s /nolog
+}
+
+function Start-OracleLocal {
+    Require-Docker
+    Write-Host "[시작] 로컬 Oracle 컨테이너를 기동합니다: $Container"
+    Invoke-Compose up -d
+    Write-Host "[정보] JDBC URL: $(Get-JdbcUrl)"
+}
+
+function Wait-OracleLocal {
+    Require-Docker
+    Write-Host "[대기] Oracle 준비 상태를 확인합니다. 제한 시간: ${TimeoutSeconds}초"
+
+    $startTime = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    $logReady = $false
+    $sqlReady = $false
+
+    while ($true) {
+        $elapsed = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds() - $startTime
+        if ($elapsed -gt $TimeoutSeconds) {
+            Write-Error "[오류] Oracle 준비 대기 시간이 초과되었습니다.`n로그 확인: ./scripts/oracle-local.ps1 logs"
+        }
+
+        $logs = & docker logs $Container 2>&1
+        if ($logs -match "DATABASE IS READY TO USE") {
+            $logReady = $true
+        }
+
+        if ($logReady) {
+            $sql = @"
+connect system/$SysPassword@//localhost:1521/$Pdb
+set heading off feedback off pagesize 0 verify off
+select 1 from dual;
+exit
+"@
+            $output = Invoke-SystemSqlPlus -SqlText $sql 2>$null
+            if ($LASTEXITCODE -eq 0 -and ($output -match "^\s*1\s*$")) {
+                $sqlReady = $true
+            }
+        }
+
+        if ($logReady -and $sqlReady) {
+            Write-Host "[확인] Oracle 로그와 SQL 연결이 모두 준비되었습니다."
+            return
+        }
+
+        Start-Sleep -Seconds 5
+    }
+}
+
+function Invoke-Bootstrap {
+    Require-Docker
+    Require-BootstrapSql
+    Write-Host "[초기화] 애플리케이션/테스트 계정을 준비합니다."
+    & docker cp $BootstrapSql "$Container`:/tmp/bootstrap.sql"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "[오류] bootstrap SQL 복사에 실패했습니다."
+    }
+
+    $sql = @"
+connect system/$SysPassword@//localhost:1521/$Pdb
+@/tmp/bootstrap.sql "$AppUser" "$AppPassword" "$TestUser" "$TestPassword"
+"@
+    Invoke-SystemSqlPlus -SqlText $sql
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "[오류] 계정 준비에 실패했습니다."
+    }
+
+    Write-Host "[확인] 계정 준비가 완료되었습니다."
+}
+
+function Invoke-Settle {
+    if ($SettleSeconds -gt 0) {
+        Write-Host "[대기] Oracle background 작업 안정화를 위해 ${SettleSeconds}초 대기합니다."
+        Start-Sleep -Seconds $SettleSeconds
+    } else {
+        Write-Host "[대기] Oracle 안정화 대기를 건너뜁니다."
+    }
+}
+
+function Show-Status {
+    Write-Host "[상태] 로컬 Oracle 설정"
+    if (Get-Command docker -ErrorAction SilentlyContinue) {
+        $dockerVersion = & docker --version
+        Write-Host "  - Docker CLI: 사용 가능 ($dockerVersion)"
+    } else {
+        Write-Host "  - Docker CLI: 없음"
+    }
+
+    if (Get-Command docker -ErrorAction SilentlyContinue) {
+        $composeVersion = & docker compose version --short 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  - Docker Compose: 사용 가능 ($composeVersion)"
+        } else {
+            Write-Host "  - Docker Compose: 없음"
+        }
+    } else {
+        Write-Host "  - Docker Compose: 없음"
+    }
+
+    Write-Host "  - 컨테이너: $Container"
+    Write-Host "  - 이미지: $Image"
+    Write-Host "  - 볼륨: $Volume"
+    Write-Host "  - 포트: localhost:$Port -> 1521"
+    Write-Host "  - JDBC URL: $(Get-JdbcUrl)"
+    Write-Host "  - 앱 사용자: $AppUser"
+    Write-Host "  - 테스트 사용자: $TestUser"
+
+    if (Get-Command docker -ErrorAction SilentlyContinue) {
+        $containerNames = & docker ps -a --format "{{.Names}}" 2>$null
+        if ($LASTEXITCODE -eq 0 -and ($containerNames -contains $Container)) {
+            $containerStatus = & docker inspect -f "{{.State.Status}}" $Container
+            Write-Host "  - 컨테이너 상태: $containerStatus"
+        } else {
+            Write-Host "  - 컨테이너 상태: 생성되지 않음"
+        }
+    } else {
+        Write-Host "  - 컨테이너 상태: 확인 불가"
+    }
+
+    Write-Host ""
+    Write-Host "다음 명령:"
+    Write-Host "  .\gradlew.bat oracleLocalTest --console=plain"
+    Write-Host "  .\gradlew.bat oracleLocalInitializeDatabase --console=plain"
+    Write-Host "  .\gradlew.bat oracleLocalResetFixedSeed --console=plain"
+    Write-Host "  ./scripts/oracle-local.ps1 start"
+    Write-Host "  ./scripts/oracle-local.ps1 wait"
+    Write-Host "  ./scripts/oracle-local.ps1 bootstrap"
+    Write-Host "  ./scripts/oracle-local.ps1 settle"
+    Write-Host "  ./scripts/oracle-local.ps1 stop"
+    Write-Host "  ./scripts/oracle-local.ps1 reset"
+    Write-Host ""
+    Write-Host "로그 확인:"
+    Write-Host "  ./scripts/oracle-local.ps1 logs"
+}
+
+function Reset-OracleLocal {
+    Require-Docker
+    Require-BootstrapSql
+    Write-Host "[초기화] 컨테이너와 로컬 Oracle 볼륨을 삭제합니다: $Volume"
+    Invoke-Compose down -v
+    Write-Host "[시작] 새 로컬 Oracle 컨테이너를 기동합니다: $Container"
+    Invoke-Compose up -d
+    Wait-OracleLocal
+    Invoke-Bootstrap
+    Invoke-Settle
+    Write-Host "[확인] 로컬 Oracle 재생성이 완료되었습니다."
+}
+
+function Stop-OracleLocal {
+    Require-Docker
+    Write-Host "[중지] 로컬 Oracle 컨테이너를 중지합니다."
+    Invoke-Compose down
+}
+
+function Show-Logs {
+    Require-Docker
+    Invoke-Compose logs -f oracle-local
+}
+
+function Show-Usage {
+    Write-Host @"
+사용법: ./scripts/oracle-local.ps1 <command>
+
+명령:
+  start      컨테이너 기동
+  wait       Oracle readiness 확인
+  bootstrap  실행 중인 컨테이너에 앱/테스트 계정 준비
+  settle     bootstrap 후 Oracle background 작업 안정화 대기
+  status     현재 설정과 다음 명령 출력
+  reset      컨테이너와 볼륨 삭제 후 계정 bootstrap
+  stop       컨테이너 중지
+  logs       Oracle 컨테이너 로그 팔로우
+  help       도움말 출력
+"@
+}
+
+if ($RemainingArgs.Count -gt 0) {
+    Write-ErrorMessage "[오류] 예상하지 못한 추가 인자: $($RemainingArgs -join ' ')"
+    Show-Usage
+    exit 1
+}
+
+switch ($Command) {
+    "start" { Start-OracleLocal }
+    "wait" { Wait-OracleLocal }
+    "bootstrap" { Invoke-Bootstrap }
+    "settle" { Invoke-Settle }
+    "status" { Show-Status }
+    "reset" { Reset-OracleLocal }
+    "stop" { Stop-OracleLocal }
+    "logs" { Show-Logs }
+    { $_ -in @("help", "--help", "-h") } { Show-Usage }
+    default {
+        Write-ErrorMessage "[오류] 알 수 없는 명령: $Command"
+        Show-Usage
+        exit 1
+    }
+}

--- a/scripts/oracle-local.ps1
+++ b/scripts/oracle-local.ps1
@@ -81,6 +81,13 @@ function Invoke-SystemSqlPlus {
     $SqlText | & docker exec -i $Container timeout "${SqlTimeoutSeconds}s" sqlplus -s /nolog
 }
 
+function Get-SystemConnectSql {
+@"
+set define off
+connect system/"$SysPassword"@//localhost:1521/$Pdb
+"@
+}
+
 function Start-OracleLocal {
     Require-Docker
     Write-Host "[시작] 로컬 Oracle 컨테이너를 기동합니다: $Container"
@@ -102,14 +109,14 @@ function Wait-OracleLocal {
             Write-Error "[오류] Oracle 준비 대기 시간이 초과되었습니다.`n로그 확인: ./scripts/oracle-local.ps1 logs"
         }
 
-        $logs = & docker logs $Container 2>&1
+        $logs = & docker logs --tail 100 $Container 2>&1
         if ($logs -match "DATABASE IS READY TO USE") {
             $logReady = $true
         }
 
         if ($logReady) {
             $sql = @"
-connect system/$SysPassword@//localhost:1521/$Pdb
+$(Get-SystemConnectSql)
 set heading off feedback off pagesize 0 verify off
 select 1 from dual;
 exit
@@ -139,7 +146,7 @@ function Invoke-Bootstrap {
     }
 
     $sql = @"
-connect system/$SysPassword@//localhost:1521/$Pdb
+$(Get-SystemConnectSql)
 @/tmp/bootstrap.sql "$AppUser" "$AppPassword" "$TestUser" "$TestPassword"
 "@
     Invoke-SystemSqlPlus -SqlText $sql

--- a/scripts/oracle-local.sh
+++ b/scripts/oracle-local.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/infra/local-oracle/compose.yml"
+BOOTSTRAP_SQL="$ROOT_DIR/infra/local-oracle/bootstrap.sql"
+
+ORACLE_LOCAL_IMAGE="${ORACLE_LOCAL_IMAGE:-container-registry.oracle.com/database/free:23.26.0.0-lite}"
+ORACLE_LOCAL_CONTAINER="${ORACLE_LOCAL_CONTAINER:-se-issue-tracker-oracle}"
+ORACLE_LOCAL_VOLUME="${ORACLE_LOCAL_VOLUME:-se_issue_tracker_oracle_data}"
+ORACLE_LOCAL_PORT="${ORACLE_LOCAL_PORT:-1521}"
+ORACLE_LOCAL_SYS_PASSWORD="${ORACLE_LOCAL_SYS_PASSWORD:-OracleLocal2026!}"
+ORACLE_LOCAL_APP_USER="${ORACLE_LOCAL_APP_USER:-ITS_USER}"
+ORACLE_LOCAL_APP_PASSWORD="${ORACLE_LOCAL_APP_PASSWORD:-ItsLocalDev2026!}"
+ORACLE_LOCAL_TEST_USER="${ORACLE_LOCAL_TEST_USER:-ITS_TEST_USER}"
+ORACLE_LOCAL_TEST_PASSWORD="${ORACLE_LOCAL_TEST_PASSWORD:-ItsTestLocal2026!}"
+ORACLE_LOCAL_PDB="${ORACLE_LOCAL_PDB:-FREEPDB1}"
+ORACLE_LOCAL_TIMEOUT="${ORACLE_LOCAL_TIMEOUT:-900}"
+ORACLE_LOCAL_SQL_TIMEOUT="${ORACLE_LOCAL_SQL_TIMEOUT:-30}"
+ORACLE_LOCAL_SETTLE_SECONDS="${ORACLE_LOCAL_SETTLE_SECONDS:-60}"
+
+export ORACLE_LOCAL_IMAGE
+export ORACLE_LOCAL_CONTAINER
+export ORACLE_LOCAL_VOLUME
+export ORACLE_LOCAL_PORT
+export ORACLE_LOCAL_SYS_PASSWORD
+
+jdbc_url() {
+    echo "jdbc:oracle:thin:@//localhost:${ORACLE_LOCAL_PORT}/${ORACLE_LOCAL_PDB}"
+}
+
+compose() {
+    docker compose -f "$COMPOSE_FILE" "$@"
+}
+
+require_docker() {
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "[오류] docker CLI를 찾을 수 없습니다." >&2
+        exit 1
+    fi
+
+    if ! docker info >/dev/null 2>&1; then
+        echo "[오류] Docker 데몬에 연결할 수 없습니다." >&2
+        exit 1
+    fi
+
+    if ! docker compose version >/dev/null 2>&1; then
+        echo "[오류] docker compose를 사용할 수 없습니다." >&2
+        exit 1
+    fi
+
+    if [[ ! -f "$COMPOSE_FILE" ]]; then
+        echo "[오류] Compose 파일을 찾을 수 없습니다: $COMPOSE_FILE" >&2
+        exit 1
+    fi
+
+}
+
+require_bootstrap_sql() {
+    if [[ ! -f "$BOOTSTRAP_SQL" ]]; then
+        echo "[오류] bootstrap SQL을 찾을 수 없습니다: $BOOTSTRAP_SQL" >&2
+        exit 1
+    fi
+}
+
+start() {
+    require_docker
+    echo "[시작] 로컬 Oracle 컨테이너를 기동합니다: $ORACLE_LOCAL_CONTAINER"
+    compose up -d
+    echo "[정보] JDBC URL: $(jdbc_url)"
+}
+
+sqlplus_system() {
+    docker exec -i "$ORACLE_LOCAL_CONTAINER" timeout "${ORACLE_LOCAL_SQL_TIMEOUT}s" sqlplus -s /nolog
+}
+
+wait_for_ready() {
+    require_docker
+    echo "[대기] Oracle 준비 상태를 확인합니다. 제한 시간: ${ORACLE_LOCAL_TIMEOUT}초"
+
+    local start_time
+    local elapsed
+    local log_ready=0
+    local sql_ready=0
+    start_time="$(date +%s)"
+
+    while true; do
+        elapsed="$(($(date +%s) - start_time))"
+        if (( elapsed > ORACLE_LOCAL_TIMEOUT )); then
+            echo "[오류] Oracle 준비 대기 시간이 초과되었습니다." >&2
+            echo "로그 확인: ./scripts/oracle-local.sh logs" >&2
+            exit 1
+        fi
+
+        if [[ "$(docker logs "$ORACLE_LOCAL_CONTAINER" 2>&1)" == *"DATABASE IS READY TO USE"* ]]; then
+            log_ready=1
+        fi
+
+        if [[ "$log_ready" -eq 1 ]] && {
+            printf 'connect system/%s@//localhost:1521/%s\n' "$ORACLE_LOCAL_SYS_PASSWORD" "$ORACLE_LOCAL_PDB"
+            printf '%s\n' \
+                "set heading off feedback off pagesize 0 verify off" \
+                "select 1 from dual;" \
+                "exit"
+        } | sqlplus_system 2>/dev/null | grep -q '^[[:space:]]*1[[:space:]]*$'; then
+            sql_ready=1
+        fi
+
+        if [[ "$log_ready" -eq 1 && "$sql_ready" -eq 1 ]]; then
+            echo "[확인] Oracle 로그와 SQL 연결이 모두 준비되었습니다."
+            return 0
+        fi
+
+        sleep 5
+    done
+}
+
+bootstrap() {
+    require_docker
+    require_bootstrap_sql
+    echo "[초기화] 애플리케이션/테스트 계정을 준비합니다."
+    docker cp "$BOOTSTRAP_SQL" "$ORACLE_LOCAL_CONTAINER:/tmp/bootstrap.sql"
+    {
+        printf 'connect system/%s@//localhost:1521/%s\n' "$ORACLE_LOCAL_SYS_PASSWORD" "$ORACLE_LOCAL_PDB"
+        printf '@/tmp/bootstrap.sql "%s" "%s" "%s" "%s"\n' \
+            "$ORACLE_LOCAL_APP_USER" \
+            "$ORACLE_LOCAL_APP_PASSWORD" \
+            "$ORACLE_LOCAL_TEST_USER" \
+            "$ORACLE_LOCAL_TEST_PASSWORD"
+    } | sqlplus_system
+    echo "[확인] 계정 준비가 완료되었습니다."
+}
+
+settle() {
+    if [[ "$ORACLE_LOCAL_SETTLE_SECONDS" =~ ^[0-9]+$ ]] && (( ORACLE_LOCAL_SETTLE_SECONDS > 0 )); then
+        echo "[대기] Oracle background 작업 안정화를 위해 ${ORACLE_LOCAL_SETTLE_SECONDS}초 대기합니다."
+        sleep "$ORACLE_LOCAL_SETTLE_SECONDS"
+    else
+        echo "[대기] Oracle 안정화 대기를 건너뜁니다."
+    fi
+}
+
+status() {
+    echo "[상태] 로컬 Oracle 설정"
+    if command -v docker >/dev/null 2>&1; then
+        echo "  - Docker CLI: 사용 가능 ($(docker --version))"
+    else
+        echo "  - Docker CLI: 없음"
+    fi
+
+    if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+        echo "  - Docker Compose: 사용 가능 ($(docker compose version --short))"
+    else
+        echo "  - Docker Compose: 없음"
+    fi
+
+    echo "  - 컨테이너: $ORACLE_LOCAL_CONTAINER"
+    echo "  - 이미지: $ORACLE_LOCAL_IMAGE"
+    echo "  - 볼륨: $ORACLE_LOCAL_VOLUME"
+    echo "  - 포트: localhost:$ORACLE_LOCAL_PORT -> 1521"
+    echo "  - JDBC URL: $(jdbc_url)"
+    echo "  - 앱 사용자: $ORACLE_LOCAL_APP_USER"
+    echo "  - 테스트 사용자: $ORACLE_LOCAL_TEST_USER"
+
+    if command -v docker >/dev/null 2>&1 && docker ps -a --format '{{.Names}}' | grep -Fxq "$ORACLE_LOCAL_CONTAINER"; then
+        echo "  - 컨테이너 상태: $(docker inspect -f '{{.State.Status}}' "$ORACLE_LOCAL_CONTAINER")"
+    else
+        echo "  - 컨테이너 상태: 생성되지 않음"
+    fi
+
+    cat <<'MSG'
+
+다음 명령:
+  ./gradlew oracleLocalTest --console=plain
+  ./gradlew oracleLocalInitializeDatabase --console=plain
+  ./gradlew oracleLocalResetFixedSeed --console=plain
+  ./scripts/oracle-local.sh start
+  ./scripts/oracle-local.sh wait
+  ./scripts/oracle-local.sh bootstrap
+  ./scripts/oracle-local.sh settle
+  ./scripts/oracle-local.sh stop
+  ./scripts/oracle-local.sh reset
+
+로그 확인:
+  ./scripts/oracle-local.sh logs
+MSG
+}
+
+reset() {
+    require_docker
+    require_bootstrap_sql
+    echo "[초기화] 컨테이너와 로컬 Oracle 볼륨을 삭제합니다: $ORACLE_LOCAL_VOLUME"
+    compose down -v
+    echo "[시작] 새 로컬 Oracle 컨테이너를 기동합니다: $ORACLE_LOCAL_CONTAINER"
+    compose up -d
+    wait_for_ready
+    bootstrap
+    settle
+    echo "[확인] 로컬 Oracle 재생성이 완료되었습니다."
+}
+
+stop() {
+    require_docker
+    echo "[중지] 로컬 Oracle 컨테이너를 중지합니다."
+    compose down
+}
+
+logs() {
+    require_docker
+    compose logs -f oracle-local
+}
+
+usage() {
+    cat <<'MSG'
+사용법: ./scripts/oracle-local.sh <command>
+
+명령:
+  start      컨테이너 기동
+  wait       Oracle readiness 확인
+  bootstrap  실행 중인 컨테이너에 앱/테스트 계정 준비
+  settle     bootstrap 후 Oracle background 작업 안정화 대기
+  status     현재 설정과 다음 명령 출력
+  reset      컨테이너와 볼륨 삭제 후 계정 bootstrap
+  stop       컨테이너 중지
+  logs       Oracle 컨테이너 로그 팔로우
+  help       도움말 출력
+MSG
+}
+
+command_name="${1:-help}"
+if [[ $# -gt 0 ]]; then
+    shift
+fi
+
+if [[ $# -gt 0 ]]; then
+    echo "[오류] 예상하지 못한 추가 인자: $*" >&2
+    usage >&2
+    exit 1
+fi
+
+case "$command_name" in
+    start)
+        start
+        ;;
+    wait)
+        wait_for_ready
+        ;;
+    bootstrap)
+        bootstrap
+        ;;
+    settle)
+        settle
+        ;;
+    status)
+        status
+        ;;
+    reset)
+        reset
+        ;;
+    stop)
+        stop
+        ;;
+    logs)
+        logs
+        ;;
+    help|--help|-h)
+        usage
+        ;;
+    *)
+        echo "[오류] 알 수 없는 명령: $command_name" >&2
+        usage >&2
+        exit 1
+        ;;
+esac

--- a/scripts/oracle-local.sh
+++ b/scripts/oracle-local.sh
@@ -74,6 +74,12 @@ sqlplus_system() {
     docker exec -i "$ORACLE_LOCAL_CONTAINER" timeout "${ORACLE_LOCAL_SQL_TIMEOUT}s" sqlplus -s /nolog
 }
 
+system_connect_sql() {
+    printf 'set define off\nconnect system/"%s"@//localhost:1521/%s\n' \
+        "$ORACLE_LOCAL_SYS_PASSWORD" \
+        "$ORACLE_LOCAL_PDB"
+}
+
 wait_for_ready() {
     require_docker
     echo "[대기] Oracle 준비 상태를 확인합니다. 제한 시간: ${ORACLE_LOCAL_TIMEOUT}초"
@@ -92,12 +98,12 @@ wait_for_ready() {
             exit 1
         fi
 
-        if [[ "$(docker logs "$ORACLE_LOCAL_CONTAINER" 2>&1)" == *"DATABASE IS READY TO USE"* ]]; then
+        if [[ "$(docker logs --tail 100 "$ORACLE_LOCAL_CONTAINER" 2>&1)" == *"DATABASE IS READY TO USE"* ]]; then
             log_ready=1
         fi
 
         if [[ "$log_ready" -eq 1 ]] && {
-            printf 'connect system/%s@//localhost:1521/%s\n' "$ORACLE_LOCAL_SYS_PASSWORD" "$ORACLE_LOCAL_PDB"
+            system_connect_sql
             printf '%s\n' \
                 "set heading off feedback off pagesize 0 verify off" \
                 "select 1 from dual;" \
@@ -121,7 +127,7 @@ bootstrap() {
     echo "[초기화] 애플리케이션/테스트 계정을 준비합니다."
     docker cp "$BOOTSTRAP_SQL" "$ORACLE_LOCAL_CONTAINER:/tmp/bootstrap.sql"
     {
-        printf 'connect system/%s@//localhost:1521/%s\n' "$ORACLE_LOCAL_SYS_PASSWORD" "$ORACLE_LOCAL_PDB"
+        system_connect_sql
         printf '@/tmp/bootstrap.sql "%s" "%s" "%s" "%s"\n' \
             "$ORACLE_LOCAL_APP_USER" \
             "$ORACLE_LOCAL_APP_PASSWORD" \

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProvider.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProvider.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -53,56 +54,66 @@ public final class DriverManagerConnectionProvider implements DatabaseConnection
     }
 
     public static DriverManagerConnectionProvider fromIntegrationTestEnvironment() {
-        String url = readEnvironment("ITS_TEST_DB_URL", readEnvironment("ITS_DB_URL", DEFAULT_ORACLE_URL));
-        String user = readRequiredEnvironment("ITS_TEST_DB_USER");
-        String password = readRequiredEnvironment("ITS_TEST_DB_PASSWORD");
-        int connectionRetries = readNonNegativeIntegerEnvironment("ITS_TEST_DB_CONNECT_RETRIES", 0);
-        long retryDelayMillis = readNonNegativeLongEnvironment("ITS_TEST_DB_CONNECT_RETRY_DELAY_MS", 0);
+        return fromIntegrationTestEnvironment(System.getenv(), DriverManager::getConnection);
+    }
+
+    static DriverManagerConnectionProvider fromIntegrationTestEnvironment(
+            Map<String, String> environment,
+            ConnectionOpener connectionOpener) {
+        Objects.requireNonNull(environment, "environment");
+        Objects.requireNonNull(connectionOpener, "connectionOpener");
+        String url = readEnvironment(environment, "ITS_TEST_DB_URL",
+                readEnvironment(environment, "ITS_DB_URL", DEFAULT_ORACLE_URL));
+        String user = readRequiredEnvironment(environment, "ITS_TEST_DB_USER");
+        String password = readRequiredEnvironment(environment, "ITS_TEST_DB_PASSWORD");
+        int connectionRetries = readNonNegativeIntegerEnvironment(environment, "ITS_TEST_DB_CONNECT_RETRIES", 0);
+        long retryDelayMillis = readNonNegativeLongEnvironment(environment, "ITS_TEST_DB_CONNECT_RETRY_DELAY_MS", 0);
         return new DriverManagerConnectionProvider(
                 url,
                 user,
                 password,
                 connectionRetries,
                 retryDelayMillis,
-                DriverManager::getConnection);
+                connectionOpener);
     }
 
     @Override
     public Connection getConnection() throws SQLException {
-        SQLException lastException = null;
-        int maxAttempts = connectionRetries + 1;
-        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+        int attempt = 1;
+        while (true) {
             try {
                 return connectionOpener.open(url, user, password);
             } catch (SQLException exception) {
-                lastException = exception;
-                if (attempt == maxAttempts || !isRetryableConnectionException(exception)) {
+                if (attempt > connectionRetries || !isRetryableConnectionException(exception)) {
                     throw exception;
                 }
                 sleepBeforeRetry();
+                attempt++;
             }
         }
-        throw lastException;
     }
 
-    private static String readEnvironment(String name, String defaultValue) {
-        String value = System.getenv(name);
+    private static String readEnvironment(Map<String, String> environment, String name, String defaultValue) {
+        String value = environment.get(name);
         if (value == null || value.isBlank()) {
             return defaultValue;
         }
         return value;
     }
 
-    private static String readRequiredEnvironment(String name) {
-        String value = System.getenv(name);
+    private static String readRequiredEnvironment(Map<String, String> environment, String name) {
+        String value = environment.get(name);
         if (value == null || value.isBlank()) {
             throw new IllegalStateException(name + " environment variable is required.");
         }
         return value;
     }
 
-    private static int readNonNegativeIntegerEnvironment(String name, int defaultValue) {
-        String value = System.getenv(name);
+    private static int readNonNegativeIntegerEnvironment(
+            Map<String, String> environment,
+            String name,
+            int defaultValue) {
+        String value = environment.get(name);
         if (value == null || value.isBlank()) {
             return defaultValue;
         }
@@ -113,8 +124,11 @@ public final class DriverManagerConnectionProvider implements DatabaseConnection
         }
     }
 
-    private static long readNonNegativeLongEnvironment(String name, long defaultValue) {
-        String value = System.getenv(name);
+    private static long readNonNegativeLongEnvironment(
+            Map<String, String> environment,
+            String name,
+            long defaultValue) {
+        String value = environment.get(name);
         if (value == null || value.isBlank()) {
             return defaultValue;
         }

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProvider.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProvider.java
@@ -3,20 +3,44 @@ package com.github.marcellokim.issuetracker.persistence;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 public final class DriverManagerConnectionProvider implements DatabaseConnectionProvider {
 
     public static final String DEFAULT_ORACLE_URL = "jdbc:oracle:thin:@//localhost:1521/XEPDB1";
+    private static final List<String> RETRYABLE_ORACLE_ERRORS = List.of(
+            "ORA-12514",
+            "ORA-12516",
+            "ORA-12519",
+            "ORA-12520");
+    private static final Set<Integer> RETRYABLE_ORACLE_ERROR_CODES = Set.of(12514, 12516, 12519, 12520);
 
     private final String url;
     private final String user;
     private final String password;
+    private final int connectionRetries;
+    private final long retryDelayMillis;
+    private final ConnectionOpener connectionOpener;
 
     public DriverManagerConnectionProvider(String url, String user, String password) {
+        this(url, user, password, 0, 0, DriverManager::getConnection);
+    }
+
+    DriverManagerConnectionProvider(
+            String url,
+            String user,
+            String password,
+            int connectionRetries,
+            long retryDelayMillis,
+            ConnectionOpener connectionOpener) {
         this.url = Objects.requireNonNull(url, "url");
         this.user = Objects.requireNonNull(user, "user");
         this.password = Objects.requireNonNull(password, "password");
+        this.connectionRetries = requireNonNegative(connectionRetries, "connectionRetries");
+        this.retryDelayMillis = requireNonNegative(retryDelayMillis, "retryDelayMillis");
+        this.connectionOpener = Objects.requireNonNull(connectionOpener, "connectionOpener");
     }
 
     public static DriverManagerConnectionProvider fromEnvironment() {
@@ -32,12 +56,33 @@ public final class DriverManagerConnectionProvider implements DatabaseConnection
         String url = readEnvironment("ITS_TEST_DB_URL", readEnvironment("ITS_DB_URL", DEFAULT_ORACLE_URL));
         String user = readRequiredEnvironment("ITS_TEST_DB_USER");
         String password = readRequiredEnvironment("ITS_TEST_DB_PASSWORD");
-        return new DriverManagerConnectionProvider(url, user, password);
+        int connectionRetries = readNonNegativeIntegerEnvironment("ITS_TEST_DB_CONNECT_RETRIES", 0);
+        long retryDelayMillis = readNonNegativeLongEnvironment("ITS_TEST_DB_CONNECT_RETRY_DELAY_MS", 0);
+        return new DriverManagerConnectionProvider(
+                url,
+                user,
+                password,
+                connectionRetries,
+                retryDelayMillis,
+                DriverManager::getConnection);
     }
 
     @Override
     public Connection getConnection() throws SQLException {
-        return DriverManager.getConnection(url, user, password);
+        SQLException lastException = null;
+        int maxAttempts = connectionRetries + 1;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                return connectionOpener.open(url, user, password);
+            } catch (SQLException exception) {
+                lastException = exception;
+                if (attempt == maxAttempts || !isRetryableConnectionException(exception)) {
+                    throw exception;
+                }
+                sleepBeforeRetry();
+            }
+        }
+        throw lastException;
     }
 
     private static String readEnvironment(String name, String defaultValue) {
@@ -54,5 +99,78 @@ public final class DriverManagerConnectionProvider implements DatabaseConnection
             throw new IllegalStateException(name + " environment variable is required.");
         }
         return value;
+    }
+
+    private static int readNonNegativeIntegerEnvironment(String name, int defaultValue) {
+        String value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        try {
+            return requireNonNegative(Integer.parseInt(value), name);
+        } catch (NumberFormatException exception) {
+            throw new IllegalStateException(name + " must be a non-negative integer.", exception);
+        }
+    }
+
+    private static long readNonNegativeLongEnvironment(String name, long defaultValue) {
+        String value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        try {
+            return requireNonNegative(Long.parseLong(value), name);
+        } catch (NumberFormatException exception) {
+            throw new IllegalStateException(name + " must be a non-negative integer.", exception);
+        }
+    }
+
+    private static int requireNonNegative(int value, String name) {
+        if (value < 0) {
+            throw new IllegalArgumentException(name + " must not be negative.");
+        }
+        return value;
+    }
+
+    private static long requireNonNegative(long value, String name) {
+        if (value < 0) {
+            throw new IllegalArgumentException(name + " must not be negative.");
+        }
+        return value;
+    }
+
+    private static boolean isRetryableConnectionException(SQLException exception) {
+        for (Throwable current = exception; current != null; current = current.getCause()) {
+            if (current instanceof SQLException sqlException && isRetryableOracleError(sqlException)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isRetryableOracleError(SQLException exception) {
+        if (RETRYABLE_ORACLE_ERROR_CODES.contains(exception.getErrorCode())) {
+            return true;
+        }
+        String message = exception.getMessage();
+        return message != null && RETRYABLE_ORACLE_ERRORS.stream().anyMatch(message::contains);
+    }
+
+    private void sleepBeforeRetry() throws SQLException {
+        if (retryDelayMillis == 0) {
+            return;
+        }
+        try {
+            Thread.sleep(retryDelayMillis);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new SQLException("Interrupted while waiting to retry Oracle connection.", exception);
+        }
+    }
+
+    @FunctionalInterface
+    interface ConnectionOpener {
+
+        Connection open(String url, String user, String password) throws SQLException;
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProvider.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProvider.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -167,7 +168,8 @@ public final class DriverManagerConnectionProvider implements DatabaseConnection
             return true;
         }
         String message = exception.getMessage();
-        return message != null && RETRYABLE_ORACLE_ERRORS.stream().anyMatch(message::contains);
+        String normalizedMessage = message == null ? "" : message.toUpperCase(Locale.ROOT);
+        return RETRYABLE_ORACLE_ERRORS.stream().anyMatch(normalizedMessage::contains);
     }
 
     private void sleepBeforeRetry() throws SQLException {

--- a/src/test/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProviderTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProviderTest.java
@@ -1,0 +1,110 @@
+package com.github.marcellokim.issuetracker.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("DriverManager connection provider")
+class DriverManagerConnectionProviderTest {
+
+    @Test
+    @DisplayName("retries transient Oracle listener connection error codes")
+    void retriesTransientOracleListenerConnectionErrorCodes() throws SQLException {
+        AtomicInteger attempts = new AtomicInteger();
+        Connection expectedConnection = connectionProxy();
+        DriverManagerConnectionProvider provider = new DriverManagerConnectionProvider(
+                "jdbc:oracle:thin:@//localhost:1521/FREEPDB1",
+                "ITS_TEST_USER",
+                "secret",
+                2,
+                0,
+                (url, user, password) -> {
+                    if (attempts.incrementAndGet() < 3) {
+                        throw new SQLException("listener could not find available handler", "66000", 12516);
+                    }
+                    return expectedConnection;
+                });
+
+        assertSame(expectedConnection, provider.getConnection());
+        assertEquals(3, attempts.get());
+    }
+
+    @Test
+    @DisplayName("retries transient Oracle listener messages without vendor codes")
+    void retriesTransientOracleListenerMessagesWithoutVendorCodes() throws SQLException {
+        AtomicInteger attempts = new AtomicInteger();
+        Connection expectedConnection = connectionProxy();
+        DriverManagerConnectionProvider provider = new DriverManagerConnectionProvider(
+                "jdbc:oracle:thin:@//localhost:1521/FREEPDB1",
+                "ITS_TEST_USER",
+                "secret",
+                1,
+                0,
+                (url, user, password) -> {
+                    if (attempts.incrementAndGet() == 1) {
+                        throw new SQLException("ORA-12516: listener could not find available handler");
+                    }
+                    return expectedConnection;
+                });
+
+        assertSame(expectedConnection, provider.getConnection());
+        assertEquals(2, attempts.get());
+    }
+
+    @Test
+    @DisplayName("does not retry non-listener SQL exceptions")
+    void doesNotRetryNonListenerSqlExceptions() {
+        AtomicInteger attempts = new AtomicInteger();
+        DriverManagerConnectionProvider provider = new DriverManagerConnectionProvider(
+                "jdbc:oracle:thin:@//localhost:1521/FREEPDB1",
+                "ITS_TEST_USER",
+                "secret",
+                3,
+                0,
+                (url, user, password) -> {
+                    attempts.incrementAndGet();
+                    throw new SQLException("ORA-01017: invalid username/password");
+                });
+
+        assertThrows(SQLException.class, provider::getConnection);
+        assertEquals(1, attempts.get());
+    }
+
+    @Test
+    @DisplayName("rejects negative retry settings")
+    void rejectsNegativeRetrySettings() {
+        assertThrows(IllegalArgumentException.class, () -> new DriverManagerConnectionProvider(
+                "jdbc:oracle:thin:@//localhost:1521/FREEPDB1",
+                "ITS_TEST_USER",
+                "secret",
+                -1,
+                0,
+                (url, user, password) -> connectionProxy()));
+        assertThrows(IllegalArgumentException.class, () -> new DriverManagerConnectionProvider(
+                "jdbc:oracle:thin:@//localhost:1521/FREEPDB1",
+                "ITS_TEST_USER",
+                "secret",
+                0,
+                -1,
+                (url, user, password) -> connectionProxy()));
+    }
+
+    private static Connection connectionProxy() {
+        return (Connection) Proxy.newProxyInstance(
+                Connection.class.getClassLoader(),
+                new Class<?>[] { Connection.class },
+                (proxy, method, args) -> {
+                    if ("toString".equals(method.getName())) {
+                        return "connection-proxy";
+                    }
+                    throw new UnsupportedOperationException(method.getName());
+                });
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProviderTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProviderTest.java
@@ -161,6 +161,28 @@ class DriverManagerConnectionProviderTest {
     }
 
     @Test
+    @DisplayName("retries transient Oracle listener messages case-insensitively")
+    void retriesTransientOracleListenerMessagesCaseInsensitively() throws SQLException {
+        AtomicInteger attempts = new AtomicInteger();
+        Connection expectedConnection = connectionProxy();
+        DriverManagerConnectionProvider provider = new DriverManagerConnectionProvider(
+                "jdbc:oracle:thin:@//localhost:1521/FREEPDB1",
+                "ITS_TEST_USER",
+                "secret",
+                1,
+                0,
+                (url, user, password) -> {
+                    if (attempts.incrementAndGet() == 1) {
+                        throw new SQLException("ora-12514: listener does not currently know of service requested");
+                    }
+                    return expectedConnection;
+                });
+
+        assertSame(expectedConnection, provider.getConnection());
+        assertEquals(2, attempts.get());
+    }
+
+    @Test
     @DisplayName("walks exception causes to find retryable Oracle listener errors")
     void walksExceptionCausesToFindRetryableOracleListenerErrors() throws SQLException {
         AtomicInteger attempts = new AtomicInteger();

--- a/src/test/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProviderTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProviderTest.java
@@ -3,16 +3,118 @@ package com.github.marcellokim.issuetracker.persistence;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("DriverManager connection provider")
 class DriverManagerConnectionProviderTest {
+
+    @Test
+    @DisplayName("default constructor opens a plain driver manager connection without retry")
+    void defaultConstructorOpensPlainDriverManagerConnectionWithoutRetry() {
+        DriverManagerConnectionProvider provider = new DriverManagerConnectionProvider(
+                "jdbc:unknown:issue-tracker",
+                "ITS_TEST_USER",
+                "secret");
+
+        assertThrows(SQLException.class, provider::getConnection);
+    }
+
+    @Test
+    @DisplayName("creates default provider from database environment")
+    void createsDefaultProviderFromDatabaseEnvironment() {
+        DriverManagerConnectionProvider provider = DriverManagerConnectionProvider.from(
+                new DatabaseEnvironment("jdbc:unknown:issue-tracker", "ITS_TEST_USER", "secret"));
+
+        assertThrows(SQLException.class, provider::getConnection);
+        assertThrows(NullPointerException.class, () -> DriverManagerConnectionProvider.from(null));
+    }
+
+    @Test
+    @DisplayName("parses integration-test environment and retries with configured settings")
+    void parsesIntegrationTestEnvironmentAndRetriesWithConfiguredSettings() throws SQLException {
+        AtomicInteger attempts = new AtomicInteger();
+        Connection expectedConnection = connectionProxy();
+        Map<String, String> environment = withIntegrationEnvironment(
+                "ITS_TEST_DB_URL", "jdbc:oracle:thin:@//localhost:1521/FREEPDB1",
+                "ITS_TEST_DB_CONNECT_RETRIES", "1",
+                "ITS_TEST_DB_CONNECT_RETRY_DELAY_MS", "0");
+        DriverManagerConnectionProvider provider = DriverManagerConnectionProvider.fromIntegrationTestEnvironment(
+                environment,
+                (url, user, password) -> {
+                    assertEquals("jdbc:oracle:thin:@//localhost:1521/FREEPDB1", url);
+                    assertEquals("ITS_TEST_USER", user);
+                    assertEquals("secret", password);
+                    if (attempts.incrementAndGet() == 1) {
+                        throw new SQLException("listener does not currently know of service", "66000", 12514);
+                    }
+                    return expectedConnection;
+                });
+
+        assertSame(expectedConnection, provider.getConnection());
+        assertEquals(2, attempts.get());
+    }
+
+    @Test
+    @DisplayName("uses shared database URL and default retry settings when test overrides are blank")
+    void usesSharedDatabaseUrlAndDefaultRetrySettingsWhenTestOverridesAreBlank() throws SQLException {
+        AtomicInteger attempts = new AtomicInteger();
+        Connection expectedConnection = connectionProxy();
+        Map<String, String> environment = withIntegrationEnvironment(
+                "ITS_TEST_DB_URL", " ",
+                "ITS_DB_URL", "jdbc:oracle:thin:@//localhost:1521/XEPDB1",
+                "ITS_TEST_DB_CONNECT_RETRIES", " ",
+                "ITS_TEST_DB_CONNECT_RETRY_DELAY_MS", " ");
+        DriverManagerConnectionProvider provider = DriverManagerConnectionProvider.fromIntegrationTestEnvironment(
+                environment,
+                (url, user, password) -> {
+                    attempts.incrementAndGet();
+                    assertEquals("jdbc:oracle:thin:@//localhost:1521/XEPDB1", url);
+                    return expectedConnection;
+                });
+
+        assertSame(expectedConnection, provider.getConnection());
+        assertEquals(1, attempts.get());
+    }
+
+    @Test
+    @DisplayName("rejects invalid integration-test retry environment settings")
+    void rejectsInvalidIntegrationTestRetryEnvironmentSettings() {
+        assertThrows(IllegalStateException.class, () -> DriverManagerConnectionProvider.fromIntegrationTestEnvironment(
+                withIntegrationEnvironment("ITS_TEST_DB_CONNECT_RETRIES", "abc"),
+                (url, user, password) -> connectionProxy()));
+        assertThrows(IllegalArgumentException.class, () -> DriverManagerConnectionProvider.fromIntegrationTestEnvironment(
+                withIntegrationEnvironment("ITS_TEST_DB_CONNECT_RETRIES", "-1"),
+                (url, user, password) -> connectionProxy()));
+        assertThrows(IllegalStateException.class, () -> DriverManagerConnectionProvider.fromIntegrationTestEnvironment(
+                withIntegrationEnvironment("ITS_TEST_DB_CONNECT_RETRY_DELAY_MS", "abc"),
+                (url, user, password) -> connectionProxy()));
+        assertThrows(IllegalArgumentException.class, () -> DriverManagerConnectionProvider.fromIntegrationTestEnvironment(
+                withIntegrationEnvironment("ITS_TEST_DB_CONNECT_RETRY_DELAY_MS", "-1"),
+                (url, user, password) -> connectionProxy()));
+    }
+
+    @Test
+    @DisplayName("requires integration-test database credentials")
+    void requiresIntegrationTestDatabaseCredentials() {
+        assertThrows(IllegalStateException.class, () -> DriverManagerConnectionProvider.fromIntegrationTestEnvironment(
+                withIntegrationEnvironment("ITS_TEST_DB_USER", " "),
+                (url, user, password) -> connectionProxy()));
+        assertThrows(IllegalStateException.class, () -> DriverManagerConnectionProvider.fromIntegrationTestEnvironment(
+                withoutIntegrationEnvironmentKey("ITS_TEST_DB_USER"),
+                (url, user, password) -> connectionProxy()));
+        assertThrows(IllegalStateException.class, () -> DriverManagerConnectionProvider.fromIntegrationTestEnvironment(
+                withIntegrationEnvironment("ITS_TEST_DB_PASSWORD", ""),
+                (url, user, password) -> connectionProxy()));
+    }
 
     @Test
     @DisplayName("retries transient Oracle listener connection error codes")
@@ -59,6 +161,50 @@ class DriverManagerConnectionProviderTest {
     }
 
     @Test
+    @DisplayName("walks exception causes to find retryable Oracle listener errors")
+    void walksExceptionCausesToFindRetryableOracleListenerErrors() throws SQLException {
+        AtomicInteger attempts = new AtomicInteger();
+        Connection expectedConnection = connectionProxy();
+        SQLException nestedRetryableException = new SQLException("ORA-12514: listener does not know service");
+        SQLException wrapperException = new SQLException("connection failed");
+        wrapperException.initCause(new RuntimeException(nestedRetryableException));
+        DriverManagerConnectionProvider provider = new DriverManagerConnectionProvider(
+                "jdbc:oracle:thin:@//localhost:1521/FREEPDB1",
+                "ITS_TEST_USER",
+                "secret",
+                1,
+                0,
+                (url, user, password) -> {
+                    if (attempts.incrementAndGet() == 1) {
+                        throw wrapperException;
+                    }
+                    return expectedConnection;
+                });
+
+        assertSame(expectedConnection, provider.getConnection());
+        assertEquals(2, attempts.get());
+    }
+
+    @Test
+    @DisplayName("does not retry retryable SQL exceptions after the configured budget")
+    void doesNotRetryRetryableSqlExceptionsAfterConfiguredBudget() {
+        AtomicInteger attempts = new AtomicInteger();
+        DriverManagerConnectionProvider provider = new DriverManagerConnectionProvider(
+                "jdbc:oracle:thin:@//localhost:1521/FREEPDB1",
+                "ITS_TEST_USER",
+                "secret",
+                0,
+                0,
+                (url, user, password) -> {
+                    attempts.incrementAndGet();
+                    throw new SQLException("listener does not currently know of service", "66000", 12514);
+                });
+
+        assertThrows(SQLException.class, provider::getConnection);
+        assertEquals(1, attempts.get());
+    }
+
+    @Test
     @DisplayName("does not retry non-listener SQL exceptions")
     void doesNotRetryNonListenerSqlExceptions() {
         AtomicInteger attempts = new AtomicInteger();
@@ -78,6 +224,74 @@ class DriverManagerConnectionProviderTest {
     }
 
     @Test
+    @DisplayName("does not retry SQL exceptions without retryable codes or messages")
+    void doesNotRetrySqlExceptionsWithoutRetryableCodesOrMessages() {
+        AtomicInteger attempts = new AtomicInteger();
+        DriverManagerConnectionProvider provider = new DriverManagerConnectionProvider(
+                "jdbc:oracle:thin:@//localhost:1521/FREEPDB1",
+                "ITS_TEST_USER",
+                "secret",
+                3,
+                0,
+                (url, user, password) -> {
+                    attempts.incrementAndGet();
+                    throw new SQLException((String) null);
+                });
+
+        assertThrows(SQLException.class, provider::getConnection);
+        assertEquals(1, attempts.get());
+    }
+
+    @Test
+    @DisplayName("waits before retry when retry delay is configured")
+    void waitsBeforeRetryWhenRetryDelayIsConfigured() throws SQLException {
+        AtomicInteger attempts = new AtomicInteger();
+        Connection expectedConnection = connectionProxy();
+        DriverManagerConnectionProvider provider = new DriverManagerConnectionProvider(
+                "jdbc:oracle:thin:@//localhost:1521/FREEPDB1",
+                "ITS_TEST_USER",
+                "secret",
+                1,
+                1,
+                (url, user, password) -> {
+                    if (attempts.incrementAndGet() == 1) {
+                        throw new SQLException("listener does not currently know of service", "66000", 12516);
+                    }
+                    return expectedConnection;
+                });
+
+        assertSame(expectedConnection, provider.getConnection());
+        assertEquals(2, attempts.get());
+    }
+
+    @Test
+    @DisplayName("wraps interruptions while waiting before retry")
+    void wrapsInterruptionsWhileWaitingBeforeRetry() {
+        AtomicInteger attempts = new AtomicInteger();
+        DriverManagerConnectionProvider provider = new DriverManagerConnectionProvider(
+                "jdbc:oracle:thin:@//localhost:1521/FREEPDB1",
+                "ITS_TEST_USER",
+                "secret",
+                1,
+                1_000,
+                (url, user, password) -> {
+                    attempts.incrementAndGet();
+                    throw new SQLException("listener does not currently know of service", "66000", 12516);
+                });
+
+        Thread.currentThread().interrupt();
+        try {
+            SQLException exception = assertThrows(SQLException.class, provider::getConnection);
+
+            assertEquals("Interrupted while waiting to retry Oracle connection.", exception.getMessage());
+            assertTrue(Thread.currentThread().isInterrupted());
+            assertEquals(1, attempts.get());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
     @DisplayName("rejects negative retry settings")
     void rejectsNegativeRetrySettings() {
         assertThrows(IllegalArgumentException.class, () -> new DriverManagerConnectionProvider(
@@ -94,6 +308,22 @@ class DriverManagerConnectionProviderTest {
                 0,
                 -1,
                 (url, user, password) -> connectionProxy()));
+    }
+
+    private static Map<String, String> withIntegrationEnvironment(String... entries) {
+        Map<String, String> environment = new HashMap<>();
+        environment.put("ITS_TEST_DB_USER", "ITS_TEST_USER");
+        environment.put("ITS_TEST_DB_PASSWORD", "secret");
+        for (int index = 0; index < entries.length; index += 2) {
+            environment.put(entries[index], entries[index + 1]);
+        }
+        return environment;
+    }
+
+    private static Map<String, String> withoutIntegrationEnvironmentKey(String key) {
+        Map<String, String> environment = withIntegrationEnvironment();
+        environment.remove(key);
+        return environment;
     }
 
     private static Connection connectionProxy() {


### PR DESCRIPTION
## 요약
- Oracle Free `23.26.0.0-lite` 기반 로컬 Docker Compose 환경을 추가했습니다.
- Unix/PowerShell 래퍼와 Gradle task로 bootstrap, seed, reset, 통합 테스트 실행 흐름을 연결했습니다.
- GitHub Actions에 `Oracle 통합 테스트` job을 추가해 PR마다 Docker 기반 DB 검증이 자동 실행되도록 했습니다.
- 통합 테스트 환경에서만 Oracle 접속 재시도를 적용해 컨테이너 기동 직후 ORA-12514 계열 흔들림을 완화했습니다.
- 팀원 실행 가이드는 `docs/local-oracle-testing.md`에 정리했습니다.

## 검증
- `git diff --check`
- `./gradlew check --console=plain`
- `ORACLE_LOCAL_TIMEOUT=900 ORACLE_LOCAL_SQL_TIMEOUT=30 ORACLE_LOCAL_SETTLE_SECONDS=60 ORACLE_LOCAL_CONNECT_RETRIES=12 ORACLE_LOCAL_CONNECT_RETRY_DELAY_MS=5000 ./gradlew oracleLocalTest --console=plain`
- `ORACLE_LOCAL_TIMEOUT=900 ORACLE_LOCAL_SQL_TIMEOUT=30 ORACLE_LOCAL_SETTLE_SECONDS=60 ./gradlew oracleLocalInitializeDatabase --console=plain`
- `./scripts/open-pr.sh`

## 관련 이슈
- Closes #94