### PR TITLE
feat: Tester 검증 실패 시 fixed 이슈를 assigned로 되돌리는 역전이 구현

### DIFF
--- a/docs/superpowers/plans/2026-05-24-issue-43-reject-fix-implementation.md
+++ b/docs/superpowers/plans/2026-05-24-issue-43-reject-fix-implementation.md
@@ -1,0 +1,282 @@
+# Issue 43 Reject Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete #43 by routing `changeStatus(issueId, ASSIGNED, comment, currentUserId)` through the existing reject-fix domain behavior.
+
+**Architecture:** Keep the public API unchanged. `IssueStateController` continues calling `IssueStateService.changeStatus(...)`; `IssueStateService` adds an `ASSIGNED` branch that validates permission, calls `Issue.rejectFix(...)`, records a `CommentPurpose.STATUS_CHANGE` comment, saves the issue, and returns `IssueStateResult`.
+
+**Tech Stack:** Java 21, Gradle, JUnit Jupiter 6.1.0, existing in-memory test repositories.
+
+---
+
+## File Structure
+
+- Modify `src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java`
+  - Owns service-level behavior for status transitions.
+  - Add failing #43 tests before production code.
+  - Keep `REOPENED` as unsupported because #47 owns reopen routing.
+- Modify `src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java`
+  - Owns application-service orchestration for status transitions.
+  - Add one `ASSIGNED` switch branch and one private `rejectFix(...)` helper.
+- No changes to `IssueStateController`, `Issue`, `PermissionPolicy`, `CommentPurpose`, repositories, schema, or UI.
+
+---
+
+### Task 1: Add Failing Service Tests
+
+**Files:**
+- Modify: `src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java`
+- Test: `src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java`
+
+- [ ] **Step 1: Add the successful reject-fix service test**
+
+Insert this test after `resolveFixedIssue()` and before `closeResolvedIssue()`:
+
+```java
+    @Test
+    @DisplayName("verifier rejects fixed issue back to assigned")
+    void rejectFixedIssueBackToAssigned() {
+        var issue = fixedIssue();
+        var service = service(issue);
+
+        var result = service.changeStatus(ISSUE_ID, IssueStatus.ASSIGNED, "Needs more work",
+                verifier.getLoginId());
+
+        assertEquals(IssueStatus.ASSIGNED, result.status());
+        assertEquals(IssueStatus.ASSIGNED, issue.getStatus());
+        assertSame(assignee, result.assignee());
+        assertSame(verifier, result.verifier());
+        assertSame(assignee, result.fixer());
+        assertNull(result.resolver());
+        assertSame(assignee, issue.getAssignee());
+        assertSame(verifier, issue.getVerifier());
+        assertSame(assignee, issue.getFixer());
+        assertNull(issue.getResolver());
+        assertEquals(1, issue.getComments().size());
+        assertEquals("Needs more work", issue.getComments().getFirst().getContent());
+        assertEquals(CommentPurpose.STATUS_CHANGE, issue.getComments().getFirst().getPurpose());
+
+        var histories = issue.getHistories();
+        var statusHistory = histories.get(histories.size() - 2);
+        assertEquals(ActionType.STATUS_CHANGED, statusHistory.getAction());
+        assertEquals(IssueStatus.FIXED.name(), statusHistory.getPreviousValue());
+        assertEquals(IssueStatus.ASSIGNED.name(), statusHistory.getNewValue());
+        assertEquals("Needs more work", statusHistory.getMessage());
+        assertStatusChangedThenCommented(issue);
+    }
+```
+
+- [ ] **Step 2: Add wrong-actor and non-FIXED failure tests**
+
+Insert these tests after `rejectCloseByPlFromOtherProject()` and before `rejectBlankCommentAndWrongParticipant()`:
+
+```java
+    @Test
+    @DisplayName("only current verifier can reject a fixed issue")
+    void rejectFixRequiresCurrentVerifier() {
+        var issue = fixedIssue();
+        int commentCount = issue.getComments().size();
+        int historyCount = issue.getHistories().size();
+        var service = service(issue);
+
+        assertThrows(SecurityException.class,
+                () -> service.changeStatus(ISSUE_ID, IssueStatus.ASSIGNED, "Needs more work",
+                        otherDev.getLoginId()));
+
+        assertEquals(commentCount, issue.getComments().size());
+        assertEquals(historyCount, issue.getHistories().size());
+    }
+
+    @Test
+    @DisplayName("reject fix requires fixed issue status")
+    void rejectFixRequiresFixedIssueStatus() {
+        var issue = assignedIssue();
+        int commentCount = issue.getComments().size();
+        int historyCount = issue.getHistories().size();
+        var service = service(issue);
+
+        assertThrows(IllegalStateException.class,
+                () -> service.changeStatus(ISSUE_ID, IssueStatus.ASSIGNED, "Needs more work",
+                        pl.getLoginId()));
+
+        assertEquals(commentCount, issue.getComments().size());
+        assertEquals(historyCount, issue.getHistories().size());
+    }
+```
+
+- [ ] **Step 3: Narrow the unsupported-target test to REOPENED only**
+
+Replace the existing `rejectUnsupportedTargetStatus()` test with:
+
+```java
+    @Test
+    @DisplayName("reopened status change target remains a feature gap")
+    void rejectUnsupportedReopenedTargetStatus() {
+        var resolved = resolvedIssue();
+        var resolvedService = service(resolved);
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> resolvedService.changeStatus(ISSUE_ID, IssueStatus.REOPENED, "Needs more work",
+                        pl.getLoginId()));
+    }
+```
+
+- [ ] **Step 4: Run the service test and verify the new tests fail for the expected reason**
+
+Run:
+
+```bash
+./gradlew test --tests com.github.marcellokim.issuetracker.service.IssueStateServiceTest --console=plain
+```
+
+Expected:
+
+- `rejectFixedIssueBackToAssigned` fails because `IssueStatus.ASSIGNED` still reaches `UnsupportedOperationException`.
+- `rejectFixRequiresCurrentVerifier` fails because `IssueStatus.ASSIGNED` still reaches `UnsupportedOperationException`.
+- `rejectFixRequiresFixedIssueStatus` fails because `IssueStatus.ASSIGNED` still reaches `UnsupportedOperationException`.
+- Existing FIXED, RESOLVED, CLOSED tests continue passing.
+
+---
+
+### Task 2: Route ASSIGNED Through Reject Fix
+
+**Files:**
+- Modify: `src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java`
+- Test: `src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java`
+
+- [ ] **Step 1: Add the ASSIGNED switch branch**
+
+In `IssueStateService.changeStatus(...)`, replace the switch with:
+
+```java
+        switch (requiredTargetStatus) {
+            case FIXED -> markFixed(issue, actor, requiredComment);
+            case RESOLVED -> resolve(issue, actor, requiredComment);
+            case ASSIGNED -> rejectFix(issue, actor, requiredComment);
+            case CLOSED -> close(issue, actor, requiredComment);
+            default -> throw new UnsupportedOperationException("Unsupported target status: " + requiredTargetStatus);
+        }
+```
+
+- [ ] **Step 2: Add the private rejectFix helper**
+
+Add this helper between `resolve(...)` and `close(...)`:
+
+```java
+    private void rejectFix(Issue issue, User actor, String comment) {
+        permissionPolicy.assertCanChangeStatus(actor, issue, IssueStatus.ASSIGNED);
+        LocalDateTime changedAt = now();
+        issue.rejectFix(actor, comment, changedAt);
+        issue.addComment(
+                CommentIdGenerator.nextCommentId(),
+                comment,
+                actor,
+                changedAt,
+                CommentPurpose.STATUS_CHANGE);
+    }
+```
+
+- [ ] **Step 3: Run the focused service test**
+
+Run:
+
+```bash
+./gradlew test --tests com.github.marcellokim.issuetracker.service.IssueStateServiceTest --console=plain
+```
+
+Expected:
+
+- `BUILD SUCCESSFUL`
+- `rejectFixedIssueBackToAssigned` passes.
+- `rejectFixRequiresCurrentVerifier` passes with `SecurityException`.
+- `rejectFixRequiresFixedIssueStatus` passes with `IllegalStateException`.
+- `rejectUnsupportedReopenedTargetStatus` still passes with `UnsupportedOperationException`.
+
+- [ ] **Step 4: Commit the implementation**
+
+Run:
+
+```bash
+git add src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java \
+        src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
+git commit -m "feat: route reject fix status change"
+```
+
+Expected:
+
+- Commit succeeds.
+- Pre-commit repository setup check passes.
+
+---
+
+### Task 3: Full Verification
+
+**Files:**
+- Verify: `src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java`
+- Verify: `src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java`
+- Verify: `docs/superpowers/specs/2026-05-24-issue-43-reject-fix-design.md`
+
+- [ ] **Step 1: Check whitespace and patch hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected:
+
+- No output.
+- Exit code `0`.
+
+- [ ] **Step 2: Run the full Gradle check**
+
+Run:
+
+```bash
+./gradlew check --console=plain
+```
+
+Expected:
+
+- `BUILD SUCCESSFUL`
+- No unit-test regression outside `IssueStateServiceTest`.
+
+- [ ] **Step 3: Inspect final branch state**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline --decorate -5
+```
+
+Expected:
+
+- Branch is `feat/43-reject-fix-transition`.
+- Worktree is clean.
+- Branch contains the design commits plus `feat: route reject fix status change`.
+
+- [ ] **Step 4: Prepare PR evidence**
+
+Use this PR evidence summary:
+
+```text
+Branch: feat/43-reject-fix-transition
+Base: origin/dev
+
+Implemented #43 by completing IssueStateService.changeStatus(...) routing for
+targetStatus=ASSIGNED when the current issue is FIXED.
+
+No new public rejectFix API, IssueStatus, CommentPurpose, persistence schema,
+UC5 reassignment behavior, #47 reopen behavior, or UI behavior was added.
+
+Verification:
+- ./gradlew test --tests com.github.marcellokim.issuetracker.service.IssueStateServiceTest --console=plain
+- ./gradlew check --console=plain
+
+Not run:
+- Oracle-local integration
+- UI/manual flow
+```

--- a/docs/superpowers/specs/2026-05-24-issue-43-reject-fix-design.md
+++ b/docs/superpowers/specs/2026-05-24-issue-43-reject-fix-design.md
@@ -1,0 +1,97 @@
+# Issue #43 Reject Fix Design
+
+## Context
+
+Issue #43 implements the UC6 alternative flow where the current verifier rejects a fixed issue and moves it from `FIXED` back to `ASSIGNED`.
+
+The current `origin/dev` baseline already contains the domain and policy foundation:
+
+- `Issue.rejectFix(tester, comment, changedDate)` changes `FIXED -> ASSIGNED`.
+- `PermissionPolicy.assertCanChangeStatus(actor, issue, ASSIGNED)` allows only the active current verifier when the issue is `FIXED`.
+- The UML domain model, DCD, and OC describe the rejection as `changeStatus(issueId, targetStatus=ASSIGNED, comment)`, not as a separate controller operation.
+- The DCD and OC do not define `CommentPurpose.STATUS_CHANGE_REASON`; current code uses `CommentPurpose.STATUS_CHANGE` for status-change comments.
+
+The remaining gap is application-service routing. `IssueStateService.changeStatus(...)` currently routes `FIXED`, `RESOLVED`, and `CLOSED`, while `ASSIGNED` still falls through to the unsupported-target branch.
+
+## Decision
+
+Implement #43 by wiring `targetStatus=ASSIGNED` inside the existing `IssueStateService.changeStatus(...)` flow.
+
+Do not add a new public `rejectFix` controller/service operation. Do not introduce a new issue status. Do not add or rename `CommentPurpose` values.
+
+## Architecture
+
+`IssueStateController.changeStatus(...)` remains unchanged. It already matches the DCD/OC operation shape and passes the authenticated user's login id to `IssueStateService`.
+
+`IssueStateService.changeStatus(...)` will add an `ASSIGNED` switch branch that delegates to a private `rejectFix(Issue issue, User actor, String comment)` method.
+
+The private method will follow the existing status-change service pattern:
+
+1. `permissionPolicy.assertCanChangeStatus(actor, issue, IssueStatus.ASSIGNED)`
+2. `LocalDateTime changedAt = now()`
+3. `issue.rejectFix(actor, comment, changedAt)`
+4. `issue.addComment(CommentIdGenerator.nextCommentId(), comment, actor, changedAt, CommentPurpose.STATUS_CHANGE)`
+
+The existing outer method will continue saving the issue with `issueRepository.save(issue)` and returning `IssueStateResult`.
+
+## Data Flow
+
+1. A controller caller requests `changeStatus(issueId, ASSIGNED, comment)`.
+2. The controller loads the current session user.
+3. The service rejects blank comments before repository lookup.
+4. The service loads the issue and actor.
+5. The `ASSIGNED` branch performs verifier-only permission validation.
+6. The domain object performs the `FIXED -> ASSIGNED` transition and preserves current assignee, verifier, and fixer.
+7. The service records the rejection reason as a `STATUS_CHANGE` comment.
+8. The repository saves the updated issue.
+9. The service returns `IssueStateResult` with the updated status and retained role associations.
+
+## Error Handling
+
+- Blank `comment` fails before issue/user lookup with `IllegalArgumentException`.
+- Null `targetStatus` fails with `NullPointerException`.
+- A non-verifier actor fails with `SecurityException`.
+- A non-`FIXED` issue fails during the domain transition with `IllegalStateException`.
+- On failed domain transition, no new comment, history, or save side effect should occur.
+- `REOPENED` remains unsupported in this issue because #47 owns reopen routing.
+
+## Testing
+
+Update `IssueStateServiceTest`.
+
+Success coverage:
+
+- Current verifier calls `changeStatus(issueId, ASSIGNED, "Reject fix", verifierId)`.
+- Result status is `ASSIGNED`.
+- Issue status is `ASSIGNED`.
+- Existing assignee is retained.
+- Existing verifier is retained.
+- Existing fixer is retained.
+- Resolver remains unchanged.
+- One status-change comment is created with `CommentPurpose.STATUS_CHANGE`.
+- Latest histories are `STATUS_CHANGED` followed by `COMMENTED`.
+- `STATUS_CHANGED` records `previousValue=FIXED` and `newValue=ASSIGNED`.
+
+Failure coverage:
+
+- Wrong actor cannot reject the fix.
+- A non-`FIXED` issue cannot be rejected.
+- Existing unsupported-target coverage keeps `REOPENED` as unsupported.
+
+## Scope Exclusions
+
+- No controller API expansion beyond existing `changeStatus`.
+- No `CommentPurpose` enum/schema change.
+- No persistence schema change.
+- No UC5 reassignment behavior.
+- No #47 reopen behavior.
+- No UI behavior.
+
+## Verification
+
+Required local checks:
+
+- `./gradlew test --tests com.github.marcellokim.issuetracker.service.IssueStateServiceTest --console=plain`
+- `./gradlew check --console=plain`
+
+PR evidence should mention branch `feat/43-reject-fix-transition`, base `origin/dev`, and that Oracle-local integration and UI/manual flows are outside this issue's scope unless run separately.

--- a/docs/superpowers/specs/2026-05-24-issue-43-reject-fix-design.md
+++ b/docs/superpowers/specs/2026-05-24-issue-43-reject-fix-design.md
@@ -8,7 +8,8 @@ The current `origin/dev` baseline already contains the domain and policy foundat
 
 - `Issue.rejectFix(tester, comment, changedDate)` changes `FIXED -> ASSIGNED`.
 - `PermissionPolicy.assertCanChangeStatus(actor, issue, ASSIGNED)` allows only the active current verifier when the issue is `FIXED`.
-- The UML domain model, DCD, and OC describe the rejection as `changeStatus(issueId, targetStatus=ASSIGNED, comment)`, not as a separate controller operation.
+- The OC and current implementation API describe the rejection as `changeStatus(issueId, targetStatus=ASSIGNED, comment)`.
+- The DCD includes state-specific convenience operation names such as `rejectFix(issueId, comment)`, but the current controller/service public API exposes `changeStatus(...)`; this issue completes that existing route instead of expanding the public API.
 - The DCD and OC do not define `CommentPurpose.STATUS_CHANGE_REASON`; current code uses `CommentPurpose.STATUS_CHANGE` for status-change comments.
 
 The remaining gap is application-service routing. `IssueStateService.changeStatus(...)` currently routes `FIXED`, `RESOLVED`, and `CLOSED`, while `ASSIGNED` still falls through to the unsupported-target branch.
@@ -21,7 +22,7 @@ Do not add a new public `rejectFix` controller/service operation. Do not introdu
 
 ## Architecture
 
-`IssueStateController.changeStatus(...)` remains unchanged. It already matches the DCD/OC operation shape and passes the authenticated user's login id to `IssueStateService`.
+`IssueStateController.changeStatus(...)` remains unchanged. It matches the current implementation and OC operation shape and passes the authenticated user's login id to `IssueStateService`.
 
 `IssueStateService.changeStatus(...)` will add an `ASSIGNED` switch branch that delegates to a private `rejectFix(Issue issue, User actor, String comment)` method.
 
@@ -40,7 +41,7 @@ The existing outer method will continue saving the issue with `issueRepository.s
 2. The controller loads the current session user.
 3. The service rejects blank comments before repository lookup.
 4. The service loads the issue and actor.
-5. The `ASSIGNED` branch performs verifier-only permission validation.
+5. The `ASSIGNED` branch delegates permission validation to `PermissionPolicy`.
 6. The domain object performs the `FIXED -> ASSIGNED` transition and preserves current assignee, verifier, and fixer.
 7. The service records the rejection reason as a `STATUS_CHANGE` comment.
 8. The repository saves the updated issue.
@@ -50,8 +51,9 @@ The existing outer method will continue saving the issue with `issueRepository.s
 
 - Blank `comment` fails before issue/user lookup with `IllegalArgumentException`.
 - Null `targetStatus` fails with `NullPointerException`.
-- A non-verifier actor fails with `SecurityException`.
-- A non-`FIXED` issue fails during the domain transition with `IllegalStateException`.
+- A non-verifier actor on a `FIXED` issue fails with `SecurityException`.
+- A non-`FIXED` issue fails during the domain transition with `IllegalStateException` when the actor passes the broader `ASSIGNED` permission path, such as a PL actor.
+- This design intentionally does not change `PermissionPolicy` ordering. For `targetStatus=ASSIGNED`, the policy currently treats `FIXED` as verifier rejection and non-`FIXED` as PL assignment permission.
 - On failed domain transition, no new comment, history, or save side effect should occur.
 - `REOPENED` remains unsupported in this issue because #47 owns reopen routing.
 
@@ -67,16 +69,16 @@ Success coverage:
 - Existing assignee is retained.
 - Existing verifier is retained.
 - Existing fixer is retained.
-- Resolver remains unchanged.
+- Resolver remains unchanged; if it was `null`, it stays `null`.
 - One status-change comment is created with `CommentPurpose.STATUS_CHANGE`.
 - Latest histories are `STATUS_CHANGED` followed by `COMMENTED`.
 - `STATUS_CHANGED` records `previousValue=FIXED` and `newValue=ASSIGNED`.
 
 Failure coverage:
 
-- Wrong actor cannot reject the fix.
-- A non-`FIXED` issue cannot be rejected.
-- Existing unsupported-target coverage keeps `REOPENED` as unsupported.
+- Wrong actor on a `FIXED` issue cannot reject the fix and fails with `SecurityException`.
+- A non-`FIXED` issue cannot be rejected. Use a PL actor for this service-level test if expecting `IllegalStateException`, because the current permission policy allows PL assignment on non-`FIXED` issues before the domain `rejectFix` guard runs.
+- Existing unsupported-target coverage removes `ASSIGNED` from unsupported cases and keeps `REOPENED` as unsupported.
 
 ## Scope Exclusions
 
@@ -95,3 +97,14 @@ Required local checks:
 - `./gradlew check --console=plain`
 
 PR evidence should mention branch `feat/43-reject-fix-transition`, base `origin/dev`, and that Oracle-local integration and UI/manual flows are outside this issue's scope unless run separately.
+
+Suggested PR description wording:
+
+```text
+Implements #43 by completing the existing IssueStateService.changeStatus(...)
+routing for targetStatus=ASSIGNED when the current issue is FIXED.
+
+This keeps the public controller/service operation shape aligned with the
+current implementation and OC: changeStatus(issueId, targetStatus=ASSIGNED, comment).
+No new public rejectFix API, IssueStatus, CommentPurpose, or persistence schema is added.
+```

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java
@@ -77,6 +77,13 @@ public final class IssueStateService {
 
     private void rejectFix(Issue issue, User actor, String comment) {
         permissionPolicy.assertCanChangeStatus(actor, issue, IssueStatus.ASSIGNED);
+        if (issue.status() == IssueStatus.FIXED) {
+            requireActiveProjectMemberWithRole(
+                    actor,
+                    issue.projectId(),
+                    Role.TESTER,
+                    "Only the active TESTER verifier can reject a fixed issue.");
+        }
         LocalDateTime changedAt = now();
         issue.rejectFix(actor, comment, changedAt);
         issue.addComment(
@@ -126,6 +133,14 @@ public final class IssueStateService {
         boolean projectLead = userRepository.findActiveByRole(projectId, Role.PL).stream()
                 .anyMatch(user -> user.getLoginId().equals(actor.getLoginId()));
         if (!projectLead) {
+            throw new SecurityException(message);
+        }
+    }
+
+    private void requireActiveProjectMemberWithRole(User actor, long projectId, Role role, String message) {
+        boolean projectMember = userRepository.findActiveByRole(projectId, role).stream()
+                .anyMatch(user -> user.getLoginId().equals(actor.getLoginId()));
+        if (!projectMember) {
             throw new SecurityException(message);
         }
     }

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueStateService.java
@@ -42,6 +42,7 @@ public final class IssueStateService {
         switch (requiredTargetStatus) {
             case FIXED -> markFixed(issue, actor, requiredComment);
             case RESOLVED -> resolve(issue, actor, requiredComment);
+            case ASSIGNED -> rejectFix(issue, actor, requiredComment);
             case CLOSED -> close(issue, actor, requiredComment);
             default -> throw new UnsupportedOperationException("Unsupported target status: " + requiredTargetStatus);
         }
@@ -66,6 +67,18 @@ public final class IssueStateService {
         rejectUnresolvedBlockingIssues(issue);
         LocalDateTime changedAt = now();
         issue.resolve(actor, comment, changedAt);
+        issue.addComment(
+                CommentIdGenerator.nextCommentId(),
+                comment,
+                actor,
+                changedAt,
+                CommentPurpose.STATUS_CHANGE);
+    }
+
+    private void rejectFix(Issue issue, User actor, String comment) {
+        permissionPolicy.assertCanChangeStatus(actor, issue, IssueStatus.ASSIGNED);
+        LocalDateTime changedAt = now();
+        issue.rejectFix(actor, comment, changedAt);
         issue.addComment(
                 CommentIdGenerator.nextCommentId(),
                 comment,

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
@@ -153,6 +153,24 @@ class IssueStateServiceTest {
     }
 
     @Test
+    @DisplayName("reject fix requires verifier to belong to the issue project")
+    void rejectFixRequiresVerifierProjectMembership() {
+        var issue = fixedIssue();
+        int commentCount = issue.getComments().size();
+        int historyCount = issue.getHistories().size();
+        var users = new InMemoryUserRepository(reporter, assignee, verifier, pl, otherDev)
+                .withProjectMembers(PROJECT_ID, reporter.getLoginId(), assignee.getLoginId(), pl.getLoginId());
+        var service = service(new FakeIssueDependencyRepository(), users, issue);
+
+        assertThrows(SecurityException.class,
+                () -> service.changeStatus(ISSUE_ID, IssueStatus.ASSIGNED, "Needs more work",
+                        verifier.getLoginId()));
+
+        assertEquals(commentCount, issue.getComments().size());
+        assertEquals(historyCount, issue.getHistories().size());
+    }
+
+    @Test
     @DisplayName("reject fix requires fixed issue status")
     void rejectFixRequiresFixedIssueStatus() {
         var issue = assignedIssue();

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueStateServiceTest.java
@@ -72,6 +72,38 @@ class IssueStateServiceTest {
     }
 
     @Test
+    @DisplayName("verifier rejects fixed issue back to assigned")
+    void rejectFixedIssueBackToAssigned() {
+        var issue = fixedIssue();
+        var service = service(issue);
+
+        var result = service.changeStatus(ISSUE_ID, IssueStatus.ASSIGNED, "Needs more work",
+                verifier.getLoginId());
+
+        assertEquals(IssueStatus.ASSIGNED, result.status());
+        assertEquals(IssueStatus.ASSIGNED, issue.getStatus());
+        assertSame(assignee, result.assignee());
+        assertSame(verifier, result.verifier());
+        assertSame(assignee, result.fixer());
+        assertNull(result.resolver());
+        assertSame(assignee, issue.getAssignee());
+        assertSame(verifier, issue.getVerifier());
+        assertSame(assignee, issue.getFixer());
+        assertNull(issue.getResolver());
+        assertEquals(1, issue.getComments().size());
+        assertEquals("Needs more work", issue.getComments().getFirst().getContent());
+        assertEquals(CommentPurpose.STATUS_CHANGE, issue.getComments().getFirst().getPurpose());
+
+        var histories = issue.getHistories();
+        var statusHistory = histories.get(histories.size() - 2);
+        assertEquals(ActionType.STATUS_CHANGED, statusHistory.getAction());
+        assertEquals(IssueStatus.FIXED.name(), statusHistory.getPreviousValue());
+        assertEquals(IssueStatus.ASSIGNED.name(), statusHistory.getNewValue());
+        assertEquals("Needs more work", statusHistory.getMessage());
+        assertStatusChangedThenCommented(issue);
+    }
+
+    @Test
     @DisplayName("PL closes resolved issue and clears active assignment")
     void closeResolvedIssue() {
         var issue = resolvedIssue();
@@ -105,6 +137,38 @@ class IssueStateServiceTest {
     }
 
     @Test
+    @DisplayName("only current verifier can reject a fixed issue")
+    void rejectFixRequiresCurrentVerifier() {
+        var issue = fixedIssue();
+        int commentCount = issue.getComments().size();
+        int historyCount = issue.getHistories().size();
+        var service = service(issue);
+
+        assertThrows(SecurityException.class,
+                () -> service.changeStatus(ISSUE_ID, IssueStatus.ASSIGNED, "Needs more work",
+                        otherDev.getLoginId()));
+
+        assertEquals(commentCount, issue.getComments().size());
+        assertEquals(historyCount, issue.getHistories().size());
+    }
+
+    @Test
+    @DisplayName("reject fix requires fixed issue status")
+    void rejectFixRequiresFixedIssueStatus() {
+        var issue = assignedIssue();
+        int commentCount = issue.getComments().size();
+        int historyCount = issue.getHistories().size();
+        var service = service(issue);
+
+        assertThrows(IllegalStateException.class,
+                () -> service.changeStatus(ISSUE_ID, IssueStatus.ASSIGNED, "Needs more work",
+                        pl.getLoginId()));
+
+        assertEquals(commentCount, issue.getComments().size());
+        assertEquals(historyCount, issue.getHistories().size());
+    }
+
+    @Test
     @DisplayName("blank comment or wrong actor fails status change")
     void rejectBlankCommentAndWrongParticipant() {
         var issue = assignedIssue();
@@ -127,15 +191,11 @@ class IssueStateServiceTest {
     }
 
     @Test
-    @DisplayName("unsupported status change targets remain feature gaps")
-    void rejectUnsupportedTargetStatus() {
-        var fixed = fixedIssue();
-        var fixedService = service(fixed);
-        assertThrows(UnsupportedOperationException.class,
-                () -> fixedService.changeStatus(ISSUE_ID, IssueStatus.ASSIGNED, "Reject fix", verifier.getLoginId()));
-
+    @DisplayName("reopened status change target remains a feature gap")
+    void rejectUnsupportedReopenedTargetStatus() {
         var resolved = resolvedIssue();
         var resolvedService = service(resolved);
+
         assertThrows(UnsupportedOperationException.class,
                 () -> resolvedService.changeStatus(ISSUE_ID, IssueStatus.REOPENED, "Needs more work", pl.getLoginId()));
     }


### PR DESCRIPTION
## 요약

- `IssueStateService.changeStatus(..., ASSIGNED, ...)`가 `FIXED -> ASSIGNED` reject fix 흐름을 처리하도록 라우팅을 추가했습니다.
- 새 public `rejectFix` API, `IssueStatus`, `CommentPurpose`, schema, controller 변경 없이 기존 `Issue.rejectFix(...)`와 `PermissionPolicy`를 사용했습니다.
- verifier 성공, wrong actor 실패, non-FIXED 실패, `REOPENED` unsupported 유지 케이스를 service test로 보강했습니다.

## 배경

#43은 UC6 alternative flow인 Tester의 fixed issue reject를 구현하는 작업입니다. OC와 현재 controller/service API는 `changeStatus(issueId, targetStatus=ASSIGNED, comment)` 경로를 사용하므로, 이번 PR은 새 API를 만들지 않고 기존 service routing gap만 채웁니다.

Closes #43

## 검증

- `git diff --check`
- `./gradlew test --tests com.github.marcellokim.issuetracker.service.IssueStateServiceTest --console=plain`
- `./gradlew check --console=plain`
- pre-push hook: `test + verifyRepositorySetup` 통과

참고: `oracleIntegrationTest`는 기존 gating에 따라 Oracle TEST DB 환경변수가 없으면 skip됩니다. Oracle Docker 경로는 별도 명령 `./gradlew oracleLocalTest --console=plain`입니다.