### PR TITLE
refactor: 계층 책임 정리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 plugins {
     id 'java'
     id 'jacoco'
-    id 'application' // JavaFX 실행을 위한 플러그인
+    id 'application'
     id 'org.openjfx.javafxplugin' version '0.1.0'
     id 'org.sonarqube' version '7.2.2.6593'
 }
@@ -17,7 +17,6 @@ java {
     }
 }
 
-// --- JavaFX 설정 ---
 javafx {
     version = '21.0.6'
     modules = ['javafx.controls', 'javafx.fxml', 'javafx.graphics']
@@ -30,15 +29,6 @@ application {
 repositories {
     mavenCentral()
 }
-
-// javafx {
-//     version = '21.0.6'
-//     modules = ['javafx.controls', 'javafx.fxml']
-// }
-
-// application {
-//     mainClass = 'com.github.marcellokim.issuetracker.Main'
-// }
 
 sonar {
     properties {
@@ -65,26 +55,6 @@ sonar {
         property 'sonar.coverage.exclusions', coverageExcludedSources
         property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/test/jacocoTestReport.xml'
 
-        // property 'sonar.exclusions', [
-        //     '.github/**',
-        //     'bin/**',
-        //     'config/**',
-        //     'docs/**',
-        //     'scripts/**',
-        //     'src/main/resources/db/oracle/**'
-        // ].join(',')
-        // property 'sonar.test.exclusions', [
-        //     'src/test/**'
-        // ].join(',')
-        // property 'sonar.cpd.exclusions', [
-        //     '.github/**',
-        //     'config/**',
-        //     'docs/**',
-        //     'scripts/**',
-        //     'src/main/resources/db/oracle/**',
-        //     'src/test/**'
-        // ].join(',')
-
     }
 }
 
@@ -109,7 +79,6 @@ tasks.named('sonar') {
     dependsOn tasks.named('jacocoTestReport')
 }
 
-// --- 인코딩 및 실행 설정 (윈도우 한글 깨짐 방지) ---
 tasks.register('oracleConnectionCheck', JavaExec) {
     group = 'application'
     description = 'Checks Oracle Database connectivity using ITS_DB_URL, ITS_DB_USER, and ITS_DB_PASSWORD.'
@@ -290,7 +259,6 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 tasks.withType(JavaExec).configureEach {
-    // JVM 실행 시 모든 입출력 인코딩을 UTF-8로 고정
     jvmArgs += [
         "-Dfile.encoding=UTF-8",
         "-Dconsole.encoding=UTF-8",
@@ -306,8 +274,6 @@ tasks.withType(Test).configureEach {
         exceptionFormat = 'full'
     }
 }
-
-// --- 팀장님의 자동화 및 검증 태스크 영역 ---
 
 def requiredAutomationPaths = [
     'SE_Term_Project_2026-1.pdf',
@@ -374,17 +340,9 @@ tasks.register('auditAutomation', Exec) {
     group = '검증'
     description = '로컬 저장소 자동화 문서, 스크립트, DB 표준 문구 정합성을 점검합니다.'
 
-    // 윈도우 환경 대응: python3 대신 python 자동 선택
-    def pythonCmd = Os.isFamily(Os.FAMILY_WINDOWS) ? 'python' : 'python3'
-    executable pythonCmd
-
-    args 'scripts/lib/project_maintenance.py', 'audit', '--local-only', '--skip-git-branches', '--quiet'
-
-    // 파이썬 인코딩 강제 설정 (UnicodeDecodeError 방지)
     environment "PYTHONUTF8", "1"
     environment "PYTHONIOENCODING", "UTF-8"
 
-    // 자동화 감사 실패 시 Gradle check도 실패하게 둔다.
     ignoreExitValue = false
     commandLine pythonExecutable.get(), 'scripts/lib/project_maintenance.py', 'audit', '--local-only', '--skip-git-branches', '--quiet'
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/controller/ProjectController.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/controller/ProjectController.java
@@ -31,7 +31,6 @@ public final class ProjectController {
         return projectService.viewProjectAdminDetail(projectId, user.getLoginId());
     }
 
-    // viewProjectAdminDetail에서 프로젝트 멤버가지지만 일단 남겨
     public List<ProjectMemberResult> viewProjectParticipants(long projectId) {
         User user = requireCurrentUser();
         return projectService.viewProjectParticipants(projectId, user.getLoginId());

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/ActionType.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/ActionType.java
@@ -1,6 +1,5 @@
 package com.github.marcellokim.issuetracker.domain;
 
-// 확정
 public enum ActionType {
     CREATED,
     TITLE_DESCRIPTION_UPDATED,

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Comment.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Comment.java
@@ -75,7 +75,6 @@ public final class Comment {
         updatedDate = Objects.requireNonNull(changedAt, "changedAt must not be null");
     }
 
-    // --- getters ---
     public long id() {
         return id;
     }

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Issue.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Issue.java
@@ -84,7 +84,6 @@ public class Issue {
         return new Issue(state);
     }
 
-    // --- getters ---
     public long id() {
         return id;
     }
@@ -197,7 +196,6 @@ public class Issue {
         return Collections.unmodifiableList(blockedByDependencies);
     }
 
-    // --- status management ---
     public void assignFromNew(User assignee, User verifier, User changedBy, LocalDateTime changedDate) {
         requireStatus(IssueStatus.NEW);
         assign(assignee, verifier, changedBy, changedDate, "Issue assigned from NEW");
@@ -299,7 +297,6 @@ public class Issue {
         changeStatusTo(IssueStatus.ASSIGNED, requiredComment, tester, changedDate);
     }
 
-    // --- other methods ---
     public IssueDependency addDependency(
             String dependencyId,
             Issue blockingIssue,
@@ -417,7 +414,6 @@ public class Issue {
                 changedDate);
     }
 
-    // --- general-purpose private methods ---
     private void changeStatusTo(IssueStatus targetStatus, String message, User changedBy, LocalDateTime changedDate) {
         Objects.requireNonNull(targetStatus, "targetStatus must not be null");
         Objects.requireNonNull(changedBy, CHANGED_BY_REQUIRED);

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/IssueStatus.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/IssueStatus.java
@@ -1,6 +1,5 @@
 package com.github.marcellokim.issuetracker.domain;
 
-// 확정
 public enum IssueStatus {
     NEW,
     ASSIGNED,

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Priority.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Priority.java
@@ -1,6 +1,5 @@
 package com.github.marcellokim.issuetracker.domain;
 
-// 확정
 public enum Priority {
     BLOCKER,
     CRITICAL,

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Project.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Project.java
@@ -16,7 +16,6 @@ public class Project {
             String description,
             String managedByLoginId,
             LocalDateTime now) {
-        // New projects are transient; the repository assigns the database id on save.
         LocalDateTime timestamp = Objects.requireNonNull(now, "now");
         return new Project(0L, name, description, managedByLoginId, timestamp, timestamp);
     }
@@ -28,7 +27,6 @@ public class Project {
             String managedByLoginId,
             LocalDateTime createdDate,
             LocalDateTime updatedAt) {
-        // Persistence reconstruction keeps stored id and timestamps exactly as read.
         requirePositive(id, "id");
         return new Project(id, name, description, managedByLoginId, createdDate, updatedAt);
     }

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/ProjectMember.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/ProjectMember.java
@@ -11,13 +11,11 @@ public final class ProjectMember {
 
     public static ProjectMember create(long projectId, String userId,
             LocalDateTime joinedAt) {
-        // New project memberships are created by application flow before persistence.
         return new ProjectMember(projectId, userId, joinedAt);
     }
 
     public static ProjectMember fromPersistence(long projectId, String userId,
             LocalDateTime joinedAt) {
-        // Persistence reconstruction keeps the stored membership row exactly as read.
         return new ProjectMember(projectId, userId, joinedAt);
     }
 

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Role.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Role.java
@@ -1,6 +1,5 @@
 package com.github.marcellokim.issuetracker.domain;
 
-// 확정
 public enum Role {
     ADMIN,
     PL,

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/DatabaseEnvironment.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/DatabaseEnvironment.java
@@ -37,10 +37,6 @@ public record DatabaseEnvironment(String url, String user, String password) {
         if (!isConfigured(environment)) {
             throw new IllegalStateException(MISSING_MESSAGE);
         }
-        /*
-         * Oracle application 환경 해석을 value object 한 곳에 모음.
-         * CLI, JavaFX startup, JDBC provider 생성이 같은 준비 상태 규칙 공유.
-         */
         return new DatabaseEnvironment(
                 environment.get(URL_VARIABLE),
                 environment.get(USER_VARIABLE),

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueDependencyRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueDependencyRepository.java
@@ -18,12 +18,6 @@ import java.util.Optional;
 
 public final class JdbcIssueDependencyRepository implements IssueDependencyRepository {
 
-    /*
-     * IssueDependency domain behavior is not finalized yet.
-     * Keep this JDBC implementation aligned with the current repository
-     * contract, and revisit it after the domain/service rules are fixed.
-     */
-
     private static final String BASE_SELECT = "select id, dependency_id, blocking_issue_id, blocked_issue_id, discovered_at from issue_dependencies";
     private static final String FIND_BY_ID_SQL = BASE_SELECT + " where id = ?";
     private static final String FIND_BY_DEPENDENCY_ID_SQL = BASE_SELECT + " where dependency_id = ?";

--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcProjectRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcProjectRepository.java
@@ -275,8 +275,6 @@ public final class JdbcProjectRepository implements ProjectRepository {
     }
 
     static Project mapProject(ResultSet resultSet) throws SQLException {
-        // JDBC mappers reconstruct persisted rows rather than creating new domain
-        // objects.
         return Project.fromPersistence(
                 resultSet.getLong("id"),
                 resultSet.getString("name"),

--- a/src/main/java/com/github/marcellokim/issuetracker/repository/IssueDependencyRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/repository/IssueDependencyRepository.java
@@ -7,12 +7,6 @@ import java.util.Optional;
 
 public interface IssueDependencyRepository {
 
-    /*
-     * IssueDependency domain behavior is not finalized yet.
-     * Keep this repository contract as-is until the domain layer decides the
-     * dependency aggregate rules and service flow.
-     */
-
     Optional<IssueDependency> findById(long dependencyId);
 
     Optional<IssueDependency> findByDependencyId(String dependencyId);

--- a/src/main/java/com/github/marcellokim/issuetracker/service/ProjectService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/ProjectService.java
@@ -32,7 +32,6 @@ public final class ProjectService {
         this.clock = Objects.requireNonNull(clock, "clock");
     }
 
-    // Non-Admin -> 단순 프로젝트 기본정보만
     public ProjectResult viewProjectNonAdminDetail(long projectId, String currentLoginId) {
         requireProjectId(projectId);
         User actor = findUser(currentLoginId);
@@ -41,7 +40,6 @@ public final class ProjectService {
         return ProjectResult.from(project);
     }
 
-    // Admin 기능 -> 프로젝트 기본정보 + 참여자 정보
     public ProjectAdminDetail viewProjectAdminDetail(long projectId, String currentUserId) {
         requireProjectId(projectId);
         requireProjectAdmin(currentUserId);
@@ -51,7 +49,6 @@ public final class ProjectService {
                 participantResults(projectId));
     }
 
-    // 일단 controller쪽에서 중복 기능인데 남기는쪽으로
     public List<ProjectMemberResult> viewProjectParticipants(long projectId, String currentUserId) {
         requireProjectId(projectId);
         requireProjectAdmin(currentUserId);

--- a/src/test/java/com/github/marcellokim/issuetracker/cli/CliCommandTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/cli/CliCommandTest.java
@@ -137,6 +137,10 @@ class CliCommandTest {
         return User.fromPersistence(loginId, loginId, PASSWORD_HASHER.hash(PASSWORD), role, active, NOW, NOW);
     }
 
+    private static UnsupportedOperationException unexpectedRuntimeCall(String methodName) {
+        return new UnsupportedOperationException("Unexpected runtime call: " + methodName);
+    }
+
     private static final class RecordingOutput implements CliOutput {
 
         private final StringBuilder text = new StringBuilder();
@@ -193,7 +197,7 @@ class CliCommandTest {
             if (fail) {
                 throw new IOException("boom");
             }
-            throw new UnsupportedOperationException("repository demo summary is injected directly in this test.");
+            throw unexpectedRuntimeCall("repositoryDemoSummaryService");
         }
 
         @Override

--- a/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerCoverageTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerCoverageTest.java
@@ -16,7 +16,6 @@ import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.MonthlyIssueCount;
 import com.github.marcellokim.issuetracker.domain.Priority;
 import com.github.marcellokim.issuetracker.domain.Project;
-import com.github.marcellokim.issuetracker.domain.ProjectMember;
 import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.StatisticsReport;
 import com.github.marcellokim.issuetracker.domain.User;
@@ -25,8 +24,8 @@ import com.github.marcellokim.issuetracker.repository.CommentRepository;
 import com.github.marcellokim.issuetracker.repository.IssueRepository;
 import com.github.marcellokim.issuetracker.support.FakeIssueDependencyRepository;
 import com.github.marcellokim.issuetracker.support.FakeIssueHistoryRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.support.StatisticsReportTestFactory;
-import com.github.marcellokim.issuetracker.repository.ProjectRepository;
 import com.github.marcellokim.issuetracker.repository.StatisticsRepository;
 import com.github.marcellokim.issuetracker.repository.UserRepository;
 import com.github.marcellokim.issuetracker.service.AccountService;
@@ -83,7 +82,7 @@ class ControllerCoverageTest {
     @DisplayName("dashboard controller reads dashboard data through service after auth")
     void dashboardControllerDelegatesDashboardReads() {
         AuthFixture auth = authenticated(Role.ADMIN);
-        FakeProjectRepository projects = new FakeProjectRepository(project(PROJECT_ID));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(PROJECT_ID));
         FakeIssueRepository issues = new FakeIssueRepository(issue(201L, PROJECT_ID, IssueStatus.NEW));
         DashboardController controller = new DashboardController(
                 auth.service(),
@@ -102,7 +101,7 @@ class ControllerCoverageTest {
         DashboardController controller = new DashboardController(
                 anonymousAuth(),
                 new DashboardSummaryService(
-                        new FakeProjectRepository(),
+                        new InMemoryProjectRepository(),
                         new FakeIssueRepository(),
                         new FakeStatisticsRepository(),
                         new FakeUserRepository(),
@@ -227,7 +226,7 @@ class ControllerCoverageTest {
     @DisplayName("project controller deletes an existing project only for ADMIN")
     void projectControllerDeletesProjectForAdmin() {
         AuthFixture auth = authenticated(Role.ADMIN);
-        FakeProjectRepository projects = new FakeProjectRepository(project(PROJECT_ID));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(PROJECT_ID));
         ProjectController controller = new ProjectController(
                 auth.service(),
                 new ProjectService(projects, new FakeIssueRepository(), auth.users(), new PermissionPolicy(),
@@ -235,7 +234,7 @@ class ControllerCoverageTest {
 
         controller.deleteProject(PROJECT_ID);
 
-        assertEquals(PROJECT_ID, projects.deletedProjectId);
+        assertEquals(PROJECT_ID, projects.lastDeletedProjectId());
         assertFalse(projects.findById(PROJECT_ID).isPresent());
     }
 
@@ -243,7 +242,7 @@ class ControllerCoverageTest {
     @DisplayName("project controller rejects invalid id, missing project, and non-admin users")
     void projectControllerRejectsInvalidDeleteRequests() {
         AuthFixture admin = authenticated(Role.ADMIN);
-        FakeProjectRepository projects = new FakeProjectRepository();
+        InMemoryProjectRepository projects = new InMemoryProjectRepository();
         ProjectController adminController = new ProjectController(
                 admin.service(),
                 new ProjectService(projects, new FakeIssueRepository(), admin.users(), new PermissionPolicy(),
@@ -255,7 +254,7 @@ class ControllerCoverageTest {
         ProjectController plController = new ProjectController(
                 pl.service(),
                 new ProjectService(
-                        new FakeProjectRepository(project(PROJECT_ID)),
+                        new InMemoryProjectRepository(project(PROJECT_ID)),
                         new FakeIssueRepository(),
                         pl.users(),
                         new PermissionPolicy(),
@@ -325,7 +324,7 @@ class ControllerCoverageTest {
     @DisplayName("account controller creates account through service after auth")
     void accountControllerCreatesAccount() {
         AuthFixture auth = authenticated(Role.ADMIN);
-        FakeProjectRepository projects = new FakeProjectRepository();
+        InMemoryProjectRepository projects = new InMemoryProjectRepository();
         FakeIssueRepository issues = new FakeIssueRepository();
         PasswordHasher hasher = new PasswordHasher();
         AccountController controller = new AccountController(
@@ -346,7 +345,7 @@ class ControllerCoverageTest {
         AuthFixture auth = authenticated(Role.ADMIN);
         User target = user("target1", Role.DEV);
         auth.users().save(target);
-        FakeProjectRepository projects = new FakeProjectRepository();
+        InMemoryProjectRepository projects = new InMemoryProjectRepository();
         FakeIssueRepository issues = new FakeIssueRepository();
         PasswordHasher hasher = new PasswordHasher();
         AccountController controller = new AccountController(
@@ -373,7 +372,7 @@ class ControllerCoverageTest {
         AccountController controller = new AccountController(
                 anonymousAuth(),
                 new AccountService(new PermissionPolicy(), new FakeUserRepository(),
-                        new FakeProjectRepository(), new FakeIssueRepository(), new PasswordHasher(),
+                        new InMemoryProjectRepository(), new FakeIssueRepository(), new PasswordHasher(),
                         java.time.LocalDateTime::now));
 
         assertThrows(SecurityException.class,
@@ -381,11 +380,11 @@ class ControllerCoverageTest {
     }
 
     @Test
-    @DisplayName("stub controllers keep DCD layer dependencies injectable")
-    void stubControllersAcceptLayerDependencies() {
+    @DisplayName("controllers keep DCD layer dependencies injectable")
+    void controllersAcceptLayerDependencies() {
         AuthFixture auth = authenticated(Role.ADMIN);
         FakeUserRepository users = auth.users();
-        FakeProjectRepository projects = new FakeProjectRepository(project(PROJECT_ID));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(PROJECT_ID));
         FakeIssueRepository issues = new FakeIssueRepository(issue(301L, PROJECT_ID, IssueStatus.NEW));
         PermissionPolicy policy = new PermissionPolicy();
         Clock clock = java.time.LocalDateTime::now;
@@ -598,74 +597,6 @@ class ControllerCoverageTest {
             return 2;
         }
 
-    }
-
-    private static final class FakeProjectRepository implements ProjectRepository {
-
-        private final Map<Long, Project> projectsById = new LinkedHashMap<>();
-        private final Map<Long, List<ProjectMember>> membersByProjectId = new LinkedHashMap<>();
-        private long deletedProjectId;
-
-        private FakeProjectRepository(Project... projects) {
-            for (Project project : projects) {
-                projectsById.put(project.getId(), project);
-            }
-        }
-
-        private FakeProjectRepository(Project project, List<ProjectMember> members) {
-            this(project);
-            membersByProjectId.put(project.getId(), List.copyOf(members));
-        }
-
-        @Override
-        public Optional<Project> findById(long projectId) {
-            return Optional.ofNullable(projectsById.get(projectId));
-        }
-
-        @Override
-        public Optional<Project> findByName(String name) {
-            return projectsById.values().stream()
-                    .filter(project -> project.getName().equals(name))
-                    .findFirst();
-        }
-
-        @Override
-        public List<Project> findAll() {
-            return new ArrayList<>(projectsById.values());
-        }
-
-        @Override
-        public Project save(Project project) {
-            projectsById.put(project.getId(), project);
-            return project;
-        }
-
-        @Override
-        public void deleteById(long projectId) {
-            deletedProjectId = projectId;
-            projectsById.remove(projectId);
-        }
-
-        @Override
-        public void addParticipant(long projectId, String userLoginId) {
-        }
-
-        @Override
-        public void removeParticipant(long projectId, String userLoginId) {
-        }
-
-        @Override
-        public List<ProjectMember> findParticipants(long projectId) {
-            return membersByProjectId.getOrDefault(projectId, List.of());
-        }
-
-        @Override
-        public boolean existsByParticipant(String userLoginId) {
-            return membersByProjectId.values().stream()
-                    .flatMap(List::stream)
-                    .map(ProjectMember::userId)
-                    .anyMatch(userLoginId::equals);
-        }
     }
 
     private static final class FakeUserRepository implements UserRepository {

--- a/src/test/java/com/github/marcellokim/issuetracker/controller/IssueControllerTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/controller/IssueControllerTest.java
@@ -13,11 +13,9 @@ import com.github.marcellokim.issuetracker.domain.IssueHistory;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.Priority;
 import com.github.marcellokim.issuetracker.domain.Project;
-import com.github.marcellokim.issuetracker.domain.ProjectMember;
 import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.User;
 import com.github.marcellokim.issuetracker.repository.CommentRepository;
-import com.github.marcellokim.issuetracker.repository.ProjectRepository;
 import com.github.marcellokim.issuetracker.support.FakeIssueDependencyRepository;
 import com.github.marcellokim.issuetracker.support.FakeIssueHistoryRepository;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
@@ -30,11 +28,11 @@ import com.github.marcellokim.issuetracker.service.IssueSummary;
 import com.github.marcellokim.issuetracker.service.IssueWorkflowService;
 import com.github.marcellokim.issuetracker.service.PermissionPolicy;
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
 import com.github.marcellokim.issuetracker.technical.PasswordHasher;
 import com.github.marcellokim.issuetracker.technical.SessionStore;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -299,7 +297,7 @@ class IssueControllerTest {
         var issueRepository = new InMemoryIssueRepository(issues);
         var policy = new PermissionPolicy();
         var issueService = new IssueService(
-                new FakeProjectRepository(project),
+                new InMemoryProjectRepository(project),
                 issueRepository,
                 dependencies,
                 comments,
@@ -315,7 +313,7 @@ class IssueControllerTest {
         var users = new InMemoryUserRepository(dev);
         var authService = new AuthenticationService(users, hasher, new SessionStore());
         var issueService = new IssueService(
-                new FakeProjectRepository(project),
+                new InMemoryProjectRepository(project),
                 new InMemoryIssueRepository(),
                 new FakeIssueDependencyRepository(),
                 new FakeCommentRepository(),
@@ -339,61 +337,6 @@ class IssueControllerTest {
                         .priority(Priority.MAJOR)
                         .status(IssueStatus.NEW)
                         .updatedAt(now));
-    }
-
-    private static final class FakeProjectRepository implements ProjectRepository {
-
-        private final Map<Long, Project> projects = new LinkedHashMap<>();
-
-        private FakeProjectRepository(Project... projects) {
-            for (Project p : projects) {
-                this.projects.put(p.getId(), p);
-            }
-        }
-
-        @Override
-        public Optional<Project> findById(long projectId) {
-            return Optional.ofNullable(projects.get(projectId));
-        }
-
-        @Override
-        public Optional<Project> findByName(String name) {
-            return Optional.empty();
-        }
-
-        @Override
-        public List<Project> findAll() {
-            return new ArrayList<>(projects.values());
-        }
-
-        @Override
-        public Project save(Project project) {
-            projects.put(project.getId(), project);
-            return project;
-        }
-
-        @Override
-        public void deleteById(long projectId) {
-            projects.remove(projectId);
-        }
-
-        @Override
-        public void addParticipant(long projectId, String userLoginId) {
-        }
-
-        @Override
-        public void removeParticipant(long projectId, String userLoginId) {
-        }
-
-        @Override
-        public List<ProjectMember> findParticipants(long projectId) {
-            return List.of();
-        }
-
-        @Override
-        public boolean existsByParticipant(String userLoginId) {
-            return false;
-        }
     }
 
     private static final class FakeCommentRepository implements CommentRepository {

--- a/src/test/java/com/github/marcellokim/issuetracker/controller/ProjectControllerTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/controller/ProjectControllerTest.java
@@ -7,15 +7,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.marcellokim.issuetracker.domain.Issue;
-import com.github.marcellokim.issuetracker.domain.IssueSearchCriteria;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.Priority;
 import com.github.marcellokim.issuetracker.domain.Project;
 import com.github.marcellokim.issuetracker.domain.ProjectMember;
 import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.User;
-import com.github.marcellokim.issuetracker.repository.IssueRepository;
-import com.github.marcellokim.issuetracker.repository.ProjectRepository;
 import com.github.marcellokim.issuetracker.repository.UserRepository;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
 import com.github.marcellokim.issuetracker.service.PermissionPolicy;
@@ -23,6 +20,8 @@ import com.github.marcellokim.issuetracker.service.ProjectAdminDetail;
 import com.github.marcellokim.issuetracker.service.ProjectMemberResult;
 import com.github.marcellokim.issuetracker.service.ProjectResult;
 import com.github.marcellokim.issuetracker.service.ProjectService;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.technical.PasswordHasher;
 import com.github.marcellokim.issuetracker.technical.SessionStore;
 import java.time.LocalDateTime;
@@ -44,7 +43,7 @@ class ProjectControllerTest {
     @DisplayName("invalid project ids are rejected")
     void invalidProjectIdsAreRejected() {
         AuthFixture auth = authenticated(Role.ADMIN);
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         FakeUserRepository users = new FakeUserRepository(auth.user(), active("dev1", Role.DEV));
         ProjectController controller = controller(auth, projects, users);
 
@@ -63,12 +62,12 @@ class ProjectControllerTest {
     @DisplayName("ADMIN views projects, participants, and project detail")
     void adminViewsProjectsAndProjectParticipants() {
         AuthFixture auth = authenticated(Role.ADMIN);
-        FakeProjectRepository projects = new FakeProjectRepository(
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(
                 project(1L, "project-one"),
                 project(2L, "project-two"));
         projects.addParticipant(1L, "pl1");
         projects.addParticipant(1L, "dev1");
-        FakeIssueRepository issues = new FakeIssueRepository(
+        InMemoryIssueRepository issues = new InMemoryIssueRepository(
                 issue(101L, 1L, IssueStatus.NEW),
                 issue(102L, 2L, IssueStatus.ASSIGNED));
         ProjectController controller = controller(
@@ -81,12 +80,12 @@ class ProjectControllerTest {
         ProjectAdminDetail viewedDetail = controller.viewProjectAdminDetail(1L);
 
         assertEquals("project-one", viewedDetail.project().name());
-        assertEquals(List.of("pl1", "dev1"), viewedParticipants.stream()
+        assertEquals(List.of("dev1", "pl1"), viewedParticipants.stream()
                 .map(ProjectMemberResult::userId)
                 .toList());
         assertEquals("project-one", viewedDetail.project().name());
         assertThrows(NoSuchMethodException.class, () -> ProjectAdminDetail.class.getMethod("issues"));
-        assertEquals(List.of("pl1", "dev1"), viewedDetail.participants().stream()
+        assertEquals(List.of("dev1", "pl1"), viewedDetail.participants().stream()
                 .map(ProjectMemberResult::userId)
                 .toList());
         assertThrows(IllegalArgumentException.class, () -> controller.viewProjectNonAdminDetail(404L));
@@ -98,7 +97,7 @@ class ProjectControllerTest {
     @DisplayName("ADMIN creates projects")
     void adminCreatesProjects() {
         AuthFixture auth = authenticated(Role.ADMIN);
-        FakeProjectRepository projects = new FakeProjectRepository();
+        InMemoryProjectRepository projects = new InMemoryProjectRepository();
         ProjectController controller = controller(auth, projects, new FakeUserRepository(auth.user()));
 
         ProjectResult created = controller.createProject(" project-alpha ", "first project");
@@ -116,7 +115,7 @@ class ProjectControllerTest {
     @DisplayName("ADMIN updates project name and description")
     void adminUpdatesProjectNameAndDescription() {
         AuthFixture auth = authenticated(Role.ADMIN);
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         ProjectController controller = controller(auth, projects, new FakeUserRepository(auth.user()));
 
         ProjectResult renamed = controller.renameProject(1L, " project-renamed ");
@@ -132,7 +131,7 @@ class ProjectControllerTest {
     @DisplayName("ADMIN deletes projects")
     void adminDeletesProjects() {
         AuthFixture auth = authenticated(Role.ADMIN);
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         ProjectController controller = controller(auth, projects, new FakeUserRepository(auth.user()));
 
         controller.deleteProject(1L);
@@ -145,7 +144,7 @@ class ProjectControllerTest {
     void onlyAdminCanManageProjects() {
         for (Role role : List.of(Role.PL, Role.DEV, Role.TESTER)) {
             AuthFixture auth = authenticated(role);
-            FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+            InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
             FakeUserRepository users = new FakeUserRepository(auth.user(), active("dev1", Role.DEV));
             ProjectController controller = controller(auth, projects, users);
 
@@ -164,7 +163,7 @@ class ProjectControllerTest {
     @Test
     @DisplayName("anonymous users cannot manage projects")
     void anonymousUsersCannotManageProjects() {
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         FakeUserRepository users = new FakeUserRepository(active("dev1", Role.DEV));
         ProjectController controller = new ProjectController(
                 anonymousAuth(),
@@ -185,7 +184,7 @@ class ProjectControllerTest {
     @DisplayName("blank project names are rejected")
     void blankProjectNamesAreRejected() {
         AuthFixture auth = authenticated(Role.ADMIN);
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         ProjectController controller = controller(auth, projects, new FakeUserRepository(auth.user()));
 
         assertThrows(IllegalArgumentException.class, () -> controller.createProject(" ", "blank"));
@@ -196,7 +195,7 @@ class ProjectControllerTest {
     @DisplayName("blank project descriptions are rejected")
     void blankProjectDescriptionsAreRejected() {
         AuthFixture auth = authenticated(Role.ADMIN);
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         ProjectController controller = controller(auth, projects, new FakeUserRepository(auth.user()));
 
         assertThrows(IllegalArgumentException.class, () -> controller.createProject("project-one", null));
@@ -209,7 +208,7 @@ class ProjectControllerTest {
     @DisplayName("duplicate project names are rejected")
     void duplicateProjectNamesAreRejected() {
         AuthFixture auth = authenticated(Role.ADMIN);
-        FakeProjectRepository projects = new FakeProjectRepository(
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(
                 project(1L, "project-one"),
                 project(2L, "project-two"));
         ProjectController controller = controller(auth, projects, new FakeUserRepository(auth.user()));
@@ -224,7 +223,7 @@ class ProjectControllerTest {
         AuthFixture auth = authenticated(Role.ADMIN);
         User activeDeveloper = active("dev1", Role.DEV);
         User inactiveTester = inactive("tester1", Role.TESTER);
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         FakeUserRepository users = new FakeUserRepository(auth.user(), activeDeveloper, inactiveTester);
         ProjectController controller = controller(auth, projects, users);
 
@@ -243,7 +242,7 @@ class ProjectControllerTest {
     void participantAddAllowsFirstProjectLead() {
         AuthFixture auth = authenticated(Role.ADMIN);
         User pl1 = active("pl1", Role.PL);
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         FakeUserRepository users = new FakeUserRepository(auth.user(), pl1);
         ProjectController controller = controller(auth, projects, users);
 
@@ -258,7 +257,7 @@ class ProjectControllerTest {
         AuthFixture auth = authenticated(Role.ADMIN);
         User pl1 = active("pl1", Role.PL);
         User pl2 = active("pl2", Role.PL);
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         projects.addParticipant(1L, "pl1");
         FakeUserRepository users = new FakeUserRepository(auth.user(), pl1, pl2);
         ProjectController controller = controller(auth, projects, users);
@@ -273,7 +272,7 @@ class ProjectControllerTest {
         AuthFixture auth = authenticated(Role.ADMIN);
         User inactivePl = inactive("pl1", Role.PL);
         User activePl = active("pl2", Role.PL);
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         projects.addParticipant(1L, "pl1");
         FakeUserRepository users = new FakeUserRepository(auth.user(), inactivePl, activePl);
         ProjectController controller = controller(auth, projects, users);
@@ -286,7 +285,7 @@ class ProjectControllerTest {
     @DisplayName("participant remove requires current membership")
     void participantRemoveRequiresCurrentMembership() {
         AuthFixture auth = authenticated(Role.ADMIN);
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         projects.addParticipant(1L, "dev1");
         FakeUserRepository users = new FakeUserRepository(auth.user(), active("dev1", Role.DEV));
         ProjectController controller = controller(auth, projects, users);
@@ -304,10 +303,10 @@ class ProjectControllerTest {
     void participantRemoveRejectsAssignedIssueAssignee() {
         AuthFixture auth = authenticated(Role.ADMIN);
         User assignee = active("dev1", Role.DEV);
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         projects.addParticipant(1L, assignee.getLoginId());
         FakeUserRepository users = new FakeUserRepository(auth.user(), assignee);
-        FakeIssueRepository issues = new FakeIssueRepository(
+        InMemoryIssueRepository issues = new InMemoryIssueRepository(
                 issueWithAssigneeAndVerifier(101L, 1L, IssueStatus.ASSIGNED, assignee, null));
         ProjectController controller = controller(auth, projects, users, issues);
 
@@ -321,10 +320,10 @@ class ProjectControllerTest {
     void participantRemoveRejectsFixedIssueVerifier() {
         AuthFixture auth = authenticated(Role.ADMIN);
         User verifier = active("tester1", Role.TESTER);
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         projects.addParticipant(1L, verifier.getLoginId());
         FakeUserRepository users = new FakeUserRepository(auth.user(), verifier);
-        FakeIssueRepository issues = new FakeIssueRepository(
+        InMemoryIssueRepository issues = new InMemoryIssueRepository(
                 issueWithAssigneeAndVerifier(101L, 1L, IssueStatus.FIXED, null, verifier));
         ProjectController controller = controller(auth, projects, users, issues);
 
@@ -338,10 +337,10 @@ class ProjectControllerTest {
     void participantRemoveRejectsFixedIssueAssignee() {
         AuthFixture auth = authenticated(Role.ADMIN);
         User assignee = active("dev1", Role.DEV);
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         projects.addParticipant(1L, assignee.getLoginId());
         FakeUserRepository users = new FakeUserRepository(auth.user(), assignee);
-        FakeIssueRepository issues = new FakeIssueRepository(
+        InMemoryIssueRepository issues = new InMemoryIssueRepository(
                 issueWithAssigneeAndVerifier(101L, 1L, IssueStatus.FIXED, assignee, null));
         ProjectController controller = controller(auth, projects, users, issues);
 
@@ -355,10 +354,10 @@ class ProjectControllerTest {
     void participantRemoveRejectsAssignedIssueVerifier() {
         AuthFixture auth = authenticated(Role.ADMIN);
         User verifier = active("tester1", Role.TESTER);
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         projects.addParticipant(1L, verifier.getLoginId());
         FakeUserRepository users = new FakeUserRepository(auth.user(), verifier);
-        FakeIssueRepository issues = new FakeIssueRepository(
+        InMemoryIssueRepository issues = new InMemoryIssueRepository(
                 issueWithAssigneeAndVerifier(101L, 1L, IssueStatus.ASSIGNED, null, verifier));
         ProjectController controller = controller(auth, projects, users, issues);
 
@@ -373,11 +372,11 @@ class ProjectControllerTest {
         AuthFixture auth = authenticated(Role.ADMIN);
         User assignee = active("dev1", Role.DEV);
         User verifier = active("tester1", Role.TESTER);
-        FakeProjectRepository projects = new FakeProjectRepository(project(1L, "project-one"));
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project(1L, "project-one"));
         projects.addParticipant(1L, assignee.getLoginId());
         projects.addParticipant(1L, verifier.getLoginId());
         FakeUserRepository users = new FakeUserRepository(auth.user(), assignee, verifier);
-        FakeIssueRepository issues = new FakeIssueRepository(
+        InMemoryIssueRepository issues = new InMemoryIssueRepository(
                 issueWithAssigneeAndVerifier(101L, 1L, IssueStatus.RESOLVED, assignee, verifier));
         ProjectController controller = controller(auth, projects, users, issues);
 
@@ -389,7 +388,7 @@ class ProjectControllerTest {
 
     private static ProjectController controller(
             AuthFixture auth,
-            FakeProjectRepository projects,
+            InMemoryProjectRepository projects,
             FakeUserRepository users) {
         return new ProjectController(
                 auth.service(),
@@ -398,24 +397,24 @@ class ProjectControllerTest {
 
     private static ProjectController controller(
             AuthFixture auth,
-            FakeProjectRepository projects,
+            InMemoryProjectRepository projects,
             FakeUserRepository users,
-            FakeIssueRepository issues) {
+            InMemoryIssueRepository issues) {
         return new ProjectController(
                 auth.service(),
                 service(projects, users, issues));
     }
 
     private static ProjectService service(
-            FakeProjectRepository projects,
+            InMemoryProjectRepository projects,
             FakeUserRepository users) {
-        return service(projects, users, new FakeIssueRepository());
+        return service(projects, users, new InMemoryIssueRepository());
     }
 
     private static ProjectService service(
-            FakeProjectRepository projects,
+            InMemoryProjectRepository projects,
             FakeUserRepository users,
-            FakeIssueRepository issues) {
+            InMemoryIssueRepository issues) {
         users.attachProjects(projects);
         return new ProjectService(
                 projects,
@@ -494,88 +493,10 @@ class ProjectControllerTest {
     private record AuthFixture(AuthenticationService service, User user) {
     }
 
-    private static final class FakeProjectRepository implements ProjectRepository {
-
-        private final Map<Long, Project> projectsById = new LinkedHashMap<>();
-        private final Map<Long, List<ProjectMember>> membersByProjectId = new LinkedHashMap<>();
-        private long nextProjectId = 100L;
-
-        private FakeProjectRepository(Project... projects) {
-            for (Project project : projects) {
-                projectsById.put(project.getId(), project);
-            }
-        }
-
-        @Override
-        public Optional<Project> findById(long projectId) {
-            return Optional.ofNullable(projectsById.get(projectId));
-        }
-
-        @Override
-        public Optional<Project> findByName(String name) {
-            return projectsById.values().stream()
-                    .filter(project -> project.getName().equals(name))
-                    .findFirst();
-        }
-
-        @Override
-        public List<Project> findAll() {
-            return new ArrayList<>(projectsById.values());
-        }
-
-        @Override
-        public Project save(Project project) {
-            Project persistedProject = project.getId() == 0L
-                    ? Project.fromPersistence(nextProjectId++, project.getName(), project.getDescription(),
-                            project.getManagedByLoginId(),
-                            project.getCreatedDate(), project.getUpdatedAt())
-                    : project;
-            projectsById.put(persistedProject.getId(), persistedProject);
-            return persistedProject;
-        }
-
-        @Override
-        public void deleteById(long projectId) {
-            projectsById.remove(projectId);
-            membersByProjectId.remove(projectId);
-        }
-
-        @Override
-        public void addParticipant(long projectId, String userLoginId) {
-            membersByProjectId.computeIfAbsent(projectId, ignored -> new ArrayList<>())
-                    .add(ProjectMember.create(projectId, userLoginId, NOW));
-        }
-
-        @Override
-        public void removeParticipant(long projectId, String userLoginId) {
-            membersByProjectId.computeIfAbsent(projectId, ignored -> new ArrayList<>())
-                    .removeIf(member -> member.userId().equals(userLoginId));
-        }
-
-        @Override
-        public List<ProjectMember> findParticipants(long projectId) {
-            return List.copyOf(membersByProjectId.getOrDefault(projectId, List.of()));
-        }
-
-        @Override
-        public boolean existsByParticipant(String userLoginId) {
-            return membersByProjectId.values().stream()
-                    .flatMap(List::stream)
-                    .map(ProjectMember::userId)
-                    .anyMatch(userLoginId::equals);
-        }
-
-        private List<String> participantIds(long projectId) {
-            return findParticipants(projectId).stream()
-                    .map(ProjectMember::userId)
-                    .toList();
-        }
-    }
-
     private static final class FakeUserRepository implements UserRepository {
 
         private final Map<String, User> usersByLoginId = new LinkedHashMap<>();
-        private FakeProjectRepository projects;
+        private InMemoryProjectRepository projects;
 
         private FakeUserRepository(User... users) {
             for (User user : users) {
@@ -583,7 +504,7 @@ class ProjectControllerTest {
             }
         }
 
-        private void attachProjects(FakeProjectRepository projects) {
+        private void attachProjects(InMemoryProjectRepository projects) {
             this.projects = Objects.requireNonNull(projects, "projects");
         }
 
@@ -650,103 +571,4 @@ class ProjectControllerTest {
         }
     }
 
-    private static final class FakeIssueRepository implements IssueRepository {
-
-        private final Map<Long, Issue> issuesById = new LinkedHashMap<>();
-
-        private FakeIssueRepository(Issue... issues) {
-            for (Issue issue : issues) {
-                issuesById.put(issue.id(), issue);
-            }
-        }
-
-        @Override
-        public Optional<Issue> findById(long issueId) {
-            return Optional.ofNullable(issuesById.get(issueId));
-        }
-
-        @Override
-        public List<Issue> findAllById(List<Long> issueIds) {
-            return issueIds.stream()
-                    .filter(issuesById::containsKey)
-                    .map(issuesById::get)
-                    .toList();
-        }
-
-        @Override
-        public List<Issue> findByProject(long projectId) {
-            return issuesById.values().stream()
-                    .filter(issue -> issue.projectId() == projectId)
-                    .toList();
-        }
-
-        @Override
-        public List<Issue> findDeletedByProject(long projectId) {
-            return List.of();
-        }
-
-        @Override
-        public List<Issue> findByCriteria(IssueSearchCriteria criteria) {
-            return new ArrayList<>(issuesById.values());
-        }
-
-        @Override
-        public boolean existsByProjectIdAndTitle(long projectId, String title) {
-            return issuesById.values().stream()
-                    .anyMatch(issue -> issue.projectId() == projectId && issue.title().equals(title));
-        }
-
-        @Override
-        public boolean existsByProjectIdAndTitleExcludingIssueId(long projectId, String title, long excludedIssueId) {
-            return issuesById.values().stream()
-                    .anyMatch(issue -> issue.id() != excludedIssueId
-                            && issue.projectId() == projectId
-                            && issue.title().equals(title));
-        }
-
-        @Override
-        public boolean existsByResponsibleUser(String userLoginId) {
-            return issuesById.values().stream()
-                    .filter(issue -> issue.status() != IssueStatus.DELETED)
-                    .anyMatch(issue -> userLoginId.equals(issue.assigneeId())
-                            || userLoginId.equals(issue.verifierId())
-                            || userLoginId.equals(issue.fixerId())
-                            || userLoginId.equals(issue.resolverId()));
-        }
-
-        @Override
-        public boolean existsActiveAssignmentByProjectAndUser(long projectId, String loginId) {
-            return issuesById.values().stream()
-                    .filter(issue -> issue.projectId() == projectId)
-                    .filter(issue -> issue.status() == IssueStatus.ASSIGNED || issue.status() == IssueStatus.FIXED)
-                    .anyMatch(issue -> loginId.equals(issue.assigneeId()) || loginId.equals(issue.verifierId()));
-        }
-
-        @Override
-        public Issue save(Issue issue) {
-            issuesById.put(issue.id(), issue);
-            return issue;
-        }
-
-        @Override
-        public Issue softDelete(long issueId, String changedById, String message, LocalDateTime changedDate) {
-            throw new UnsupportedOperationException("softDelete is not needed by ProjectControllerTest.");
-        }
-
-        @Override
-        public Issue restore(long issueId, String changedById, String message, LocalDateTime changedDate) {
-            throw new UnsupportedOperationException("restore is not needed by ProjectControllerTest.");
-        }
-
-        @Override
-        public int purgeDeletedById(long issueId) {
-            throw new UnsupportedOperationException("purgeDeletedById is not needed by ProjectControllerTest.");
-        }
-
-        @Override
-        public int purgeDeletedBeyondLimit(long projectId, int maxDeletedIssues) {
-            return 0;
-        }
-
-    }
 }

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/DomainValueObjectsTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/DomainValueObjectsTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 class DomainValueObjectsTest {
 
     private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 19, 14, 0);
-    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
     private final User dev = User.fromPersistence("dev1", "Developer One", "hash", Role.DEV, true, null, null);
 
     @Test

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueChangeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueChangeTest.java
@@ -12,13 +12,9 @@ import org.junit.jupiter.api.Test;
 @DisplayName("이슈 변경")
 class IssueChangeTest {
 
-    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
     private final User reporter = User.fromPersistence("tester1", "Tester One", "hash", Role.TESTER, true, null, null);
-    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
     private final User pl = User.fromPersistence("pl1", "PL One", "hash", Role.PL, true, null, null);
-    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
     private final User assignee = User.fromPersistence("dev1", "Dev One", "hash", Role.DEV, true, null, null);
-    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
     private final User verifier = User.fromPersistence("tester2", "Tester Two", "hash", Role.TESTER, true, null, null);
     private final LocalDateTime createdAt = LocalDateTime.of(2026, 5, 18, 10, 0);
 

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCreationTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCreationTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 @DisplayName("이슈 생성")
 class IssueCreationTest {
 
-    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
     private final User reporter = User.fromPersistence("tester1", "Tester One", "hash", Role.TESTER, true, null, null);
     private final LocalDateTime now = LocalDateTime.of(2026, 5, 18, 10, 0);
 

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueDependencyTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueDependencyTest.java
@@ -14,9 +14,7 @@ import org.junit.jupiter.api.Test;
 @DisplayName("이슈 의존성")
 class IssueDependencyTest {
 
-    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
     private final User reporter = User.fromPersistence("tester1", "Tester One", "hash", Role.TESTER, true, null, null);
-    // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
     private final User pl = User.fromPersistence("pl1", "PL One", "hash", Role.PL, true, null, null);
     private final LocalDateTime createdAt = LocalDateTime.of(2026, 5, 18, 10, 0);
 

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueHistoryTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueHistoryTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 class IssueHistoryTest {
 
         private static final LocalDateTime CHANGED_AT = LocalDateTime.of(2026, 5, 19, 13, 0);
-        // userId 제거: 5-param → 7-param 통합 (DCD ver1 기준)
         private final User pl = User.fromPersistence("pl1", "PL One", "hash", Role.PL, true, null, null);
 
         @Test

--- a/src/test/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProviderTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/persistence/DriverManagerConnectionProviderTest.java
@@ -356,7 +356,7 @@ class DriverManagerConnectionProviderTest {
                     if ("toString".equals(method.getName())) {
                         return "connection-proxy";
                     }
-                    throw new UnsupportedOperationException(method.getName());
+                    throw new UnsupportedOperationException("Unexpected Connection call: " + method.getName());
                 });
     }
 }

--- a/src/test/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcCommentRepositoryTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcCommentRepositoryTest.java
@@ -50,7 +50,7 @@ class JdbcCommentRepositoryTest {
                     if ("getTimestamp".equals(name)) {
                         return (Timestamp) values.get((String) args[0]);
                     }
-                    throw new UnsupportedOperationException(name);
+                    throw new UnsupportedOperationException("Unexpected ResultSet call: " + name);
                 }
         );
     }

--- a/src/test/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueQueriesTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueQueriesTest.java
@@ -151,7 +151,8 @@ class JdbcIssueQueriesTest {
                         if ("toString".equals(method.getName())) {
                             return "PreparedStatementRecorder";
                         }
-                        throw new UnsupportedOperationException("Unsupported method: " + method.getName());
+                        throw new UnsupportedOperationException(
+                                "Unexpected PreparedStatement call: " + method.getName());
                     });
         }
 

--- a/src/test/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueWriteSupportTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueWriteSupportTest.java
@@ -35,7 +35,7 @@ class JdbcIssueWriteSupportTest {
                     if ("toString".equals(method.getName())) {
                         return "FailingCleanupConnection";
                     }
-                    throw new UnsupportedOperationException(method.getName());
+                    throw new UnsupportedOperationException("Unexpected Connection call: " + method.getName());
                 }
         );
     }

--- a/src/test/java/com/github/marcellokim/issuetracker/service/AccountServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/AccountServiceTest.java
@@ -10,19 +10,15 @@ import com.github.marcellokim.issuetracker.domain.Issue;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.Priority;
 import com.github.marcellokim.issuetracker.domain.Project;
-import com.github.marcellokim.issuetracker.domain.ProjectMember;
 import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.User;
 import com.github.marcellokim.issuetracker.repository.ProjectRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
 import com.github.marcellokim.issuetracker.technical.PasswordHasher;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -93,7 +89,7 @@ class AccountServiceTest {
         InMemoryUserRepository users = new InMemoryUserRepository(
                 admin(),
                 user("dev1", Role.DEV, true));
-        FakeProjectRepository projects = new FakeProjectRepository()
+        InMemoryProjectRepository projects = new InMemoryProjectRepository()
                 .withProject(project(1L, "project1"))
                 .withParticipant(1L, "dev1");
         AccountService service = service(users, projects, new InMemoryIssueRepository());
@@ -108,7 +104,7 @@ class AccountServiceTest {
         User dev = user("dev1", Role.DEV, true);
         User tester = user("tester1", Role.TESTER, true);
         InMemoryUserRepository users = new InMemoryUserRepository(admin(), dev, tester);
-        FakeProjectRepository projects = new FakeProjectRepository()
+        InMemoryProjectRepository projects = new InMemoryProjectRepository()
                 .withProject(project(1L, "project1"));
         InMemoryIssueRepository issues = new InMemoryIssueRepository(assignedIssue(dev, tester));
         AccountService service = service(users, projects, issues);
@@ -138,7 +134,7 @@ class AccountServiceTest {
         InMemoryUserRepository users = new InMemoryUserRepository(
                 admin(),
                 user("pl1", Role.PL, true));
-        FakeProjectRepository projects = new FakeProjectRepository()
+        InMemoryProjectRepository projects = new InMemoryProjectRepository()
                 .withProject(project(1L, "project1"))
                 .withParticipant(1L, "pl1");
         AccountService service = service(users, projects, new InMemoryIssueRepository());
@@ -154,7 +150,7 @@ class AccountServiceTest {
         User tester = user("tester1", Role.TESTER, true);
         InMemoryUserRepository users = new InMemoryUserRepository(admin(), dev, tester);
         InMemoryIssueRepository issues = new InMemoryIssueRepository(assignedIssue(dev, tester));
-        AccountService service = service(users, new FakeProjectRepository(), issues);
+        AccountService service = service(users, new InMemoryProjectRepository(), issues);
 
         assertThrows(IllegalArgumentException.class,
                 () -> service.deactivateAccount("dev1", actor(users, "admin")));
@@ -169,7 +165,7 @@ class AccountServiceTest {
         User tester = user("tester1", Role.TESTER, true);
         InMemoryUserRepository users = new InMemoryUserRepository(admin(), dev, tester);
         InMemoryIssueRepository issues = new InMemoryIssueRepository(completedIssueWithAudit(dev, tester));
-        AccountService service = service(users, new FakeProjectRepository(), issues);
+        AccountService service = service(users, new InMemoryProjectRepository(), issues);
 
         UserResult result = service.deactivateAccount("dev1", actor(users, "admin"));
 
@@ -226,19 +222,19 @@ class AccountServiceTest {
                 () -> new AccountService(policy, users, null, new InMemoryIssueRepository(), PASSWORD_HASHER,
                         java.time.LocalDateTime::now));
         assertThrows(NullPointerException.class,
-                () -> new AccountService(policy, users, new FakeProjectRepository(), null, PASSWORD_HASHER,
+                () -> new AccountService(policy, users, new InMemoryProjectRepository(), null, PASSWORD_HASHER,
                         java.time.LocalDateTime::now));
         assertNotNull(new AccountService(
                 policy,
                 users,
-                new FakeProjectRepository(),
+                new InMemoryProjectRepository(),
                 new InMemoryIssueRepository(),
                 PASSWORD_HASHER,
                 java.time.LocalDateTime::now));
     }
 
     private static AccountService service(InMemoryUserRepository users) {
-        return service(users, new FakeProjectRepository(), new InMemoryIssueRepository());
+        return service(users, new InMemoryProjectRepository(), new InMemoryIssueRepository());
     }
 
     private static AccountService service(
@@ -301,73 +297,4 @@ class AccountServiceTest {
                 .updatedAt(now));
     }
 
-    private static final class FakeProjectRepository implements ProjectRepository {
-
-        private final Map<Long, Project> projects = new LinkedHashMap<>();
-        private final Map<Long, List<ProjectMember>> participants = new LinkedHashMap<>();
-
-        FakeProjectRepository withProject(Project project) {
-            projects.put(project.getId(), project);
-            return this;
-        }
-
-        FakeProjectRepository withParticipant(long projectId, String loginId) {
-            participants.computeIfAbsent(projectId, ignored -> new ArrayList<>())
-                    .add(ProjectMember.create(projectId, loginId, LocalDateTime.of(2026, 5, 1, 0, 0)));
-            return this;
-        }
-
-        @Override
-        public Optional<Project> findById(long projectId) {
-            return Optional.ofNullable(projects.get(projectId));
-        }
-
-        @Override
-        public Optional<Project> findByName(String name) {
-            return projects.values().stream()
-                    .filter(project -> project.getName().equals(name))
-                    .findFirst();
-        }
-
-        @Override
-        public List<Project> findAll() {
-            return List.copyOf(projects.values());
-        }
-
-        @Override
-        public Project save(Project project) {
-            projects.put(project.getId(), project);
-            return project;
-        }
-
-        @Override
-        public void deleteById(long projectId) {
-            projects.remove(projectId);
-            participants.remove(projectId);
-        }
-
-        @Override
-        public void addParticipant(long projectId, String userLoginId) {
-            withParticipant(projectId, userLoginId);
-        }
-
-        @Override
-        public void removeParticipant(long projectId, String userLoginId) {
-            participants.computeIfAbsent(projectId, ignored -> new ArrayList<>())
-                    .removeIf(participant -> participant.userId().equals(userLoginId));
-        }
-
-        @Override
-        public List<ProjectMember> findParticipants(long projectId) {
-            return List.copyOf(participants.getOrDefault(projectId, List.of()));
-        }
-
-        @Override
-        public boolean existsByParticipant(String userLoginId) {
-            return participants.values().stream()
-                    .flatMap(List::stream)
-                    .map(ProjectMember::userId)
-                    .anyMatch(userLoginId::equals);
-        }
-    }
 }

--- a/src/test/java/com/github/marcellokim/issuetracker/service/DashboardSummaryServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/DashboardSummaryServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.marcellokim.issuetracker.domain.DailyIssueCount;
 import com.github.marcellokim.issuetracker.domain.Issue;
-import com.github.marcellokim.issuetracker.domain.IssueSearchCriteria;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.MonthlyIssueCount;
 import com.github.marcellokim.issuetracker.domain.Priority;
@@ -13,10 +12,10 @@ import com.github.marcellokim.issuetracker.domain.ProjectMember;
 import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.StatisticsReport;
 import com.github.marcellokim.issuetracker.domain.User;
-import com.github.marcellokim.issuetracker.repository.IssueRepository;
-import com.github.marcellokim.issuetracker.repository.ProjectRepository;
 import com.github.marcellokim.issuetracker.repository.StatisticsRepository;
-import com.github.marcellokim.issuetracker.repository.UserRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
 import com.github.marcellokim.issuetracker.support.StatisticsReportTestFactory;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -24,7 +23,6 @@ import java.time.YearMonth;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -47,13 +45,13 @@ class DashboardSummaryServiceTest {
         statusCounts.put(IssueStatus.NEW, 1);
 
         DashboardSummaryService service = new DashboardSummaryService(
-                new FakeProjectRepository(project, List.of(
+                new InMemoryProjectRepository(project).withParticipants(PROJECT_ID, List.of(
                         ProjectMember.create(PROJECT_ID, pl.getLoginId(), NOW),
                         ProjectMember.create(PROJECT_ID, dev.getLoginId(), NOW),
-                        ProjectMember.create(PROJECT_ID, tester.getLoginId(), NOW))),
-                new FakeIssueRepository(List.of(activeIssue), List.of(deletedIssue)),
+                        ProjectMember.create(PROJECT_ID, tester.getLoginId(), NOW))).rejectWrites(),
+                new InMemoryIssueRepository(activeIssue, deletedIssue),
                 new FakeStatisticsRepository(statusCounts),
-                new FakeUserRepository(List.of(pl, dev, tester)),
+                new InMemoryUserRepository(pl, dev, tester),
                 new PermissionPolicy());
 
         DashboardProjectSummary summary = service.projectSummariesFor(pl).getFirst();
@@ -79,16 +77,15 @@ class DashboardSummaryServiceTest {
         Project project2 = Project.fromPersistence(2L, "project2", "Demo project", "admin", NOW, NOW);
 
         DashboardSummaryService service = new DashboardSummaryService(
-                new FakeProjectRepository(
-                        List.of(project1, project2),
-                        Map.of(
-                                project1.getId(),
-                                List.of(ProjectMember.create(project1.getId(), dev.getLoginId(), NOW)),
-                                project2.getId(),
-                                List.of(ProjectMember.create(project2.getId(), tester.getLoginId(), NOW)))),
-                new FakeIssueRepository(List.of(), List.of()),
+                new InMemoryProjectRepository(project1, project2)
+                        .withParticipants(project1.getId(),
+                                List.of(ProjectMember.create(project1.getId(), dev.getLoginId(), NOW)))
+                        .withParticipants(project2.getId(),
+                                List.of(ProjectMember.create(project2.getId(), tester.getLoginId(), NOW)))
+                        .rejectWrites(),
+                new InMemoryIssueRepository(),
                 new FakeStatisticsRepository(Map.of()),
-                new FakeUserRepository(List.of(admin, dev, tester)),
+                new InMemoryUserRepository(admin, dev, tester),
                 new PermissionPolicy());
 
         List<DashboardProjectSummary> summaries = service.projectSummariesFor(admin);
@@ -110,16 +107,15 @@ class DashboardSummaryServiceTest {
         Project project2 = Project.fromPersistence(2L, "project2", "Demo project", "admin", NOW, NOW);
 
         DashboardSummaryService service = new DashboardSummaryService(
-                new FakeProjectRepository(
-                        List.of(project1, project2),
-                        Map.of(
-                                project1.getId(),
-                                List.of(ProjectMember.create(project1.getId(), dev.getLoginId(), NOW)),
-                                project2.getId(),
-                                List.of(ProjectMember.create(project2.getId(), tester.getLoginId(), NOW)))),
-                new FakeIssueRepository(List.of(), List.of()),
+                new InMemoryProjectRepository(project1, project2)
+                        .withParticipants(project1.getId(),
+                                List.of(ProjectMember.create(project1.getId(), dev.getLoginId(), NOW)))
+                        .withParticipants(project2.getId(),
+                                List.of(ProjectMember.create(project2.getId(), tester.getLoginId(), NOW)))
+                        .rejectWrites(),
+                new InMemoryIssueRepository(),
                 new FakeStatisticsRepository(Map.of()),
-                new FakeUserRepository(List.of(dev, tester)),
+                new InMemoryUserRepository(dev, tester),
                 new PermissionPolicy());
 
         List<DashboardProjectSummary> summaries = service.projectSummariesFor(dev);
@@ -146,176 +142,6 @@ class DashboardSummaryServiceTest {
                 .priority(Priority.MAJOR)
                 .status(status)
                 .updatedAt(NOW));
-    }
-
-    private static final class FakeProjectRepository implements ProjectRepository {
-
-        private final List<Project> projects;
-        private final Map<Long, List<ProjectMember>> membersByProjectId;
-
-        private FakeProjectRepository(Project project, List<ProjectMember> members) {
-            this(List.of(project), Map.of(project.getId(), members));
-        }
-
-        private FakeProjectRepository(List<Project> projects, Map<Long, List<ProjectMember>> membersByProjectId) {
-            this.projects = List.copyOf(projects);
-            this.membersByProjectId = Map.copyOf(membersByProjectId);
-        }
-
-        @Override
-        public Optional<Project> findById(long projectId) {
-            return projects.stream()
-                    .filter(project -> project.getId() == projectId)
-                    .findFirst();
-        }
-
-        @Override
-        public Optional<Project> findByName(String name) {
-            return projects.stream()
-                    .filter(project -> project.getName().equals(name))
-                    .findFirst();
-        }
-
-        @Override
-        public List<Project> findAll() {
-            return projects;
-        }
-
-        @Override
-        public Project save(Project project) {
-            throw new UnsupportedOperationException("save is not needed by DashboardSummaryServiceTest.");
-        }
-
-        @Override
-        public void deleteById(long projectId) {
-            throw new UnsupportedOperationException("deleteById is not needed by DashboardSummaryServiceTest.");
-        }
-
-        @Override
-        public void addParticipant(long projectId, String userLoginId) {
-            throw new UnsupportedOperationException("addParticipant is not needed by DashboardSummaryServiceTest.");
-        }
-
-        @Override
-        public void removeParticipant(long projectId, String userLoginId) {
-            throw new UnsupportedOperationException("removeParticipant is not needed by DashboardSummaryServiceTest.");
-        }
-
-        @Override
-        public List<ProjectMember> findParticipants(long projectId) {
-            return membersByProjectId.getOrDefault(projectId, List.of());
-        }
-
-        @Override
-        public boolean existsByParticipant(String userLoginId) {
-            return membersByProjectId.values().stream()
-                    .flatMap(List::stream)
-                    .map(ProjectMember::userId)
-                    .anyMatch(userLoginId::equals);
-        }
-    }
-
-    private static final class FakeIssueRepository implements IssueRepository {
-
-        private final List<Issue> activeIssues;
-        private final List<Issue> deletedIssues;
-
-        private FakeIssueRepository(List<Issue> activeIssues, List<Issue> deletedIssues) {
-            this.activeIssues = List.copyOf(activeIssues);
-            this.deletedIssues = List.copyOf(deletedIssues);
-        }
-
-        @Override
-        public Optional<Issue> findById(long issueId) {
-            return activeIssues.stream()
-                    .filter(issue -> issue.id() == issueId)
-                    .findFirst();
-        }
-
-        @Override
-        public List<Issue> findAllById(List<Long> issueIds) {
-            return activeIssues.stream()
-                    .filter(issue -> issueIds.contains(issue.id()))
-                    .toList();
-        }
-
-        @Override
-        public List<Issue> findByProject(long projectId) {
-            return activeIssues;
-        }
-
-        @Override
-        public List<Issue> findDeletedByProject(long projectId) {
-            return deletedIssues;
-        }
-
-        @Override
-        public List<Issue> findByCriteria(IssueSearchCriteria criteria) {
-            throw new UnsupportedOperationException("findByCriteria is not needed by DashboardSummaryServiceTest.");
-        }
-
-        @Override
-        public boolean existsByProjectIdAndTitle(long projectId, String title) {
-            return activeIssues.stream()
-                    .anyMatch(issue -> issue.projectId() == projectId && issue.title().equals(title))
-                    || deletedIssues.stream()
-                            .anyMatch(issue -> issue.projectId() == projectId && issue.title().equals(title));
-        }
-
-        @Override
-        public boolean existsByProjectIdAndTitleExcludingIssueId(long projectId, String title, long excludedIssueId) {
-            return activeIssues.stream()
-                    .anyMatch(issue -> issue.id() != excludedIssueId
-                            && issue.projectId() == projectId
-                            && issue.title().equals(title))
-                    || deletedIssues.stream()
-                            .anyMatch(issue -> issue.id() != excludedIssueId
-                                    && issue.projectId() == projectId
-                                    && issue.title().equals(title));
-        }
-
-        @Override
-        public boolean existsByResponsibleUser(String userLoginId) {
-            return activeIssues.stream()
-                    .filter(issue -> issue.status() != IssueStatus.DELETED)
-                    .anyMatch(issue -> userLoginId.equals(issue.assigneeId())
-                            || userLoginId.equals(issue.verifierId())
-                            || userLoginId.equals(issue.fixerId())
-                            || userLoginId.equals(issue.resolverId()));
-        }
-
-        @Override
-        public boolean existsActiveAssignmentByProjectAndUser(long projectId, String loginId) {
-            throw new UnsupportedOperationException(
-                    "existsActiveAssignmentByProjectAndUser is not needed by DashboardSummaryServiceTest.");
-        }
-
-        @Override
-        public Issue save(Issue issue) {
-            throw new UnsupportedOperationException("save is not needed by DashboardSummaryServiceTest.");
-        }
-
-        @Override
-        public Issue softDelete(long issueId, String changedById, String message, LocalDateTime changedDate) {
-            throw new UnsupportedOperationException("softDelete is not needed by DashboardSummaryServiceTest.");
-        }
-
-        @Override
-        public Issue restore(long issueId, String changedById, String message, LocalDateTime changedDate) {
-            throw new UnsupportedOperationException("restore is not needed by DashboardSummaryServiceTest.");
-        }
-
-        @Override
-        public int purgeDeletedById(long issueId) {
-            throw new UnsupportedOperationException("purgeDeletedById is not needed by DashboardSummaryServiceTest.");
-        }
-
-        @Override
-        public int purgeDeletedBeyondLimit(long projectId, int maxDeletedIssues) {
-            throw new UnsupportedOperationException(
-                    "purgeDeletedBeyondLimit is not needed by DashboardSummaryServiceTest.");
-        }
-
     }
 
     private static final class FakeStatisticsRepository implements StatisticsRepository {
@@ -377,53 +203,4 @@ class DashboardSummaryServiceTest {
         }
     }
 
-    private static final class FakeUserRepository implements UserRepository {
-
-        private final List<User> users;
-
-        private FakeUserRepository(List<User> users) {
-            this.users = List.copyOf(users);
-        }
-
-        @Override
-        public Optional<User> findByLoginId(String loginId) {
-            return users.stream()
-                    .filter(user -> user.getLoginId().equals(loginId))
-                    .findFirst();
-        }
-
-        @Override
-        public List<User> findAll() {
-            return users;
-        }
-
-        @Override
-        public List<User> findByRole(long projectId, Role role) {
-            return users.stream()
-                    .filter(user -> user.getRole() == role)
-                    .toList();
-        }
-
-        @Override
-        public List<User> findActiveByRole(long projectId, Role role) {
-            return users.stream()
-                    .filter(user -> user.getRole() == role)
-                    .toList();
-        }
-
-        @Override
-        public User save(User user) {
-            throw new UnsupportedOperationException("save is not needed by DashboardSummaryServiceTest.");
-        }
-
-        @Override
-        public void activate(String loginId) {
-            throw new UnsupportedOperationException("activate is not needed by DashboardSummaryServiceTest.");
-        }
-
-        @Override
-        public void deactivate(String loginId) {
-            throw new UnsupportedOperationException("deactivate is not needed by DashboardSummaryServiceTest.");
-        }
-    }
 }

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueServiceTest.java
@@ -15,18 +15,16 @@ import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.IssueHistory;
 import com.github.marcellokim.issuetracker.domain.Priority;
 import com.github.marcellokim.issuetracker.domain.Project;
-import com.github.marcellokim.issuetracker.domain.ProjectMember;
 import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.User;
 import com.github.marcellokim.issuetracker.repository.CommentRepository;
-import com.github.marcellokim.issuetracker.repository.ProjectRepository;
 import com.github.marcellokim.issuetracker.support.FakeIssueDependencyRepository;
 import com.github.marcellokim.issuetracker.support.FakeIssueHistoryRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
 import com.github.marcellokim.issuetracker.domain.IssueDependency;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -1291,7 +1289,7 @@ class IssueServiceTest {
                         InMemoryUserRepository users) {
                 comments.recordHistoriesIn(histories);
                 return new IssueService(
-                                new FakeProjectRepository(project, otherProject),
+                                new InMemoryProjectRepository(project, otherProject),
                                 issues,
                                 dependencies,
                                 comments,
@@ -1358,63 +1356,6 @@ class IssueServiceTest {
                                 purpose,
                                 now,
                                 now);
-        }
-
-        private static final class FakeProjectRepository implements ProjectRepository {
-
-                private final Map<Long, Project> projects = new LinkedHashMap<>();
-
-                private FakeProjectRepository(Project... projects) {
-                        for (Project p : projects) {
-                                this.projects.put(p.getId(), p);
-                        }
-                }
-
-                @Override
-                public Optional<Project> findById(long projectId) {
-                        return Optional.ofNullable(projects.get(projectId));
-                }
-
-                @Override
-                public Optional<Project> findByName(String name) {
-                        return projects.values().stream()
-                                        .filter(p -> p.getName().equals(name))
-                                        .findFirst();
-                }
-
-                @Override
-                public List<Project> findAll() {
-                        return new ArrayList<>(projects.values());
-                }
-
-                @Override
-                public Project save(Project project) {
-                        projects.put(project.getId(), project);
-                        return project;
-                }
-
-                @Override
-                public void deleteById(long projectId) {
-                        projects.remove(projectId);
-                }
-
-                @Override
-                public void addParticipant(long projectId, String userLoginId) {
-                }
-
-                @Override
-                public void removeParticipant(long projectId, String userLoginId) {
-                }
-
-                @Override
-                public List<ProjectMember> findParticipants(long projectId) {
-                        return List.of();
-                }
-
-                @Override
-                public boolean existsByParticipant(String userLoginId) {
-                        return false;
-                }
         }
 
         private static final class FakeCommentRepository implements CommentRepository {

--- a/src/test/java/com/github/marcellokim/issuetracker/service/RepositoryDemoSummaryServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/RepositoryDemoSummaryServiceTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.github.marcellokim.issuetracker.domain.AssignmentCandidate;
 import com.github.marcellokim.issuetracker.domain.DailyIssueCount;
 import com.github.marcellokim.issuetracker.domain.Issue;
-import com.github.marcellokim.issuetracker.domain.IssueSearchCriteria;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.MonthlyIssueCount;
 import com.github.marcellokim.issuetracker.domain.Priority;
@@ -16,17 +15,16 @@ import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.StatisticsReport;
 import com.github.marcellokim.issuetracker.domain.User;
 import com.github.marcellokim.issuetracker.repository.AssignmentRecommendationRepository;
-import com.github.marcellokim.issuetracker.repository.IssueRepository;
-import com.github.marcellokim.issuetracker.repository.ProjectRepository;
 import com.github.marcellokim.issuetracker.repository.StatisticsRepository;
-import com.github.marcellokim.issuetracker.repository.UserRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -46,12 +44,12 @@ class RepositoryDemoSummaryServiceTest {
         Issue issue = issue(101L, IssueStatus.NEW);
 
         RepositoryDemoSummaryService service = new RepositoryDemoSummaryService(
-                new FakeUserRepository(List.of(admin, dev, tester)),
-                new FakeProjectRepository(project, List.of(
+                new InMemoryUserRepository(admin, dev, tester),
+                new InMemoryProjectRepository(project).withParticipants(PROJECT_ID, List.of(
                         ProjectMember.create(PROJECT_ID, admin.getLoginId(), NOW),
                         ProjectMember.create(PROJECT_ID, dev.getLoginId(), NOW),
-                        ProjectMember.create(PROJECT_ID, tester.getLoginId(), NOW))),
-                new FakeIssueRepository(List.of(issue)),
+                        ProjectMember.create(PROJECT_ID, tester.getLoginId(), NOW))).rejectWrites(),
+                new InMemoryIssueRepository(issue),
                 new FakeStatisticsRepository(),
                 new FakeAssignmentRecommendationRepository(dev, tester));
 
@@ -84,12 +82,12 @@ class RepositoryDemoSummaryServiceTest {
         Issue issue = issue(101L, IssueStatus.NEW);
 
         RepositoryDemoSummaryService service = new RepositoryDemoSummaryService(
-                new FakeUserRepository(List.of(admin, dev, tester)),
-                new FakeProjectRepository(project, List.of(
+                new InMemoryUserRepository(admin, dev, tester),
+                new InMemoryProjectRepository(project).withParticipants(PROJECT_ID, List.of(
                         ProjectMember.create(PROJECT_ID, admin.getLoginId(), NOW),
                         ProjectMember.create(PROJECT_ID, dev.getLoginId(), NOW),
-                        ProjectMember.create(PROJECT_ID, tester.getLoginId(), NOW))),
-                new FakeIssueRepository(List.of(issue)),
+                        ProjectMember.create(PROJECT_ID, tester.getLoginId(), NOW))).rejectWrites(),
+                new InMemoryIssueRepository(issue),
                 new FakeStatisticsRepository(),
                 new FakeAssignmentRecommendationRepository(dev, tester));
 
@@ -117,212 +115,8 @@ class RepositoryDemoSummaryServiceTest {
                 .updatedAt(NOW));
     }
 
-    private static final class FakeUserRepository implements UserRepository {
-
-        private final List<User> users;
-
-        private FakeUserRepository(List<User> users) {
-            this.users = List.copyOf(users);
-        }
-
-        @Override
-        public Optional<User> findByLoginId(String loginId) {
-            return users.stream()
-                    .filter(user -> user.getLoginId().equals(loginId))
-                    .findFirst();
-        }
-
-        @Override
-        public List<User> findAll() {
-            return users;
-        }
-
-        @Override
-        public List<User> findByRole(long projectId, Role role) {
-            return users.stream()
-                    .filter(user -> user.getRole() == role)
-                    .toList();
-        }
-
-        @Override
-        public List<User> findActiveByRole(long projectId, Role role) {
-            return users.stream()
-                    .filter(User::isActive)
-                    .filter(user -> user.getRole() == role)
-                    .toList();
-        }
-
-        @Override
-        public User save(User user) {
-            throw new UnsupportedOperationException("save is not needed by RepositoryDemoSummaryServiceTest.");
-        }
-
-        @Override
-        public void activate(String loginId) {
-            throw new UnsupportedOperationException("activate is not needed by RepositoryDemoSummaryServiceTest.");
-        }
-
-        @Override
-        public void deactivate(String loginId) {
-            throw new UnsupportedOperationException("deactivate is not needed by RepositoryDemoSummaryServiceTest.");
-        }
-    }
-
-    private static final class FakeProjectRepository implements ProjectRepository {
-
-        private final Project project;
-        private final List<ProjectMember> members;
-
-        private FakeProjectRepository(Project project, List<ProjectMember> members) {
-            this.project = project;
-            this.members = List.copyOf(members);
-        }
-
-        @Override
-        public Optional<Project> findById(long projectId) {
-            return project.getId() == projectId ? Optional.of(project) : Optional.empty();
-        }
-
-        @Override
-        public Optional<Project> findByName(String name) {
-            return project.getName().equals(name) ? Optional.of(project) : Optional.empty();
-        }
-
-        @Override
-        public List<Project> findAll() {
-            return List.of(project);
-        }
-
-        @Override
-        public Project save(Project project) {
-            throw new UnsupportedOperationException("save is not needed by RepositoryDemoSummaryServiceTest.");
-        }
-
-        @Override
-        public void deleteById(long projectId) {
-            throw new UnsupportedOperationException("deleteById is not needed by RepositoryDemoSummaryServiceTest.");
-        }
-
-        @Override
-        public void addParticipant(long projectId, String userLoginId) {
-            throw new UnsupportedOperationException(
-                    "addParticipant is not needed by RepositoryDemoSummaryServiceTest.");
-        }
-
-        @Override
-        public void removeParticipant(long projectId, String userLoginId) {
-            throw new UnsupportedOperationException(
-                    "removeParticipant is not needed by RepositoryDemoSummaryServiceTest.");
-        }
-
-        @Override
-        public List<ProjectMember> findParticipants(long projectId) {
-            return project.getId() == projectId ? members : List.of();
-        }
-
-        @Override
-        public boolean existsByParticipant(String userLoginId) {
-            return members.stream()
-                    .map(ProjectMember::userId)
-                    .anyMatch(userLoginId::equals);
-        }
-    }
-
-    private static final class FakeIssueRepository implements IssueRepository {
-
-        private final List<Issue> issues;
-
-        private FakeIssueRepository(List<Issue> issues) {
-            this.issues = List.copyOf(issues);
-        }
-
-        @Override
-        public Optional<Issue> findById(long issueId) {
-            return issues.stream()
-                    .filter(issue -> issue.id() == issueId)
-                    .findFirst();
-        }
-
-        @Override
-        public List<Issue> findAllById(List<Long> issueIds) {
-            return issues.stream()
-                    .filter(issue -> issueIds.contains(issue.id()))
-                    .toList();
-        }
-
-        @Override
-        public List<Issue> findByProject(long projectId) {
-            return issues.stream()
-                    .filter(issue -> issue.projectId() == projectId)
-                    .toList();
-        }
-
-        @Override
-        public List<Issue> findDeletedByProject(long projectId) {
-            return List.of();
-        }
-
-        @Override
-        public List<Issue> findByCriteria(IssueSearchCriteria criteria) {
-            return issues;
-        }
-
-        @Override
-        public boolean existsByProjectIdAndTitle(long projectId, String title) {
-            return issues.stream()
-                    .anyMatch(issue -> issue.projectId() == projectId && issue.title().equals(title));
-        }
-
-        @Override
-        public boolean existsByProjectIdAndTitleExcludingIssueId(long projectId, String title, long excludedIssueId) {
-            return issues.stream()
-                    .anyMatch(issue -> issue.id() != excludedIssueId
-                            && issue.projectId() == projectId
-                            && issue.title().equals(title));
-        }
-
-        @Override
-        public boolean existsByResponsibleUser(String userLoginId) {
-            return issues.stream()
-                    .filter(issue -> issue.status() != IssueStatus.DELETED)
-                    .anyMatch(issue -> userLoginId.equals(issue.assigneeId())
-                            || userLoginId.equals(issue.verifierId())
-                            || userLoginId.equals(issue.fixerId())
-                            || userLoginId.equals(issue.resolverId()));
-        }
-
-        @Override
-        public boolean existsActiveAssignmentByProjectAndUser(long projectId, String loginId) {
-            throw new UnsupportedOperationException(
-                    "existsActiveAssignmentByProjectAndUser is not needed by RepositoryDemoSummaryServiceTest.");
-        }
-
-        @Override
-        public Issue save(Issue issue) {
-            throw new UnsupportedOperationException("save is not needed by RepositoryDemoSummaryServiceTest.");
-        }
-
-        @Override
-        public Issue softDelete(long issueId, String changedById, String message, LocalDateTime changedDate) {
-            throw new UnsupportedOperationException("softDelete is not needed by RepositoryDemoSummaryServiceTest.");
-        }
-
-        @Override
-        public Issue restore(long issueId, String changedById, String message, LocalDateTime changedDate) {
-            throw new UnsupportedOperationException("restore is not needed by RepositoryDemoSummaryServiceTest.");
-        }
-
-        @Override
-        public int purgeDeletedById(long issueId) {
-            throw new UnsupportedOperationException("purgeDeletedById is not needed by RepositoryDemoSummaryServiceTest.");
-        }
-
-        @Override
-        public int purgeDeletedBeyondLimit(long projectId, int maxDeletedIssues) {
-            throw new UnsupportedOperationException(
-                    "purgeDeletedBeyondLimit is not needed by RepositoryDemoSummaryServiceTest.");
-        }
-
+    private static UnsupportedOperationException unexpectedRepositoryCall(String methodName) {
+        return new UnsupportedOperationException("Unexpected repository call: " + methodName);
     }
 
     private static final class FakeStatisticsRepository implements StatisticsRepository {
@@ -374,7 +168,7 @@ class RepositoryDemoSummaryServiceTest {
                 LocalDate dailyToInclusive,
                 YearMonth monthlyFromInclusive,
                 YearMonth monthlyToInclusive) {
-            throw new UnsupportedOperationException("buildReport is not needed by RepositoryDemoSummaryServiceTest.");
+            throw unexpectedRepositoryCall("buildReport");
         }
     }
 

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/ArchitectureBoundaryTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/ArchitectureBoundaryTest.java
@@ -35,11 +35,7 @@ class ArchitectureBoundaryTest {
     private static final Path ROOT_PACKAGE_PATH = MAIN_SOURCE_ROOT.resolve(ROOT_PACKAGE.replace('.', '/'));
     private static final Pattern IMPORT_PATTERN = Pattern.compile("^import\\s+(?:static\\s+)?([\\w.]+)(?:\\.\\*)?;");
 
-    /*
-     * 임시 아키텍처 부채 표시자.
-     * 각 흐름이 의도한 service/presenter 경계로 이동하면 예외 제거 필요.
-     */
-    private static final Set<AllowedReference> TEMPORARY_ALLOWED_REFERENCES = Set.of();
+    private static final Set<AllowedReference> ALLOWED_REFERENCES = Set.of();
 
     @Test
     @DisplayName("domain package does not depend on outer layers")
@@ -154,7 +150,7 @@ class ArchitectureBoundaryTest {
         for (JavaSource source : productionSources(packageSegment)) {
             for (SourceReference importedType : source.importedTypes()) {
                 if (isForbidden(importedType.reference(), forbiddenPrefixes)
-                        && !TEMPORARY_ALLOWED_REFERENCES.contains(
+                        && !ALLOWED_REFERENCES.contains(
                                 new AllowedReference(source.relativePath(), importedType.reference()))) {
                     violations.add(new Violation(
                             source.relativePath(),
@@ -165,7 +161,7 @@ class ArchitectureBoundaryTest {
                 }
             }
             for (SourceReference reference : forbiddenFullyQualifiedReferences(source, forbiddenPrefixes)) {
-                if (!TEMPORARY_ALLOWED_REFERENCES.contains(
+                if (!ALLOWED_REFERENCES.contains(
                         new AllowedReference(source.relativePath(), reference.reference()))) {
                     violations.add(new Violation(
                             source.relativePath(),
@@ -207,7 +203,6 @@ class ArchitectureBoundaryTest {
                 .resolve(ROOT_PACKAGE.replace('.', '/'))
                 .resolve(packageSegment);
         if (!Files.exists(packagePath)) {
-            // Task 1 guard 선설치 후 Task 2 cli 패키지 생성 전까지만 빈 검사 대상 허용.
             if ("cli".equals(packageSegment) || "ui".equals(packageSegment)) {
                 return List.of();
             }

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
@@ -113,7 +113,7 @@ class ProjectMaintenanceScriptTest {
                     if args[:2] == ["pr", "list"]:
                         return [{
                             "number": 9006,
-                            "title": "temporary cli failure",
+                            "title": "cli lookup failure",
                             "body": "## 관련 이슈\\n- Closes #9998\\n",
                             "closingIssuesReferences": []
                         }]

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
@@ -131,7 +131,7 @@ class RepositoryConventionsSmokeTest {
                 new ScriptExpectation("build.gradle", "id 'application'"),
                 new ScriptExpectation("build.gradle", "id 'org.openjfx.javafxplugin' version '0.1.0'"),
                 new ScriptExpectation("build.gradle", "version = '21.0.6'"),
-                new ScriptExpectation("build.gradle", "modules = ['javafx.controls', 'javafx.fxml']"),
+                new ScriptExpectation("build.gradle", "modules = ['javafx.controls', 'javafx.fxml', 'javafx.graphics']"),
                 new ScriptExpectation("build.gradle", "mainClass = 'com.github.marcellokim.issuetracker.Main'"),
                 new ScriptExpectation("build.gradle", "providers.gradleProperty('pythonExecutable')"),
                 new ScriptExpectation("build.gradle", "? 'python' : 'python3'"),

--- a/src/test/java/com/github/marcellokim/issuetracker/support/InMemoryIssueRepository.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/support/InMemoryIssueRepository.java
@@ -5,6 +5,7 @@ import com.github.marcellokim.issuetracker.domain.IssueSearchCriteria;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.repository.IssueRepository;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +42,8 @@ public final class InMemoryIssueRepository implements IssueRepository {
     public List<Issue> findByProject(long projectId) {
         return issues.values().stream()
                 .filter(issue -> issue.projectId() == projectId)
+                .filter(issue -> issue.status() != IssueStatus.DELETED)
+                .sorted(Comparator.comparingLong(Issue::id))
                 .toList();
     }
 
@@ -49,6 +52,8 @@ public final class InMemoryIssueRepository implements IssueRepository {
         return issues.values().stream()
                 .filter(issue -> issue.projectId() == projectId)
                 .filter(issue -> issue.status() == IssueStatus.DELETED)
+                .sorted(Comparator.comparing(Issue::reportedDate).reversed()
+                        .thenComparing(Comparator.comparingLong(Issue::id).reversed()))
                 .toList();
     }
 
@@ -108,12 +113,12 @@ public final class InMemoryIssueRepository implements IssueRepository {
 
     @Override
     public Issue softDelete(long issueId, String changedById, String message, LocalDateTime changedDate) {
-        throw new UnsupportedOperationException("softDelete is not needed by these service tests");
+        throw unexpectedRepositoryCall("softDelete");
     }
 
     @Override
     public Issue restore(long issueId, String changedById, String message, LocalDateTime changedDate) {
-        throw new UnsupportedOperationException("restore is not needed by these service tests");
+        throw unexpectedRepositoryCall("restore");
     }
 
     @Override
@@ -156,5 +161,9 @@ public final class InMemoryIssueRepository implements IssueRepository {
         String normalizedKeyword = keyword.toLowerCase();
         return issue.title().toLowerCase().contains(normalizedKeyword)
                 || issue.description().toLowerCase().contains(normalizedKeyword);
+    }
+
+    private static UnsupportedOperationException unexpectedRepositoryCall(String methodName) {
+        return new UnsupportedOperationException("Unexpected repository call: " + methodName);
     }
 }

--- a/src/test/java/com/github/marcellokim/issuetracker/support/InMemoryProjectRepository.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/support/InMemoryProjectRepository.java
@@ -1,0 +1,162 @@
+package com.github.marcellokim.issuetracker.support;
+
+import com.github.marcellokim.issuetracker.domain.Project;
+import com.github.marcellokim.issuetracker.domain.ProjectMember;
+import com.github.marcellokim.issuetracker.repository.ProjectRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class InMemoryProjectRepository implements ProjectRepository {
+
+    private static final LocalDateTime DEFAULT_JOINED_AT = LocalDateTime.of(2026, 5, 1, 0, 0);
+
+    private final Map<Long, Project> projects = new LinkedHashMap<>();
+    private final Map<Long, List<ProjectMember>> participants = new LinkedHashMap<>();
+    private long nextProjectId = 100L;
+    private long lastDeletedProjectId;
+    private boolean rejectWrites;
+
+    public InMemoryProjectRepository(Project... projects) {
+        for (Project project : projects) {
+            withProject(project);
+        }
+    }
+
+    public InMemoryProjectRepository rejectWrites() {
+        rejectWrites = true;
+        return this;
+    }
+
+    public InMemoryProjectRepository withProject(Project project) {
+        Objects.requireNonNull(project, "project");
+        projects.put(project.getId(), project);
+        nextProjectId = Math.max(nextProjectId, project.getId() + 1L);
+        return this;
+    }
+
+    public InMemoryProjectRepository withParticipant(long projectId, String loginId) {
+        return withParticipant(projectId, loginId, DEFAULT_JOINED_AT);
+    }
+
+    public InMemoryProjectRepository withParticipant(long projectId, String loginId, LocalDateTime joinedAt) {
+        Objects.requireNonNull(loginId, "loginId");
+        Objects.requireNonNull(joinedAt, "joinedAt");
+        addParticipantIfAbsent(ProjectMember.create(projectId, loginId, joinedAt));
+        return this;
+    }
+
+    public InMemoryProjectRepository withParticipants(long projectId, List<ProjectMember> projectMembers) {
+        Objects.requireNonNull(projectMembers, "projectMembers");
+        participants.put(projectId, new ArrayList<>());
+        projectMembers.forEach(this::addParticipantIfAbsent);
+        return this;
+    }
+
+    public long lastDeletedProjectId() {
+        return lastDeletedProjectId;
+    }
+
+    public List<String> participantIds(long projectId) {
+        return findParticipants(projectId).stream()
+                .map(ProjectMember::userId)
+                .toList();
+    }
+
+    @Override
+    public Optional<Project> findById(long projectId) {
+        return Optional.ofNullable(projects.get(projectId));
+    }
+
+    @Override
+    public Optional<Project> findByName(String name) {
+        return projects.values().stream()
+                .filter(project -> project.getName().equals(name))
+                .findFirst();
+    }
+
+    @Override
+    public List<Project> findAll() {
+        return projects.values().stream()
+                .sorted(Comparator.comparingLong(Project::getId))
+                .toList();
+    }
+
+    @Override
+    public Project save(Project project) {
+        requireWritesAllowed("save");
+        Objects.requireNonNull(project, "project");
+        Project saved = project.getId() == 0L
+                ? Project.fromPersistence(
+                        nextProjectId++,
+                        project.getName(),
+                        project.getDescription(),
+                        project.getManagedByLoginId(),
+                        project.getCreatedDate(),
+                        project.getUpdatedAt())
+                : project;
+        projects.put(saved.getId(), saved);
+        nextProjectId = Math.max(nextProjectId, saved.getId() + 1L);
+        return saved;
+    }
+
+    @Override
+    public void deleteById(long projectId) {
+        requireWritesAllowed("deleteById");
+        lastDeletedProjectId = projectId;
+        projects.remove(projectId);
+        participants.remove(projectId);
+    }
+
+    @Override
+    public void addParticipant(long projectId, String userLoginId) {
+        requireWritesAllowed("addParticipant");
+        withParticipant(projectId, userLoginId);
+    }
+
+    @Override
+    public void removeParticipant(long projectId, String userLoginId) {
+        requireWritesAllowed("removeParticipant");
+        participants.computeIfAbsent(projectId, ignored -> new ArrayList<>())
+                .removeIf(participant -> participant.userId().equals(userLoginId));
+    }
+
+    @Override
+    public List<ProjectMember> findParticipants(long projectId) {
+        return participants.getOrDefault(projectId, List.of()).stream()
+                .sorted(Comparator.comparing(ProjectMember::userId))
+                .toList();
+    }
+
+    @Override
+    public boolean existsByParticipant(String userLoginId) {
+        Objects.requireNonNull(userLoginId, "userLoginId");
+        return participants.values().stream()
+                .flatMap(List::stream)
+                .map(ProjectMember::userId)
+                .anyMatch(userLoginId::equals);
+    }
+
+    private void requireWritesAllowed(String methodName) {
+        if (rejectWrites) {
+            throw new UnsupportedOperationException("Unexpected ProjectRepository call: " + methodName);
+        }
+    }
+
+    private void addParticipantIfAbsent(ProjectMember member) {
+        Objects.requireNonNull(member, "member");
+        List<ProjectMember> projectParticipants = participants.computeIfAbsent(
+                member.projectId(),
+                ignored -> new ArrayList<>());
+        boolean alreadyExists = projectParticipants.stream()
+                .anyMatch(existing -> existing.userId().equals(member.userId()));
+        if (!alreadyExists) {
+            projectParticipants.add(member);
+        }
+    }
+}


### PR DESCRIPTION
## 요약
- 관련 이슈: Closes #165
- 변경 목적: 계층 책임 검수 과정에서 발견한 불필요한 주석, 죽은 설정, 반복 테스트 fixture를 정리해 리뷰 가능한 구조로 줄임.

## 변경 분류
- [ ] 기능 개발
- [ ] 버그 수정
- [x] 테스트 보강
- [ ] 문서화
- [x] 환경설정 / 자동화
- [x] 리팩터링

## purpose
#165의 계층 책임 검수 범위에서 코드와 테스트가 실제 동작보다 더 크게 보이게 만드는 잡음을 줄임. 런타임 기능 추가가 아니라 기존 구조를 더 읽기 쉽게 정리하는 변경임.

## non-goals
- 권한 정책, 상태 전이 정책, DB schema 변경 없음.
- 신규 기능 또는 UI 동작 변경 없음.
- Oracle 통합 테스트 환경 구성 변경 없음.

## recommended review order
1. `build.gradle`과 production 코드의 주석/죽은 설정 제거 확인.
2. `InMemoryProjectRepository`, `InMemoryIssueRepository` 테스트 지원 객체 계약 확인.
3. controller/service 테스트에서 중복 fake repository 제거가 기존 검증 의도를 유지하는지 확인.

## diff map
- 핵심 변경: production/domain/persistence/service 코드의 오래된 설명 주석과 비활성 설정 제거.
- 테스트/fixture 변경: `InMemoryProjectRepository` 추가, `InMemoryIssueRepository.findByProject()`를 JDBC 계약과 맞춰 `DELETED` 제외.
- 중복 제거: 여러 테스트의 `FakeProjectRepository`와 일부 `FakeIssueRepository`를 공유 테스트 지원 객체로 대체.
- 제외한 변경: 삭제/복구/퍼지 상태 추적이 필요한 controller coverage fake는 테스트별 의도가 있어 유지.

## verification evidence
- `./scripts/open-pr.sh` 실행 중 `./gradlew check` 성공.
- push 전 hook에서 `./gradlew test`와 `verifyRepositorySetup` 성공.
- `git diff --check` 성공.
- 원격 CI에서 빌드/테스트, Oracle 통합 테스트, 프로젝트 상태 정렬, 워크플로우 정책 검사, 보안 분석, SonarCloud, CodeQL 통과.
- Oracle 통합 테스트는 로컬 Oracle 환경 의존으로 로컬에서는 `SKIPPED`, 원격 CI에서는 통과.

## 과제 요구사항 영향
- [x] MVC 분리 관련 변경 반영
- [x] Persistence 관련 변경 반영
- [ ] 다중 UI toolkit 영향 확인
- [ ] 통계 / 추천 기능 영향 확인
- [ ] 해당 없음

## 문서 및 증빙
- [ ] README 반영
- [ ] docs/ 반영
- [ ] 스크린샷 또는 GIF 첨부
- [x] GitHub 프로젝트 상태 업데이트
- [x] 해당 없음

## reviewer focus areas
- 공유 테스트 repository가 실제 repository 계약과 다르게 동작하지 않는지.
- 제거한 주석이 현재 설계 의도를 설명하던 필수 문맥은 아니었는지.
- 테스트 중복 제거가 검증 강도를 약하게 만들지 않았는지.

## risk / rollback
문서나 schema를 바꾸지 않는 정리성 변경이라 런타임 영향은 낮음. 문제가 있으면 해당 커밋을 revert하면 기존 테스트 fixture와 주석 상태로 되돌릴 수 있음.

## 리뷰 포인트
- 집중해서 봐야 할 부분: 테스트 지원 객체의 repository 계약 정합성.
- 남아 있는 위험/후속 작업: 없음.
