### PR TITLE
feat: Swing 로그인 화면 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,8 @@ tasks.register('runSwing', JavaExec) {
     group = 'application'
     description = 'Runs the Swing UI entry point.'
     classpath = sourceSets.main.runtimeClasspath
-    mainClass = 'com.github.marcellokim.issuetracker.ui.swing.SwingApp'
+    mainClass = 'com.github.marcellokim.issuetracker.Main'
+    args '--swing'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,13 @@ application {
     mainClass = 'com.github.marcellokim.issuetracker.Main'
 }
 
+tasks.register('runSwing', JavaExec) {
+    group = 'application'
+    description = 'Runs the Swing UI entry point.'
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'com.github.marcellokim.issuetracker.ui.swing.SwingApp'
+}
+
 repositories {
     mavenCentral()
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/Main.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/Main.java
@@ -1,11 +1,23 @@
 package com.github.marcellokim.issuetracker;
 
+import com.github.marcellokim.issuetracker.ui.javafx.JavaFXApp;
+import com.github.marcellokim.issuetracker.ui.swing.SwingApp;
+import javafx.application.Application;
+
 public final class Main {
 
     private Main() {
     }
 
     public static void main(String[] args) {
-        javafx.application.Application.launch(com.github.marcellokim.issuetracker.ui.javafx.JavaFXApp.class, args);
+        if (shouldLaunchSwing(args)) {
+            SwingApp.launch();
+            return;
+        }
+        Application.launch(JavaFXApp.class, args);
+    }
+
+    static boolean shouldLaunchSwing(String[] args) {
+        return args != null && args.length > 0 && "--swing".equals(args[0]);
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
@@ -87,13 +87,7 @@ final class LoginPanel extends JPanel implements LoginView {
         add(surface);
     }
 
-    /**
-     * Registers the action to run when the user requests login.
-     *
-     * <p>The action is invoked synchronously on the Swing Event Dispatch Thread by this panel's action
-     * listeners. Callers that perform authentication or other blocking controller/service work must offload
-     * that work from the EDT and return promptly.
-     */
+    /** Registers an EDT callback; callers must offload blocking authentication work. */
     void onLoginRequested(Runnable action) {
         loginRequested = Objects.requireNonNull(action, "action");
     }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
@@ -42,6 +42,8 @@ final class LoginPanel extends JPanel implements LoginView {
         surface.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
 
         JLabel loginIdLabel = new JLabel("ID");
+        loginIdLabel.setName("loginIdLabel");
+        loginIdLabel.setLabelFor(loginIdField);
         loginIdLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
         surface.add(loginIdLabel);
         surface.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
@@ -54,6 +56,8 @@ final class LoginPanel extends JPanel implements LoginView {
         surface.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
 
         JLabel passwordLabel = new JLabel("Password");
+        passwordLabel.setName("passwordLabel");
+        passwordLabel.setLabelFor(passwordField);
         passwordLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
         surface.add(passwordLabel);
         surface.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
@@ -105,12 +109,14 @@ final class LoginPanel extends JPanel implements LoginView {
 
     @Override
     public void setLoginEnabled(boolean enabled) {
+        loginIdField.setEnabled(enabled);
+        passwordField.setEnabled(enabled);
         signInButton.setEnabled(enabled);
     }
 
     @Override
     public void showMessage(String message, boolean error) {
-        messageLabel.setText(message);
+        messageLabel.setText(message == null || message.isBlank() ? " " : message);
         messageLabel.setForeground(error ? SwingStyles.ERROR_TEXT : SwingStyles.MUTED_TEXT);
     }
 

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
@@ -2,6 +2,7 @@ package com.github.marcellokim.issuetracker.ui.swing;
 
 import java.awt.Component;
 import java.awt.GridBagLayout;
+import java.util.Arrays;
 import java.util.Objects;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -104,7 +105,12 @@ final class LoginPanel extends JPanel implements LoginView {
 
     @Override
     public String password() {
-        return new String(passwordField.getPassword());
+        char[] passwordChars = passwordField.getPassword();
+        try {
+            return new String(passwordChars);
+        } finally {
+            Arrays.fill(passwordChars, '\0');
+        }
     }
 
     @Override

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
@@ -112,6 +112,7 @@ final class LoginPanel extends JPanel implements LoginView {
         loginIdField.setEnabled(enabled);
         passwordField.setEnabled(enabled);
         signInButton.setEnabled(enabled);
+        SwingStyles.applyPrimaryButtonState(signInButton, enabled);
     }
 
     @Override

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
@@ -1,0 +1,121 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.awt.Component;
+import java.awt.GridBagLayout;
+import java.util.Objects;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
+
+final class LoginPanel extends JPanel implements LoginView {
+
+    private final JTextField loginIdField = new JTextField();
+    private final JPasswordField passwordField = new JPasswordField();
+    private final JButton signInButton = new JButton("Sign in");
+    private final JLabel messageLabel = new JLabel(" ");
+    private Runnable loginRequested = () -> {
+    };
+
+    LoginPanel() {
+        setLayout(new GridBagLayout());
+        setBackground(SwingStyles.BACKGROUND);
+        setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING));
+
+        JPanel surface = new JPanel();
+        surface.setLayout(new BoxLayout(surface, BoxLayout.Y_AXIS));
+        surface.setBackground(SwingStyles.SURFACE);
+        surface.setBorder(SwingStyles.surfaceBorder());
+
+        JLabel title = new JLabel("Issue Tracker");
+        SwingStyles.applyTitle(title);
+        title.setAlignmentX(Component.LEFT_ALIGNMENT);
+        surface.add(title);
+        surface.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
+
+        JLabel loginIdLabel = new JLabel("ID");
+        loginIdLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        surface.add(loginIdLabel);
+        surface.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+
+        loginIdField.setName("loginIdField");
+        SwingStyles.fixHeight(loginIdField, SwingStyles.FIELD_HEIGHT);
+        loginIdField.setMaximumSize(loginIdField.getPreferredSize());
+        loginIdField.setAlignmentX(Component.LEFT_ALIGNMENT);
+        surface.add(loginIdField);
+        surface.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
+
+        JLabel passwordLabel = new JLabel("Password");
+        passwordLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        surface.add(passwordLabel);
+        surface.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+
+        passwordField.setName("passwordField");
+        SwingStyles.fixHeight(passwordField, SwingStyles.FIELD_HEIGHT);
+        passwordField.setMaximumSize(passwordField.getPreferredSize());
+        passwordField.setAlignmentX(Component.LEFT_ALIGNMENT);
+        passwordField.addActionListener(event -> loginRequested.run());
+        surface.add(passwordField);
+        surface.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
+
+        signInButton.setName("signInButton");
+        SwingStyles.applyPrimaryButton(signInButton);
+        signInButton.setMaximumSize(signInButton.getPreferredSize());
+        signInButton.setAlignmentX(Component.LEFT_ALIGNMENT);
+        signInButton.addActionListener(event -> loginRequested.run());
+        surface.add(signInButton);
+        surface.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+
+        messageLabel.setName("messageLabel");
+        SwingStyles.applyMuted(messageLabel);
+        messageLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        surface.add(messageLabel);
+
+        add(surface);
+    }
+
+    /**
+     * Registers the action to run when the user requests login.
+     *
+     * <p>The action is invoked synchronously on the Swing Event Dispatch Thread by this panel's action
+     * listeners. Callers that perform authentication or other blocking controller/service work must offload
+     * that work from the EDT and return promptly.
+     */
+    void onLoginRequested(Runnable action) {
+        loginRequested = Objects.requireNonNull(action, "action");
+    }
+
+    @Override
+    public String loginId() {
+        return loginIdField.getText();
+    }
+
+    @Override
+    public String password() {
+        return new String(passwordField.getPassword());
+    }
+
+    @Override
+    public void setLoginEnabled(boolean enabled) {
+        signInButton.setEnabled(enabled);
+    }
+
+    @Override
+    public void showMessage(String message, boolean error) {
+        messageLabel.setText(message);
+        messageLabel.setForeground(error ? SwingStyles.ERROR_TEXT : SwingStyles.MUTED_TEXT);
+    }
+
+    @Override
+    public void clearPassword() {
+        passwordField.setText("");
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
@@ -19,7 +19,7 @@ final class LoginPanel extends JPanel implements LoginView {
     private final JPasswordField passwordField = new JPasswordField();
     private final JButton signInButton = new JButton("Sign in");
     private final JLabel messageLabel = new JLabel(" ");
-    private Runnable loginRequested = () -> {
+    private transient Runnable loginRequested = () -> {
     };
 
     LoginPanel() {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPresenter.java
@@ -1,0 +1,46 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.controller.AuthenticationController;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.service.AuthenticationResult;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.util.Objects;
+
+public final class LoginPresenter {
+
+    private final AuthenticationController authenticationController;
+    private final LoginView view;
+    private final SwingNavigator navigator;
+
+    public LoginPresenter(
+            AuthenticationController authenticationController,
+            LoginView view,
+            SwingNavigator navigator
+    ) {
+        this.authenticationController = Objects.requireNonNull(authenticationController, "authenticationController");
+        this.view = Objects.requireNonNull(view, "view");
+        this.navigator = Objects.requireNonNull(navigator, "navigator");
+    }
+
+    public void loginRequested() {
+        view.setLoginEnabled(false);
+        try {
+            AuthenticationResult result = authenticationController.login(view.loginId(), view.password());
+            if (!result.success()) {
+                view.showMessage(result.message(), true);
+                return;
+            }
+
+            UserResult user = result.user();
+            view.showMessage("", false);
+            view.clearPassword();
+            if (user.role() == Role.ADMIN) {
+                navigator.showAdminDashboard(user);
+            } else {
+                navigator.showProjectList(user);
+            }
+        } finally {
+            view.setLoginEnabled(true);
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginView.java
@@ -1,0 +1,14 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+public interface LoginView {
+
+    String loginId();
+
+    String password();
+
+    void setLoginEnabled(boolean enabled);
+
+    void showMessage(String message, boolean error);
+
+    void clearPassword();
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/PlaceholderPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/PlaceholderPanel.java
@@ -1,0 +1,56 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.util.Objects;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+final class PlaceholderPanel extends JPanel {
+
+    PlaceholderPanel(String destination, UserResult user, Runnable onLogout) {
+        Objects.requireNonNull(destination, "destination");
+        Objects.requireNonNull(user, "user");
+        Objects.requireNonNull(onLogout, "onLogout");
+
+        setLayout(new BorderLayout());
+        setBackground(SwingStyles.BACKGROUND);
+        setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING));
+
+        JPanel surface = new JPanel();
+        surface.setLayout(new BoxLayout(surface, BoxLayout.Y_AXIS));
+        surface.setBackground(SwingStyles.SURFACE);
+        surface.setBorder(SwingStyles.surfaceBorder());
+
+        JLabel title = new JLabel(destination);
+        title.setName("placeholderTitle");
+        title.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applySectionTitle(title);
+        surface.add(title);
+        surface.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+
+        JLabel userLabel = new JLabel(user.name() + " (" + user.role() + ")");
+        userLabel.setName("placeholderUser");
+        userLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyMuted(userLabel);
+        surface.add(userLabel);
+        surface.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
+
+        JButton logoutButton = new JButton("Logout");
+        logoutButton.setName("logoutButton");
+        logoutButton.setAlignmentX(Component.LEFT_ALIGNMENT);
+        logoutButton.addActionListener(event -> onLogout.run());
+        surface.add(logoutButton);
+
+        add(surface, BorderLayout.CENTER);
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingApp.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingApp.java
@@ -2,7 +2,6 @@ package com.github.marcellokim.issuetracker.ui.swing;
 
 import com.github.marcellokim.issuetracker.config.ApplicationContext;
 import java.awt.BorderLayout;
-import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.GridBagLayout;
 import javax.swing.BorderFactory;
@@ -14,8 +13,6 @@ import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.WindowConstants;
 
 public final class SwingApp {
-
-    private static final Dimension MINIMUM_SIZE = new Dimension(800, 600);
 
     private SwingApp() {
     }
@@ -55,7 +52,7 @@ public final class SwingApp {
         JFrame frame = new JFrame("Issue Tracker - Startup Failed");
         frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         frame.setSize(SwingStyles.WINDOW_SIZE);
-        frame.setMinimumSize(MINIMUM_SIZE);
+        frame.setMinimumSize(SwingStyles.MINIMUM_SIZE);
         frame.setLocationRelativeTo(null);
 
         JPanel root = new JPanel(new GridBagLayout());

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingApp.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingApp.java
@@ -1,0 +1,103 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.config.ApplicationContext;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.GridBagLayout;
+import javax.swing.BorderFactory;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.WindowConstants;
+
+public final class SwingApp {
+
+    private static final Dimension MINIMUM_SIZE = new Dimension(800, 600);
+
+    private SwingApp() {
+    }
+
+    public static void main(String[] args) {
+        StartupState startupState = initialize();
+        EventQueue.invokeLater(() -> {
+            setSystemLookAndFeel();
+            if (startupState.failure() == null) {
+                new SwingAppFrame(startupState.context()).setVisible(true);
+            } else {
+                startupFailureFrame(startupState.failure()).setVisible(true);
+            }
+        });
+    }
+
+    private static StartupState initialize() {
+        try {
+            return new StartupState(ApplicationContext.fromEnvironment(), null);
+        } catch (Exception exception) {
+            return new StartupState(null, exception);
+        }
+    }
+
+    private static void setSystemLookAndFeel() {
+        try {
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        } catch (ClassNotFoundException
+                 | InstantiationException
+                 | IllegalAccessException
+                 | UnsupportedLookAndFeelException exception) {
+            // The default cross-platform look and feel is acceptable when the system one is unavailable.
+        }
+    }
+
+    private static JFrame startupFailureFrame(Exception failure) {
+        JFrame frame = new JFrame("Issue Tracker - Startup Failed");
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        frame.setSize(SwingStyles.WINDOW_SIZE);
+        frame.setMinimumSize(MINIMUM_SIZE);
+        frame.setLocationRelativeTo(null);
+
+        JPanel root = new JPanel(new GridBagLayout());
+        root.setBackground(SwingStyles.BACKGROUND);
+        root.setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING));
+
+        JPanel surface = new JPanel(new BorderLayout());
+        surface.setBackground(SwingStyles.SURFACE);
+        surface.setBorder(SwingStyles.surfaceBorder());
+
+        JLabel message = new JLabel(startupFailureHtml(failure));
+        message.setForeground(SwingStyles.BODY_TEXT);
+        surface.add(message, BorderLayout.CENTER);
+        root.add(surface);
+
+        frame.setContentPane(root);
+        return frame;
+    }
+
+    private static String startupFailureHtml(Exception failure) {
+        String detail = failure.getMessage();
+        if (detail == null || detail.isBlank()) {
+            detail = "No additional error details were provided.";
+        }
+        return "<html><body style='width: 520px;'>"
+                + "<h2>Issue Tracker could not start</h2>"
+                + "<p>Check the database configuration and try again.</p>"
+                + "<p><b>Reason:</b> " + escapeHtml(detail) + "</p>"
+                + "</body></html>";
+    }
+
+    private static String escapeHtml(String value) {
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;");
+    }
+
+    private record StartupState(ApplicationContext context, Exception failure) {
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingApp.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingApp.java
@@ -18,6 +18,10 @@ public final class SwingApp {
     }
 
     public static void main(String[] args) {
+        launch();
+    }
+
+    public static void launch() {
         StartupState startupState = initialize();
         EventQueue.invokeLater(() -> {
             setSystemLookAndFeel();

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
@@ -2,12 +2,11 @@ package com.github.marcellokim.issuetracker.ui.swing;
 
 import com.github.marcellokim.issuetracker.config.ApplicationContext;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
-import com.github.marcellokim.issuetracker.service.UserResult;
 import java.util.Objects;
 import javax.swing.JFrame;
 import javax.swing.WindowConstants;
 
-public final class SwingAppFrame extends JFrame implements SwingNavigator {
+public final class SwingAppFrame extends JFrame {
 
     private static final long serialVersionUID = 1L;
 
@@ -27,22 +26,4 @@ public final class SwingAppFrame extends JFrame implements SwingNavigator {
         setLocationRelativeTo(null);
     }
 
-    @Override
-    public void showLogin() {
-        appPanel.showLogin();
-    }
-
-    @Override
-    public void showAdminDashboard(UserResult user) {
-        appPanel.showAdminDashboard(user);
-    }
-
-    @Override
-    public void showProjectList(UserResult user) {
-        appPanel.showProjectList(user);
-    }
-
-    void logout() {
-        appPanel.logout();
-    }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
@@ -1,0 +1,211 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.config.ApplicationContext;
+import com.github.marcellokim.issuetracker.controller.AuthenticationController;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.BorderLayout;
+import java.awt.CardLayout;
+import java.awt.Dimension;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.SwingWorker;
+import javax.swing.WindowConstants;
+
+public final class SwingAppFrame extends JFrame implements SwingNavigator {
+
+    private static final long serialVersionUID = 1L;
+    private static final Dimension MINIMUM_SIZE = new Dimension(800, 600);
+    private static final String LOGIN_CARD = "login";
+    private static final String ADMIN_DASHBOARD_CARD = "adminDashboard";
+    private static final String PROJECT_LIST_CARD = "projectList";
+
+    private final AuthenticationController authenticationController;
+    private final CardLayout cardLayout = new CardLayout();
+    private final JPanel cards = new JPanel(cardLayout);
+    private final LoginPanel loginPanel = new LoginPanel();
+    private final JPanel adminDashboardCard = new JPanel(new BorderLayout());
+    private final JPanel projectListCard = new JPanel(new BorderLayout());
+    private SwingWorker<Void, Void> loginWorker;
+
+    public SwingAppFrame(ApplicationContext context) {
+        this(Objects.requireNonNull(context, "context").authenticationController());
+    }
+
+    SwingAppFrame(AuthenticationController authenticationController) {
+        super("Issue Tracker");
+        this.authenticationController = Objects.requireNonNull(
+                authenticationController,
+                "authenticationController");
+
+        LoginPresenter presenter = new LoginPresenter(
+                this.authenticationController,
+                new EdtLoginView(loginPanel),
+                this);
+        loginPanel.onLoginRequested(() -> submitLogin(presenter));
+
+        cards.setName("appCards");
+        adminDashboardCard.setName("adminDashboardCard");
+        projectListCard.setName("projectListCard");
+        cards.add(loginPanel, LOGIN_CARD);
+        cards.add(adminDashboardCard, ADMIN_DASHBOARD_CARD);
+        cards.add(projectListCard, PROJECT_LIST_CARD);
+
+        setContentPane(cards);
+        setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        setSize(SwingStyles.WINDOW_SIZE);
+        setMinimumSize(MINIMUM_SIZE);
+        setLocationRelativeTo(null);
+        showLogin();
+    }
+
+    @Override
+    public void showLogin() {
+        runOnEdtAndWait(() -> {
+            setTitle("Issue Tracker");
+            loginPanel.showMessage(" ", false);
+            loginPanel.clearPassword();
+            loginPanel.setLoginEnabled(true);
+            cardLayout.show(cards, LOGIN_CARD);
+        });
+    }
+
+    @Override
+    public void showAdminDashboard(UserResult user) {
+        Objects.requireNonNull(user, "user");
+        runOnEdtAndWait(() -> {
+            setTitle("Admin dashboard");
+            showPlaceholder(adminDashboardCard, "Admin dashboard", user);
+            cardLayout.show(cards, ADMIN_DASHBOARD_CARD);
+        });
+    }
+
+    @Override
+    public void showProjectList(UserResult user) {
+        Objects.requireNonNull(user, "user");
+        runOnEdtAndWait(() -> {
+            setTitle("Project list");
+            showPlaceholder(projectListCard, "Project list", user);
+            cardLayout.show(cards, PROJECT_LIST_CARD);
+        });
+    }
+
+    void logout() {
+        authenticationController.logout();
+        showLogin();
+    }
+
+    private void submitLogin(LoginPresenter presenter) {
+        if (loginWorker != null && !loginWorker.isDone()) {
+            return;
+        }
+
+        loginWorker = new SwingWorker<>() {
+            @Override
+            protected Void doInBackground() {
+                presenter.loginRequested();
+                return null;
+            }
+
+            @Override
+            protected void done() {
+                try {
+                    get();
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                    showLoginFailure("Login was interrupted. Please try again.");
+                } catch (ExecutionException exception) {
+                    showLoginFailure("Login failed. Please try again.");
+                }
+            }
+        };
+        loginWorker.execute();
+    }
+
+    private void showPlaceholder(JPanel card, String destination, UserResult user) {
+        card.removeAll();
+        card.add(new PlaceholderPanel(destination, user, this::logout), BorderLayout.CENTER);
+        card.revalidate();
+        card.repaint();
+    }
+
+    private void showLoginFailure(String message) {
+        runOnEdtAndWait(() -> {
+            loginPanel.showMessage(message, true);
+            loginPanel.clearPassword();
+            loginPanel.setLoginEnabled(true);
+        });
+    }
+
+    private static void runOnEdtAndWait(Runnable action) {
+        Objects.requireNonNull(action, "action");
+        if (SwingUtilities.isEventDispatchThread()) {
+            action.run();
+            return;
+        }
+
+        try {
+            SwingUtilities.invokeAndWait(action);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while updating Swing UI.", exception);
+        } catch (InvocationTargetException exception) {
+            rethrow(exception.getCause());
+        }
+    }
+
+    private static <T> T callOnEdtAndWait(Supplier<T> action) {
+        AtomicReference<T> result = new AtomicReference<>();
+        runOnEdtAndWait(() -> result.set(action.get()));
+        return result.get();
+    }
+
+    private static void rethrow(Throwable cause) {
+        if (cause instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (cause instanceof Error error) {
+            throw error;
+        }
+        throw new IllegalStateException("Swing UI update failed.", cause);
+    }
+
+    private static final class EdtLoginView implements LoginView {
+
+        private final LoginView delegate;
+
+        private EdtLoginView(LoginView delegate) {
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
+        }
+
+        @Override
+        public String loginId() {
+            return callOnEdtAndWait(delegate::loginId);
+        }
+
+        @Override
+        public String password() {
+            return callOnEdtAndWait(delegate::password);
+        }
+
+        @Override
+        public void setLoginEnabled(boolean enabled) {
+            runOnEdtAndWait(() -> delegate.setLoginEnabled(enabled));
+        }
+
+        @Override
+        public void showMessage(String message, boolean error) {
+            runOnEdtAndWait(() -> delegate.showMessage(message, error));
+        }
+
+        @Override
+        public void clearPassword() {
+            runOnEdtAndWait(delegate::clearPassword);
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
@@ -3,35 +3,15 @@ package com.github.marcellokim.issuetracker.ui.swing;
 import com.github.marcellokim.issuetracker.config.ApplicationContext;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.service.UserResult;
-import java.awt.BorderLayout;
-import java.awt.CardLayout;
-import java.awt.Dimension;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Objects;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 import javax.swing.JFrame;
-import javax.swing.JPanel;
-import javax.swing.SwingUtilities;
-import javax.swing.SwingWorker;
 import javax.swing.WindowConstants;
 
 public final class SwingAppFrame extends JFrame implements SwingNavigator {
 
     private static final long serialVersionUID = 1L;
-    private static final Dimension MINIMUM_SIZE = new Dimension(800, 600);
-    private static final String LOGIN_CARD = "login";
-    private static final String ADMIN_DASHBOARD_CARD = "adminDashboard";
-    private static final String PROJECT_LIST_CARD = "projectList";
 
-    private final AuthenticationController authenticationController;
-    private final CardLayout cardLayout = new CardLayout();
-    private final JPanel cards = new JPanel(cardLayout);
-    private final LoginPanel loginPanel = new LoginPanel();
-    private final JPanel adminDashboardCard = new JPanel(new BorderLayout());
-    private final JPanel projectListCard = new JPanel(new BorderLayout());
-    private SwingWorker<Void, Void> loginWorker;
+    private final SwingAppPanel appPanel;
 
     public SwingAppFrame(ApplicationContext context) {
         this(Objects.requireNonNull(context, "context").authenticationController());
@@ -39,173 +19,30 @@ public final class SwingAppFrame extends JFrame implements SwingNavigator {
 
     SwingAppFrame(AuthenticationController authenticationController) {
         super("Issue Tracker");
-        this.authenticationController = Objects.requireNonNull(
-                authenticationController,
-                "authenticationController");
-
-        LoginPresenter presenter = new LoginPresenter(
-                this.authenticationController,
-                new EdtLoginView(loginPanel),
-                this);
-        loginPanel.onLoginRequested(() -> submitLogin(presenter));
-
-        cards.setName("appCards");
-        adminDashboardCard.setName("adminDashboardCard");
-        projectListCard.setName("projectListCard");
-        cards.add(loginPanel, LOGIN_CARD);
-        cards.add(adminDashboardCard, ADMIN_DASHBOARD_CARD);
-        cards.add(projectListCard, PROJECT_LIST_CARD);
-
-        setContentPane(cards);
+        this.appPanel = new SwingAppPanel(authenticationController, this::setTitle);
+        setContentPane(appPanel);
         setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         setSize(SwingStyles.WINDOW_SIZE);
-        setMinimumSize(MINIMUM_SIZE);
+        setMinimumSize(SwingStyles.MINIMUM_SIZE);
         setLocationRelativeTo(null);
-        showLogin();
     }
 
     @Override
     public void showLogin() {
-        runOnEdtAndWait(() -> {
-            setTitle("Issue Tracker");
-            loginPanel.showMessage(" ", false);
-            loginPanel.clearPassword();
-            loginPanel.setLoginEnabled(true);
-            cardLayout.show(cards, LOGIN_CARD);
-        });
+        appPanel.showLogin();
     }
 
     @Override
     public void showAdminDashboard(UserResult user) {
-        Objects.requireNonNull(user, "user");
-        runOnEdtAndWait(() -> {
-            setTitle("Admin dashboard");
-            showPlaceholder(adminDashboardCard, "Admin dashboard", user);
-            cardLayout.show(cards, ADMIN_DASHBOARD_CARD);
-        });
+        appPanel.showAdminDashboard(user);
     }
 
     @Override
     public void showProjectList(UserResult user) {
-        Objects.requireNonNull(user, "user");
-        runOnEdtAndWait(() -> {
-            setTitle("Project list");
-            showPlaceholder(projectListCard, "Project list", user);
-            cardLayout.show(cards, PROJECT_LIST_CARD);
-        });
+        appPanel.showProjectList(user);
     }
 
     void logout() {
-        authenticationController.logout();
-        showLogin();
-    }
-
-    private void submitLogin(LoginPresenter presenter) {
-        if (loginWorker != null && !loginWorker.isDone()) {
-            return;
-        }
-
-        loginWorker = new SwingWorker<>() {
-            @Override
-            protected Void doInBackground() {
-                presenter.loginRequested();
-                return null;
-            }
-
-            @Override
-            protected void done() {
-                try {
-                    get();
-                } catch (InterruptedException exception) {
-                    Thread.currentThread().interrupt();
-                    showLoginFailure("Login was interrupted. Please try again.");
-                } catch (ExecutionException exception) {
-                    showLoginFailure("Login failed. Please try again.");
-                }
-            }
-        };
-        loginWorker.execute();
-    }
-
-    private void showPlaceholder(JPanel card, String destination, UserResult user) {
-        card.removeAll();
-        card.add(new PlaceholderPanel(destination, user, this::logout), BorderLayout.CENTER);
-        card.revalidate();
-        card.repaint();
-    }
-
-    private void showLoginFailure(String message) {
-        runOnEdtAndWait(() -> {
-            loginPanel.showMessage(message, true);
-            loginPanel.clearPassword();
-            loginPanel.setLoginEnabled(true);
-        });
-    }
-
-    private static void runOnEdtAndWait(Runnable action) {
-        Objects.requireNonNull(action, "action");
-        if (SwingUtilities.isEventDispatchThread()) {
-            action.run();
-            return;
-        }
-
-        try {
-            SwingUtilities.invokeAndWait(action);
-        } catch (InterruptedException exception) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted while updating Swing UI.", exception);
-        } catch (InvocationTargetException exception) {
-            rethrow(exception.getCause());
-        }
-    }
-
-    private static <T> T callOnEdtAndWait(Supplier<T> action) {
-        AtomicReference<T> result = new AtomicReference<>();
-        runOnEdtAndWait(() -> result.set(action.get()));
-        return result.get();
-    }
-
-    private static void rethrow(Throwable cause) {
-        if (cause instanceof RuntimeException runtimeException) {
-            throw runtimeException;
-        }
-        if (cause instanceof Error error) {
-            throw error;
-        }
-        throw new IllegalStateException("Swing UI update failed.", cause);
-    }
-
-    private static final class EdtLoginView implements LoginView {
-
-        private final LoginView delegate;
-
-        private EdtLoginView(LoginView delegate) {
-            this.delegate = Objects.requireNonNull(delegate, "delegate");
-        }
-
-        @Override
-        public String loginId() {
-            return callOnEdtAndWait(delegate::loginId);
-        }
-
-        @Override
-        public String password() {
-            return callOnEdtAndWait(delegate::password);
-        }
-
-        @Override
-        public void setLoginEnabled(boolean enabled) {
-            runOnEdtAndWait(() -> delegate.setLoginEnabled(enabled));
-        }
-
-        @Override
-        public void showMessage(String message, boolean error) {
-            runOnEdtAndWait(() -> delegate.showMessage(message, error));
-        }
-
-        @Override
-        public void clearPassword() {
-            runOnEdtAndWait(delegate::clearPassword);
-        }
+        appPanel.logout();
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -21,13 +21,13 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private static final String ADMIN_DASHBOARD_CARD = "adminDashboard";
     private static final String PROJECT_LIST_CARD = "projectList";
 
-    private final AuthenticationController authenticationController;
-    private final Consumer<String> titleUpdater;
+    private final transient AuthenticationController authenticationController;
+    private final transient Consumer<String> titleUpdater;
     private final CardLayout cardLayout = new CardLayout();
     private final LoginPanel loginPanel = new LoginPanel();
     private final JPanel adminDashboardCard = new JPanel(new BorderLayout());
     private final JPanel projectListCard = new JPanel(new BorderLayout());
-    private SwingWorker<Void, Void> loginWorker;
+    private transient SwingWorker<Void, Void> loginWorker;
 
     SwingAppPanel(AuthenticationController authenticationController, Consumer<String> titleUpdater) {
         this.authenticationController = Objects.requireNonNull(authenticationController, "authenticationController");

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -1,0 +1,205 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.controller.AuthenticationController;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.BorderLayout;
+import java.awt.CardLayout;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.SwingWorker;
+
+final class SwingAppPanel extends JPanel implements SwingNavigator {
+
+    private static final long serialVersionUID = 1L;
+    private static final String LOGIN_CARD = "login";
+    private static final String ADMIN_DASHBOARD_CARD = "adminDashboard";
+    private static final String PROJECT_LIST_CARD = "projectList";
+
+    private final AuthenticationController authenticationController;
+    private final Consumer<String> titleUpdater;
+    private final CardLayout cardLayout = new CardLayout();
+    private final LoginPanel loginPanel = new LoginPanel();
+    private final JPanel adminDashboardCard = new JPanel(new BorderLayout());
+    private final JPanel projectListCard = new JPanel(new BorderLayout());
+    private SwingWorker<Void, Void> loginWorker;
+
+    SwingAppPanel(AuthenticationController authenticationController, Consumer<String> titleUpdater) {
+        this.authenticationController = Objects.requireNonNull(authenticationController, "authenticationController");
+        this.titleUpdater = Objects.requireNonNull(titleUpdater, "titleUpdater");
+
+        setName("appCards");
+        setLayout(cardLayout);
+        adminDashboardCard.setName("adminDashboardCard");
+        projectListCard.setName("projectListCard");
+        loginPanel.onLoginRequested(this::submitLogin);
+
+        add(loginPanel, LOGIN_CARD);
+        add(adminDashboardCard, ADMIN_DASHBOARD_CARD);
+        add(projectListCard, PROJECT_LIST_CARD);
+        showLogin();
+    }
+
+    @Override
+    public void showLogin() {
+        runOnEdtAndWait(() -> {
+            titleUpdater.accept("Issue Tracker");
+            loginPanel.showMessage(" ", false);
+            loginPanel.clearPassword();
+            loginPanel.setLoginEnabled(true);
+            cardLayout.show(this, LOGIN_CARD);
+        });
+    }
+
+    @Override
+    public void showAdminDashboard(UserResult user) {
+        Objects.requireNonNull(user, "user");
+        runOnEdtAndWait(() -> {
+            titleUpdater.accept("Admin dashboard");
+            showPlaceholder(adminDashboardCard, "Admin dashboard", user);
+            cardLayout.show(this, ADMIN_DASHBOARD_CARD);
+        });
+    }
+
+    @Override
+    public void showProjectList(UserResult user) {
+        Objects.requireNonNull(user, "user");
+        runOnEdtAndWait(() -> {
+            titleUpdater.accept("Project list");
+            showPlaceholder(projectListCard, "Project list", user);
+            cardLayout.show(this, PROJECT_LIST_CARD);
+        });
+    }
+
+    void logout() {
+        authenticationController.logout();
+        showLogin();
+    }
+
+    private void submitLogin() {
+        if (loginWorker != null && !loginWorker.isDone()) {
+            return;
+        }
+
+        LoginView capturedView = captureLoginRequest();
+        LoginPresenter presenter = new LoginPresenter(authenticationController, capturedView, this);
+        loginWorker = new SwingWorker<>() {
+            @Override
+            protected Void doInBackground() {
+                presenter.loginRequested();
+                return null;
+            }
+
+            @Override
+            protected void done() {
+                try {
+                    get();
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                    showLoginFailure("Login was interrupted. Please try again.");
+                } catch (ExecutionException exception) {
+                    showLoginFailure("Login failed. Please try again.");
+                }
+            }
+        };
+        loginWorker.execute();
+    }
+
+    private LoginView captureLoginRequest() {
+        return callOnEdtAndWait(() -> {
+            loginPanel.setLoginEnabled(false);
+            return new CapturedLoginView(loginPanel.loginId(), loginPanel.password(), loginPanel);
+        });
+    }
+
+    private void showPlaceholder(JPanel card, String destination, UserResult user) {
+        card.removeAll();
+        card.add(new PlaceholderPanel(destination, user, this::logout), BorderLayout.CENTER);
+        card.revalidate();
+        card.repaint();
+    }
+
+    private void showLoginFailure(String message) {
+        runOnEdtAndWait(() -> {
+            loginPanel.showMessage(message, true);
+            loginPanel.clearPassword();
+            loginPanel.setLoginEnabled(true);
+        });
+    }
+
+    private static void runOnEdtAndWait(Runnable action) {
+        Objects.requireNonNull(action, "action");
+        if (SwingUtilities.isEventDispatchThread()) {
+            action.run();
+            return;
+        }
+
+        try {
+            SwingUtilities.invokeAndWait(action);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while updating Swing UI.", exception);
+        } catch (InvocationTargetException exception) {
+            rethrow(exception.getCause());
+        }
+    }
+
+    private static <T> T callOnEdtAndWait(Supplier<T> action) {
+        AtomicReference<T> result = new AtomicReference<>();
+        runOnEdtAndWait(() -> result.set(action.get()));
+        return result.get();
+    }
+
+    private static void rethrow(Throwable cause) {
+        if (cause instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (cause instanceof Error error) {
+            throw error;
+        }
+        throw new IllegalStateException("Swing UI update failed.", cause);
+    }
+
+    private static final class CapturedLoginView implements LoginView {
+
+        private final String loginId;
+        private final String password;
+        private final LoginView delegate;
+
+        private CapturedLoginView(String loginId, String password, LoginView delegate) {
+            this.loginId = loginId;
+            this.password = password;
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
+        }
+
+        @Override
+        public String loginId() {
+            return loginId;
+        }
+
+        @Override
+        public String password() {
+            return password;
+        }
+
+        @Override
+        public void setLoginEnabled(boolean enabled) {
+            runOnEdtAndWait(() -> delegate.setLoginEnabled(enabled));
+        }
+
+        @Override
+        public void showMessage(String message, boolean error) {
+            runOnEdtAndWait(() -> delegate.showMessage(message, error));
+        }
+
+        @Override
+        public void clearPassword() {
+            runOnEdtAndWait(delegate::clearPassword);
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -104,6 +104,8 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
                     showLoginFailure("Login was interrupted. Please try again.");
                 } catch (ExecutionException exception) {
                     showLoginFailure("Login failed. Please try again.");
+                } finally {
+                    loginWorker = null;
                 }
             }
         };

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -45,7 +45,6 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         showLogin();
     }
 
-    @Override
     public void showLogin() {
         runOnEdtAndWait(() -> {
             titleUpdater.accept("Issue Tracker");
@@ -88,7 +87,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
         LoginView capturedView = captureLoginRequest();
         LoginPresenter presenter = new LoginPresenter(authenticationController, capturedView, this);
-        loginWorker = new SwingWorker<>() {
+        SwingWorker<Void, Void> worker = new SwingWorker<>() {
             @Override
             protected Void doInBackground() {
                 presenter.loginRequested();
@@ -105,11 +104,18 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
                 } catch (ExecutionException exception) {
                     showLoginFailure("Login failed. Please try again.");
                 } finally {
-                    loginWorker = null;
+                    clearCompletedLoginWorker(this);
                 }
             }
         };
-        loginWorker.execute();
+        loginWorker = worker;
+        worker.execute();
+    }
+
+    private void clearCompletedLoginWorker(SwingWorker<?, ?> worker) {
+        if (loginWorker == worker) {
+            loginWorker = null;
+        }
     }
 
     private LoginView captureLoginRequest() {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingNavigator.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingNavigator.java
@@ -4,8 +4,6 @@ import com.github.marcellokim.issuetracker.service.UserResult;
 
 public interface SwingNavigator {
 
-    void showLogin();
-
     void showAdminDashboard(UserResult user);
 
     void showProjectList(UserResult user);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingNavigator.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingNavigator.java
@@ -1,0 +1,12 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.UserResult;
+
+public interface SwingNavigator {
+
+    void showLogin();
+
+    void showAdminDashboard(UserResult user);
+
+    void showProjectList(UserResult user);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingStyles.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingStyles.java
@@ -1,0 +1,69 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.border.Border;
+
+final class SwingStyles {
+
+    static final Dimension WINDOW_SIZE = new Dimension(1024, 768);
+    static final int OUTER_PADDING = 32;
+    static final int LOGIN_PANEL_WIDTH = 360;
+    static final int FIELD_HEIGHT = 34;
+    static final int BUTTON_HEIGHT = 36;
+    static final int ROW_GAP = 8;
+    static final int SECTION_GAP = 16;
+    static final Color BACKGROUND = new Color(245, 247, 250);
+    static final Color SURFACE = Color.WHITE;
+    static final Color BORDER = new Color(218, 224, 231);
+    static final Color PRIMARY = new Color(32, 96, 160);
+    static final Color PRIMARY_TEXT = Color.WHITE;
+    static final Color BODY_TEXT = new Color(36, 43, 51);
+    static final Color MUTED_TEXT = new Color(95, 106, 120);
+    static final Color ERROR_TEXT = new Color(154, 35, 45);
+
+    private SwingStyles() {
+    }
+
+    static Border surfaceBorder() {
+        return BorderFactory.createCompoundBorder(
+                BorderFactory.createLineBorder(BORDER),
+                BorderFactory.createEmptyBorder(24, 24, 24, 24));
+    }
+
+    static void applyTitle(JLabel label) {
+        label.setForeground(BODY_TEXT);
+        label.setFont(label.getFont().deriveFont(Font.BOLD, 22f));
+    }
+
+    static void applySectionTitle(JLabel label) {
+        label.setForeground(BODY_TEXT);
+        label.setFont(label.getFont().deriveFont(Font.BOLD, 18f));
+    }
+
+    static void applyMuted(JLabel label) {
+        label.setForeground(MUTED_TEXT);
+    }
+
+    static void applyPrimaryButton(JButton button) {
+        button.setBackground(PRIMARY);
+        button.setForeground(PRIMARY_TEXT);
+        button.setFocusPainted(false);
+        button.setPreferredSize(new Dimension(LOGIN_PANEL_WIDTH, BUTTON_HEIGHT));
+    }
+
+    static void fixHeight(JComponent component, int height) {
+        Dimension preferred = component.getPreferredSize();
+        Dimension size = new Dimension(LOGIN_PANEL_WIDTH, height);
+        if (preferred.width > LOGIN_PANEL_WIDTH) {
+            size.width = preferred.width;
+        }
+        component.setPreferredSize(size);
+        component.setMinimumSize(size);
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingStyles.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingStyles.java
@@ -24,6 +24,7 @@ final class SwingStyles {
     static final Color BORDER = new Color(218, 224, 231);
     static final Color PRIMARY = new Color(32, 96, 160);
     static final Color PRIMARY_TEXT = Color.WHITE;
+    static final Color DISABLED_BUTTON_BACKGROUND = new Color(229, 234, 240);
     static final Color BODY_TEXT = new Color(36, 43, 51);
     static final Color MUTED_TEXT = new Color(95, 106, 120);
     static final Color ERROR_TEXT = new Color(154, 35, 45);
@@ -56,6 +57,10 @@ final class SwingStyles {
         button.setForeground(PRIMARY_TEXT);
         button.setFocusPainted(false);
         button.setPreferredSize(new Dimension(LOGIN_PANEL_WIDTH, BUTTON_HEIGHT));
+    }
+
+    static void applyPrimaryButtonState(JButton button, boolean enabled) {
+        button.setBackground(enabled ? PRIMARY : DISABLED_BUTTON_BACKGROUND);
     }
 
     static void fixHeight(JComponent component, int height) {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingStyles.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingStyles.java
@@ -12,6 +12,7 @@ import javax.swing.border.Border;
 final class SwingStyles {
 
     static final Dimension WINDOW_SIZE = new Dimension(1024, 768);
+    static final Dimension MINIMUM_SIZE = new Dimension(800, 600);
     static final int OUTER_PADDING = 32;
     static final int LOGIN_PANEL_WIDTH = 360;
     static final int FIELD_HEIGHT = 34;

--- a/src/test/java/com/github/marcellokim/issuetracker/MainSmokeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/MainSmokeTest.java
@@ -1,6 +1,8 @@
 package com.github.marcellokim.issuetracker;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,5 +20,21 @@ class MainSmokeTest {
     @DisplayName("Swing app class loads without error")
     void swingAppClassLoadsWithoutError() {
         assertDoesNotThrow(() -> Class.forName("com.github.marcellokim.issuetracker.ui.swing.SwingApp"));
+    }
+
+    @Test
+    @DisplayName("Swing 실행 옵션을 인식한다")
+    void recognizesSwingLaunchOption() {
+        assertTrue(Main.shouldLaunchSwing(new String[]{"--swing"}));
+        assertFalse(Main.shouldLaunchSwing(new String[0]));
+        assertFalse(Main.shouldLaunchSwing(new String[]{"--javafx"}));
+    }
+
+    @Test
+    @DisplayName("Swing app exposes reusable launch entry point")
+    void swingAppExposesLaunchEntryPoint() {
+        assertDoesNotThrow(() -> Class
+                .forName("com.github.marcellokim.issuetracker.ui.swing.SwingApp")
+                .getDeclaredMethod("launch"));
     }
 }

--- a/src/test/java/com/github/marcellokim/issuetracker/MainSmokeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/MainSmokeTest.java
@@ -13,4 +13,10 @@ class MainSmokeTest {
     void mainClassLoadsWithoutError() {
         assertDoesNotThrow(() -> Class.forName("com.github.marcellokim.issuetracker.Main"));
     }
+
+    @Test
+    @DisplayName("Swing app class loads without error")
+    void swingAppClassLoadsWithoutError() {
+        assertDoesNotThrow(() -> Class.forName("com.github.marcellokim.issuetracker.ui.swing.SwingApp"));
+    }
 }

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
@@ -136,6 +136,7 @@ class RepositoryConventionsSmokeTest {
                 new ScriptExpectation("build.gradle", "version = '21.0.6'"),
                 new ScriptExpectation("build.gradle", "modules = ['javafx.controls', 'javafx.fxml', 'javafx.graphics']"),
                 new ScriptExpectation("build.gradle", "mainClass = 'com.github.marcellokim.issuetracker.Main'"),
+                new ScriptExpectation("build.gradle", "args '--swing'"),
                 new ScriptExpectation("build.gradle", "providers.gradleProperty('pythonExecutable')"),
                 new ScriptExpectation("build.gradle", "? 'python' : 'python3'"),
                 new ScriptExpectation("build.gradle", "commandLine pythonExecutable.get(), 'scripts/lib/project_maintenance.py'"),

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanelTest.java
@@ -1,0 +1,65 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPasswordField;
+import javax.swing.SwingUtilities;
+import javax.swing.JTextField;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing login panel")
+class LoginPanelTest {
+
+    @Test
+    @DisplayName("exposes entered credentials and invokes login action")
+    void exposesEnteredCredentialsAndInvokesLoginAction() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            var panel = new LoginPanel();
+            JTextField loginId = SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class);
+            JPasswordField password = SwingComponentTestSupport.find(panel, "passwordField", JPasswordField.class);
+            JButton signIn = SwingComponentTestSupport.find(panel, "signInButton", JButton.class);
+            AtomicBoolean invoked = new AtomicBoolean();
+            AtomicBoolean invokedOnEdt = new AtomicBoolean();
+
+            panel.onLoginRequested(() -> {
+                invoked.set(true);
+                invokedOnEdt.set(SwingUtilities.isEventDispatchThread());
+            });
+            loginId.setText("admin");
+            password.setText("secret");
+            signIn.doClick();
+
+            assertTrue(invoked.get());
+            assertTrue(invokedOnEdt.get());
+            assertEquals("admin", panel.loginId());
+            assertEquals("secret", panel.password());
+        });
+    }
+
+    @Test
+    @DisplayName("updates button and message state through LoginView methods")
+    void updatesButtonAndMessageStateThroughViewMethods() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            var panel = new LoginPanel();
+            JButton signIn = SwingComponentTestSupport.find(panel, "signInButton", JButton.class);
+            JLabel message = SwingComponentTestSupport.find(panel, "messageLabel", JLabel.class);
+            JPasswordField password = SwingComponentTestSupport.find(panel, "passwordField", JPasswordField.class);
+
+            panel.setLoginEnabled(false);
+            panel.showMessage("Invalid ID or password.", true);
+            password.setText("secret");
+            panel.clearPassword();
+
+            assertFalse(signIn.isEnabled());
+            assertEquals("Invalid ID or password.", message.getText());
+            assertEquals(SwingStyles.ERROR_TEXT, message.getForeground());
+            assertEquals("", panel.password());
+        });
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanelTest.java
@@ -49,7 +49,10 @@ class LoginPanelTest {
             var panel = new LoginPanel();
             JButton signIn = SwingComponentTestSupport.find(panel, "signInButton", JButton.class);
             JLabel message = SwingComponentTestSupport.find(panel, "messageLabel", JLabel.class);
+            JTextField loginId = SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class);
             JPasswordField password = SwingComponentTestSupport.find(panel, "passwordField", JPasswordField.class);
+            JLabel loginIdLabel = SwingComponentTestSupport.find(panel, "loginIdLabel", JLabel.class);
+            JLabel passwordLabel = SwingComponentTestSupport.find(panel, "passwordLabel", JLabel.class);
 
             panel.setLoginEnabled(false);
             panel.showMessage("Invalid ID or password.", true);
@@ -57,6 +60,10 @@ class LoginPanelTest {
             panel.clearPassword();
 
             assertFalse(signIn.isEnabled());
+            assertFalse(loginId.isEnabled());
+            assertFalse(password.isEnabled());
+            assertEquals(loginId, loginIdLabel.getLabelFor());
+            assertEquals(password, passwordLabel.getLabelFor());
             assertEquals("Invalid ID or password.", message.getText());
             assertEquals(SwingStyles.ERROR_TEXT, message.getForeground());
             assertEquals("", panel.password());

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanelTest.java
@@ -62,6 +62,7 @@ class LoginPanelTest {
             assertFalse(signIn.isEnabled());
             assertFalse(loginId.isEnabled());
             assertFalse(password.isEnabled());
+            assertEquals(SwingStyles.DISABLED_BUTTON_BACKGROUND, signIn.getBackground());
             assertEquals(loginId, loginIdLabel.getLabelFor());
             assertEquals(password, passwordLabel.getLabelFor());
             assertEquals("Invalid ID or password.", message.getText());

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/LoginPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/LoginPresenterTest.java
@@ -2,7 +2,7 @@ package com.github.marcellokim.issuetracker.ui.swing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
@@ -34,7 +34,7 @@ class LoginPresenterTest {
         presenter.loginRequested();
 
         assertEquals("admin", navigator.adminUser.loginId());
-        assertSame(null, navigator.projectUser);
+        assertNull(navigator.projectUser);
         assertEquals("", view.message);
         assertFalse(view.error);
         assertTrue(view.passwordCleared);
@@ -51,7 +51,7 @@ class LoginPresenterTest {
 
             presenter.loginRequested();
 
-            assertSame(null, navigator.adminUser);
+            assertNull(navigator.adminUser);
             assertEquals(role, navigator.projectUser.role());
             assertEquals("", view.message);
             assertFalse(view.error);
@@ -71,8 +71,8 @@ class LoginPresenterTest {
 
         assertEquals("Invalid ID or password.", view.message);
         assertTrue(view.error);
-        assertSame(null, navigator.adminUser);
-        assertSame(null, navigator.projectUser);
+        assertNull(navigator.adminUser);
+        assertNull(navigator.projectUser);
         assertFalse(view.passwordCleared);
         assertTrue(view.enabled);
     }
@@ -153,11 +153,6 @@ class LoginPresenterTest {
 
         private UserResult adminUser;
         private UserResult projectUser;
-
-        @Override
-        public void showLogin() {
-            throw new AssertionError("LoginPresenter should not navigate back to login in these tests.");
-        }
 
         @Override
         public void showAdminDashboard(UserResult user) {

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/LoginPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/LoginPresenterTest.java
@@ -1,0 +1,171 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.controller.AuthenticationController;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.technical.PasswordHasher;
+import com.github.marcellokim.issuetracker.technical.SessionStore;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing login presenter")
+class LoginPresenterTest {
+
+    private static final String PASSWORD = "DemoLocalAdmin!";
+    private static final PasswordHasher PASSWORD_HASHER = new PasswordHasher();
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("routes admin login to admin dashboard")
+    void routesAdminLoginToAdminDashboard() {
+        var view = new FakeLoginView("admin", PASSWORD);
+        var navigator = new RecordingNavigator();
+        var presenter = new LoginPresenter(controller(user("admin", Role.ADMIN)), view, navigator);
+
+        presenter.loginRequested();
+
+        assertEquals("admin", navigator.adminUser.loginId());
+        assertSame(null, navigator.projectUser);
+        assertEquals("", view.message);
+        assertFalse(view.error);
+        assertTrue(view.passwordCleared);
+        assertTrue(view.enabled);
+    }
+
+    @Test
+    @DisplayName("routes project users to project list")
+    void routesProjectUsersToProjectList() {
+        for (Role role : new Role[] {Role.PL, Role.DEV, Role.TESTER}) {
+            var view = new FakeLoginView(role.name().toLowerCase(), PASSWORD);
+            var navigator = new RecordingNavigator();
+            var presenter = new LoginPresenter(controller(user(role.name().toLowerCase(), role)), view, navigator);
+
+            presenter.loginRequested();
+
+            assertSame(null, navigator.adminUser);
+            assertEquals(role, navigator.projectUser.role());
+            assertEquals("", view.message);
+            assertFalse(view.error);
+            assertTrue(view.passwordCleared);
+            assertTrue(view.enabled);
+        }
+    }
+
+    @Test
+    @DisplayName("shows returned failure message and stays on login screen")
+    void showsFailureMessageAndStaysOnLoginScreen() {
+        var view = new FakeLoginView("admin", "wrong-password");
+        var navigator = new RecordingNavigator();
+        var presenter = new LoginPresenter(controller(user("admin", Role.ADMIN)), view, navigator);
+
+        presenter.loginRequested();
+
+        assertEquals("Invalid ID or password.", view.message);
+        assertTrue(view.error);
+        assertSame(null, navigator.adminUser);
+        assertSame(null, navigator.projectUser);
+        assertFalse(view.passwordCleared);
+        assertTrue(view.enabled);
+    }
+
+    @Test
+    @DisplayName("re-enables login when controller returns blank credential failure")
+    void reEnablesLoginOnBlankCredentialFailure() {
+        var view = new FakeLoginView(" ", PASSWORD);
+        var navigator = new RecordingNavigator();
+        var presenter = new LoginPresenter(controller(), view, navigator);
+
+        presenter.loginRequested();
+
+        assertEquals("ID and password are required.", view.message);
+        assertTrue(view.error);
+        assertTrue(view.enabled);
+    }
+
+    private static AuthenticationController controller(User... users) {
+        var repository = new InMemoryUserRepository(users);
+        var service = new AuthenticationService(repository, PASSWORD_HASHER, new SessionStore());
+        return new AuthenticationController(service);
+    }
+
+    private static User user(String loginId, Role role) {
+        return User.fromPersistence(
+                loginId,
+                loginId,
+                PASSWORD_HASHER.hash(PASSWORD),
+                role,
+                true,
+                NOW,
+                NOW);
+    }
+
+    private static final class FakeLoginView implements LoginView {
+
+        private final String loginId;
+        private final String password;
+        private boolean enabled = true;
+        private String message = "";
+        private boolean error;
+        private boolean passwordCleared;
+
+        private FakeLoginView(String loginId, String password) {
+            this.loginId = loginId;
+            this.password = password;
+        }
+
+        @Override
+        public String loginId() {
+            return loginId;
+        }
+
+        @Override
+        public String password() {
+            return password;
+        }
+
+        @Override
+        public void setLoginEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        @Override
+        public void showMessage(String message, boolean error) {
+            this.message = message;
+            this.error = error;
+        }
+
+        @Override
+        public void clearPassword() {
+            passwordCleared = true;
+        }
+    }
+
+    private static final class RecordingNavigator implements SwingNavigator {
+
+        private UserResult adminUser;
+        private UserResult projectUser;
+
+        @Override
+        public void showLogin() {
+        }
+
+        @Override
+        public void showAdminDashboard(UserResult user) {
+            adminUser = user;
+        }
+
+        @Override
+        public void showProjectList(UserResult user) {
+            projectUser = user;
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/LoginPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/LoginPresenterTest.java
@@ -156,6 +156,7 @@ class LoginPresenterTest {
 
         @Override
         public void showLogin() {
+            throw new AssertionError("LoginPresenter should not navigate back to login in these tests.");
         }
 
         @Override

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/PlaceholderPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/PlaceholderPanelTest.java
@@ -1,0 +1,42 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing placeholder panel")
+class PlaceholderPanelTest {
+
+    @Test
+    @DisplayName("shows destination and invokes logout action")
+    void showsDestinationAndInvokesLogoutAction() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            AtomicBoolean loggedOut = new AtomicBoolean();
+            UserResult user = new UserResult(
+                    "admin",
+                    "Admin User",
+                    Role.ADMIN,
+                    true,
+                    LocalDateTime.of(2026, 5, 31, 0, 0),
+                    LocalDateTime.of(2026, 5, 31, 0, 0));
+            var panel = new PlaceholderPanel("Admin dashboard", user, () -> loggedOut.set(true));
+
+            JLabel title = SwingComponentTestSupport.find(panel, "placeholderTitle", JLabel.class);
+            JLabel userLabel = SwingComponentTestSupport.find(panel, "placeholderUser", JLabel.class);
+            JButton logout = SwingComponentTestSupport.find(panel, "logoutButton", JButton.class);
+            logout.doClick();
+
+            assertEquals("Admin dashboard", title.getText());
+            assertEquals("Admin User (ADMIN)", userLabel.getText());
+            assertTrue(loggedOut.get());
+        });
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -1,0 +1,154 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.controller.AuthenticationController;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.PasswordHashing;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.technical.SessionStore;
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPasswordField;
+import javax.swing.SwingUtilities;
+import javax.swing.JTextField;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing app panel")
+class SwingAppPanelTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("offloads login and uses click-time credentials")
+    void offloadsLoginAndUsesClickTimeCredentials() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        var panelRef = new AtomicReference<SwingAppPanel>();
+        AuthenticationController controller = controller(passwordHashing, user("admin", Role.ADMIN));
+
+        SwingComponentTestSupport.onEdt(() -> {
+            var panel = new SwingAppPanel(controller, titles::update);
+            panelRef.set(panel);
+            JTextField loginId = SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class);
+            JPasswordField password = SwingComponentTestSupport.find(panel, "passwordField", JPasswordField.class);
+            JButton signIn = SwingComponentTestSupport.find(panel, "signInButton", JButton.class);
+
+            loginId.setText("admin");
+            password.setText("submitted-password");
+            signIn.doClick();
+
+            loginId.setText("changed");
+            password.setText("changed-password");
+
+            assertFalse(signIn.isEnabled());
+            assertFalse(loginId.isEnabled());
+            assertFalse(password.isEnabled());
+        });
+
+        assertTrue(passwordHashing.awaitMatch());
+        assertFalse(passwordHashing.matchCalledOnEdt());
+        assertEquals("submitted-password", passwordHashing.matchedPassword());
+        assertTrue(titles.awaitAdminDashboard());
+
+        SwingComponentTestSupport.onEdt(() -> {
+            SwingAppPanel panel = panelRef.get();
+            JLabel title = SwingComponentTestSupport.find(panel, "placeholderTitle", JLabel.class);
+            JButton logout = SwingComponentTestSupport.find(panel, "logoutButton", JButton.class);
+
+            assertEquals("Admin dashboard", title.getText());
+            logout.doClick();
+
+            JTextField loginId = SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class);
+            JPasswordField password = SwingComponentTestSupport.find(panel, "passwordField", JPasswordField.class);
+            JButton signIn = SwingComponentTestSupport.find(panel, "signInButton", JButton.class);
+
+            assertTrue(signIn.isEnabled());
+            assertTrue(loginId.isEnabled());
+            assertTrue(password.isEnabled());
+            assertEquals("", new String(password.getPassword()));
+        });
+    }
+
+    private static AuthenticationController controller(PasswordHashing passwordHashing, User... users) {
+        var repository = new InMemoryUserRepository(users);
+        var service = new AuthenticationService(repository, passwordHashing, new SessionStore());
+        return new AuthenticationController(service);
+    }
+
+    private static User user(String loginId, Role role) {
+        return User.fromPersistence(loginId, loginId, "stored-password", role, true, NOW, NOW);
+    }
+
+    private static final class RecordingPasswordHashing implements PasswordHashing {
+
+        private final CountDownLatch matchCalled = new CountDownLatch(1);
+        private final AtomicReference<String> matchedPassword = new AtomicReference<>();
+        private final AtomicBoolean matchCalledOnEdt = new AtomicBoolean(true);
+
+        @Override
+        public String hash(String password) {
+            return password;
+        }
+
+        @Override
+        public boolean matches(String password, String storedCredential) {
+            matchedPassword.set(password);
+            matchCalledOnEdt.set(SwingUtilities.isEventDispatchThread());
+            matchCalled.countDown();
+            return true;
+        }
+
+        @Override
+        public boolean isHashed(String storedCredential) {
+            return true;
+        }
+
+        @Override
+        public String saltOf(String storedCredential) {
+            return "salt";
+        }
+
+        @Override
+        public String hashOf(String storedCredential) {
+            return storedCredential;
+        }
+
+        private boolean awaitMatch() throws InterruptedException {
+            return matchCalled.await(5, TimeUnit.SECONDS);
+        }
+
+        private boolean matchCalledOnEdt() {
+            return matchCalledOnEdt.get();
+        }
+
+        private String matchedPassword() {
+            return matchedPassword.get();
+        }
+    }
+
+    private static final class RecordingTitleUpdater {
+
+        private final CountDownLatch adminDashboardShown = new CountDownLatch(1);
+
+        private void update(String title) {
+            if ("Admin dashboard".equals(title)) {
+                adminDashboardShown.countDown();
+            }
+        }
+
+        private boolean awaitAdminDashboard() throws InterruptedException {
+            return adminDashboardShown.await(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -2,6 +2,8 @@ package com.github.marcellokim.issuetracker.ui.swing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
@@ -20,6 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPasswordField;
+import javax.swing.SwingWorker;
 import javax.swing.SwingUtilities;
 import javax.swing.JTextField;
 import org.junit.jupiter.api.DisplayName;
@@ -36,6 +39,8 @@ class SwingAppPanelTest {
         var passwordHashing = new RecordingPasswordHashing();
         var titles = new RecordingTitleUpdater();
         var panelRef = new AtomicReference<SwingAppPanel>();
+        var workerRef = new AtomicReference<SwingWorker<?, ?>>();
+        var workerDone = new CountDownLatch(1);
         AuthenticationController controller = controller(passwordHashing, user("admin", Role.ADMIN));
 
         SwingComponentTestSupport.onEdt(() -> {
@@ -48,6 +53,17 @@ class SwingAppPanelTest {
             loginId.setText("admin");
             password.setText("submitted-password");
             signIn.doClick();
+            SwingWorker<?, ?> worker = loginWorker(panel);
+            worker.addPropertyChangeListener(event -> {
+                if ("state".equals(event.getPropertyName())
+                        && SwingWorker.StateValue.DONE == event.getNewValue()) {
+                    workerDone.countDown();
+                }
+            });
+            if (SwingWorker.StateValue.DONE == worker.getState()) {
+                workerDone.countDown();
+            }
+            workerRef.set(worker);
 
             loginId.setText("changed");
             password.setText("changed-password");
@@ -61,7 +77,9 @@ class SwingAppPanelTest {
         assertFalse(passwordHashing.matchCalledOnEdt());
         assertEquals("submitted-password", passwordHashing.matchedPassword());
         assertTrue(titles.awaitAdminDashboard());
-        assertTrue(waitForLoginWorkerCleared(panelRef.get()));
+        assertNotNull(workerRef.get());
+        assertTrue(workerDone.await(5, TimeUnit.SECONDS));
+        SwingComponentTestSupport.onEdt(() -> assertNull(loginWorker(panelRef.get())));
 
         SwingComponentTestSupport.onEdt(() -> {
             SwingAppPanel panel = panelRef.get();
@@ -82,23 +100,10 @@ class SwingAppPanelTest {
         });
     }
 
-    private static boolean waitForLoginWorkerCleared(SwingAppPanel panel) throws Exception {
-        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-        while (System.nanoTime() < deadline) {
-            AtomicReference<Object> worker = new AtomicReference<>();
-            SwingComponentTestSupport.onEdt(() -> worker.set(loginWorker(panel)));
-            if (worker.get() == null) {
-                return true;
-            }
-            Thread.sleep(20);
-        }
-        return false;
-    }
-
-    private static Object loginWorker(SwingAppPanel panel) throws ReflectiveOperationException {
+    private static SwingWorker<?, ?> loginWorker(SwingAppPanel panel) throws ReflectiveOperationException {
         Field worker = SwingAppPanel.class.getDeclaredField("loginWorker");
         worker.setAccessible(true);
-        return worker.get(panel);
+        return (SwingWorker<?, ?>) worker.get(panel);
     }
 
     private static AuthenticationController controller(PasswordHashing passwordHashing, User... users) {

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -11,6 +11,7 @@ import com.github.marcellokim.issuetracker.service.AuthenticationService;
 import com.github.marcellokim.issuetracker.service.PasswordHashing;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
 import com.github.marcellokim.issuetracker.technical.SessionStore;
+import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -60,6 +61,7 @@ class SwingAppPanelTest {
         assertFalse(passwordHashing.matchCalledOnEdt());
         assertEquals("submitted-password", passwordHashing.matchedPassword());
         assertTrue(titles.awaitAdminDashboard());
+        assertTrue(waitForLoginWorkerCleared(panelRef.get()));
 
         SwingComponentTestSupport.onEdt(() -> {
             SwingAppPanel panel = panelRef.get();
@@ -78,6 +80,25 @@ class SwingAppPanelTest {
             assertTrue(password.isEnabled());
             assertEquals("", new String(password.getPassword()));
         });
+    }
+
+    private static boolean waitForLoginWorkerCleared(SwingAppPanel panel) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            AtomicReference<Object> worker = new AtomicReference<>();
+            SwingComponentTestSupport.onEdt(() -> worker.set(loginWorker(panel)));
+            if (worker.get() == null) {
+                return true;
+            }
+            Thread.sleep(20);
+        }
+        return false;
+    }
+
+    private static Object loginWorker(SwingAppPanel panel) throws ReflectiveOperationException {
+        Field worker = SwingAppPanel.class.getDeclaredField("loginWorker");
+        worker.setAccessible(true);
+        return worker.get(panel);
     }
 
     private static AuthenticationController controller(PasswordHashing passwordHashing, User... users) {

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingComponentTestSupport.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingComponentTestSupport.java
@@ -1,0 +1,77 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.SwingUtilities;
+
+final class SwingComponentTestSupport {
+
+    private SwingComponentTestSupport() {
+    }
+
+    static void onEdt(ThrowingRunnable action) throws Exception {
+        if (SwingUtilities.isEventDispatchThread()) {
+            action.run();
+            return;
+        }
+
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                action.run();
+            } catch (Throwable throwable) {
+                failure.set(throwable);
+            }
+        });
+        rethrow(failure.get());
+    }
+
+    static <T extends Component> T find(Container root, String name, Class<T> type) {
+        if (!SwingUtilities.isEventDispatchThread()) {
+            throw new AssertionError("Swing component lookup must run on the EDT");
+        }
+        T component = findOrNull(root, name, type);
+        if (component == null) {
+            throw new AssertionError("Component not found: " + name);
+        }
+        return component;
+    }
+
+    private static <T extends Component> T findOrNull(Container root, String name, Class<T> type) {
+        if (name.equals(root.getName()) && type.isInstance(root)) {
+            return type.cast(root);
+        }
+        for (Component child : root.getComponents()) {
+            if (name.equals(child.getName()) && type.isInstance(child)) {
+                return type.cast(child);
+            }
+            if (child instanceof Container container) {
+                T nested = findOrNull(container, name, type);
+                if (nested != null) {
+                    return nested;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static void rethrow(Throwable throwable) throws Exception {
+        if (throwable == null) {
+            return;
+        }
+        if (throwable instanceof Exception exception) {
+            throw exception;
+        }
+        if (throwable instanceof Error error) {
+            throw error;
+        }
+        throw new RuntimeException(throwable);
+    }
+
+    @FunctionalInterface
+    interface ThrowingRunnable {
+
+        void run() throws Exception;
+    }
+}


### PR DESCRIPTION
## purpose
- Swing UI의 첫 진입점인 로그인 화면을 추가한다.
- JavaFX 기본 실행 흐름은 유지하고, Swing 전용 실행 경로에서 기존 `AuthenticationController`를 재사용한다.
- Closes #202

## non-goals
- Admin dashboard, project list의 실제 데이터 화면 구현은 포함하지 않는다.
- JavaFX `Main`/`JavaFXApp` 변경은 포함하지 않는다.
- Swing presentation에서 service/repository/JDBC/domain mutation을 직접 호출하지 않는다.

## diff map
- Swing entry: `SwingApp`, `SwingAppFrame`, `SwingAppPanel`, `runSwing`
- Login flow: `LoginPresenter`, `LoginView`, `SwingNavigator`, `LoginPanel`
- Placeholder: 로그인 성공 후 role별 이동 확인용 placeholder 화면
- Tests: presenter, Swing component, app panel, main smoke test

## verification evidence
- `./gradlew test --tests 'com.github.marcellokim.issuetracker.ui.swing.*' --tests 'com.github.marcellokim.issuetracker.MainSmokeTest' --console=plain`
- `./gradlew help --task runSwing --console=plain`
- `./gradlew check --console=plain`
- `git diff --check origin/dev...HEAD`
- JavaFX `Main`/`JavaFXApp` 변경 없음 확인
- production `ui/swing`에서 repository/persistence/JDBC 직접 참조 없음 확인

## reviewer focus areas
- 로그인 요청이 EDT를 막지 않는지
- 클릭 시점 credentials snapshot으로 입력 race가 없는지
- JavaFX 기본 실행 흐름이 유지되는지
- Swing UI가 controller 계약만 사용하고 하위 계층을 직접 호출하지 않는지

## risk / rollback
- 후속 Admin dashboard/project list 화면은 아직 placeholder다.
- rollback 범위는 `runSwing` task와 `ui/swing` 추가 파일 제거로 제한된다.
