### PR TITLE
feat: Swing 관리자 대시보드 구현

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPanel.java
@@ -1,0 +1,242 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.GridLayout;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Objects;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+import javax.swing.table.DefaultTableModel;
+
+final class AdminDashboardPanel extends JPanel implements AdminDashboardView {
+
+    private static final long serialVersionUID = 1L;
+    private static final String[] PROJECT_COLUMNS = {"ID", "Project", "Members", "Issues"};
+    private static final String[] USER_COLUMNS = {"Login ID", "Name", "Role", "Active"};
+
+    private final DefaultTableModel projectTableModel = readOnlyTableModel(PROJECT_COLUMNS);
+    private final DefaultTableModel userTableModel = readOnlyTableModel(USER_COLUMNS);
+    private final JLabel messageLabel = new JLabel(" ");
+
+    AdminDashboardPanel(
+            UserResult user,
+            Runnable onAccountManagement,
+            Runnable onProjectManagement,
+            Runnable onLogout) {
+        Objects.requireNonNull(user, "user");
+        Objects.requireNonNull(onAccountManagement, "onAccountManagement");
+        Objects.requireNonNull(onProjectManagement, "onProjectManagement");
+        Objects.requireNonNull(onLogout, "onLogout");
+
+        setName("adminDashboardPanel");
+        setLayout(new BorderLayout(SwingStyles.SECTION_GAP, SwingStyles.SECTION_GAP));
+        setBackground(SwingStyles.BACKGROUND);
+        setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING));
+
+        add(header(user, onAccountManagement, onProjectManagement, onLogout), BorderLayout.NORTH);
+        add(tables(), BorderLayout.CENTER);
+    }
+
+    @Override
+    public void showDashboard(List<DashboardProjectSummary> projects, List<UserResult> users) {
+        Objects.requireNonNull(projects, "projects");
+        Objects.requireNonNull(users, "users");
+        runOnEdtAndWait(() -> {
+            messageLabel.setText(" ");
+            replaceRows(projectTableModel, projectRows(projects));
+            replaceRows(userTableModel, userRows(users));
+        });
+    }
+
+    @Override
+    public void showError(String message) {
+        runOnEdtAndWait(() -> {
+            String displayMessage = message == null || message.isBlank()
+                    ? "Dashboard data could not be loaded."
+                    : message;
+            messageLabel.setText(displayMessage);
+        });
+    }
+
+    private JPanel header(
+            UserResult user,
+            Runnable onAccountManagement,
+            Runnable onProjectManagement,
+            Runnable onLogout) {
+        JPanel header = new JPanel();
+        header.setLayout(new BoxLayout(header, BoxLayout.Y_AXIS));
+        header.setBackground(SwingStyles.SURFACE);
+        header.setBorder(SwingStyles.surfaceBorder());
+
+        JPanel titles = new JPanel();
+        titles.setLayout(new BoxLayout(titles, BoxLayout.Y_AXIS));
+        titles.setOpaque(false);
+        titles.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        JLabel title = new JLabel("Admin dashboard");
+        title.setName("adminDashboardTitle");
+        title.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyTitle(title);
+        titles.add(title);
+
+        JLabel userLabel = new JLabel(user.name() + " (" + user.role() + ")");
+        userLabel.setName("adminDashboardUser");
+        userLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyMuted(userLabel);
+        titles.add(userLabel);
+
+        messageLabel.setName("adminDashboardMessage");
+        messageLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        messageLabel.setForeground(SwingStyles.ERROR_TEXT);
+        titles.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+        titles.add(messageLabel);
+
+        JPanel actions = new JPanel();
+        actions.setOpaque(false);
+        actions.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        JButton accountButton = new JButton("Account management");
+        accountButton.setName("accountManagementButton");
+        accountButton.addActionListener(event -> onAccountManagement.run());
+        actions.add(accountButton);
+
+        JButton projectButton = new JButton("Project management");
+        projectButton.setName("projectManagementButton");
+        projectButton.addActionListener(event -> onProjectManagement.run());
+        actions.add(projectButton);
+
+        JButton logoutButton = new JButton("Logout");
+        logoutButton.setName("adminLogoutButton");
+        logoutButton.addActionListener(event -> onLogout.run());
+        actions.add(logoutButton);
+
+        header.add(titles);
+        header.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+        header.add(actions);
+        return header;
+    }
+
+    private JPanel tables() {
+        JPanel tables = new JPanel(new GridLayout(1, 2, SwingStyles.SECTION_GAP, 0));
+        tables.setOpaque(false);
+        tables.add(section("Projects", table("adminProjectTable", projectTableModel)));
+        tables.add(section("Users", table("adminUserTable", userTableModel)));
+        return tables;
+    }
+
+    private static JPanel section(String titleText, JTable table) {
+        JPanel section = new JPanel(new BorderLayout(0, SwingStyles.ROW_GAP));
+        section.setBackground(SwingStyles.SURFACE);
+        section.setBorder(SwingStyles.surfaceBorder());
+
+        JLabel title = new JLabel(titleText);
+        SwingStyles.applySectionTitle(title);
+        section.add(title, BorderLayout.NORTH);
+        JScrollPane scrollPane = new JScrollPane(table);
+        scrollPane.setColumnHeaderView(table.getTableHeader());
+        section.add(scrollPane, BorderLayout.CENTER);
+        return section;
+    }
+
+    private static JTable table(String name, DefaultTableModel model) {
+        JTable table = new JTable(model);
+        table.setName(name);
+        table.setFillsViewportHeight(true);
+        table.setRowHeight(26);
+        table.getTableHeader().setReorderingAllowed(false);
+        table.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
+        applyColumnWidths(table);
+        return table;
+    }
+
+    private static void applyColumnWidths(JTable table) {
+        if (table.getColumnCount() != 4) {
+            return;
+        }
+        table.getColumnModel().getColumn(0).setPreferredWidth(72);
+        table.getColumnModel().getColumn(1).setPreferredWidth(160);
+        table.getColumnModel().getColumn(2).setPreferredWidth(88);
+        table.getColumnModel().getColumn(3).setPreferredWidth(112);
+    }
+
+    private static Object[][] projectRows(List<DashboardProjectSummary> projects) {
+        Object[][] rows = new Object[projects.size()][PROJECT_COLUMNS.length];
+        for (int index = 0; index < projects.size(); index++) {
+            DashboardProjectSummary project = projects.get(index);
+            rows[index] = new Object[]{
+                    project.projectId(),
+                    project.projectName(),
+                    project.memberCount(),
+                    project.visibleIssueCount()
+            };
+        }
+        return rows;
+    }
+
+    private static Object[][] userRows(List<UserResult> users) {
+        Object[][] rows = new Object[users.size()][USER_COLUMNS.length];
+        for (int index = 0; index < users.size(); index++) {
+            UserResult user = users.get(index);
+            rows[index] = new Object[]{
+                    user.loginId(),
+                    user.name(),
+                    user.role().name(),
+                    user.active() ? "Yes" : "No"
+            };
+        }
+        return rows;
+    }
+
+    private static void replaceRows(DefaultTableModel model, Object[][] rows) {
+        model.setRowCount(0);
+        for (Object[] row : rows) {
+            model.addRow(row);
+        }
+    }
+
+    private static DefaultTableModel readOnlyTableModel(String[] columns) {
+        return new DefaultTableModel(columns, 0) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return false;
+            }
+        };
+    }
+
+    private static void runOnEdtAndWait(Runnable action) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            action.run();
+            return;
+        }
+        try {
+            SwingUtilities.invokeAndWait(action);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while updating Swing dashboard.", exception);
+        } catch (InvocationTargetException exception) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw new IllegalStateException("Swing dashboard update failed.", cause);
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPanel.java
@@ -5,7 +5,6 @@ import com.github.marcellokim.issuetracker.service.UserResult;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.GridLayout;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Objects;
 import javax.swing.BorderFactory;
@@ -24,6 +23,8 @@ final class AdminDashboardPanel extends JPanel implements AdminDashboardView {
     private static final long serialVersionUID = 1L;
     private static final String[] PROJECT_COLUMNS = {"ID", "Project", "Members", "Issues"};
     private static final String[] USER_COLUMNS = {"Login ID", "Name", "Role", "Active"};
+    private static final int[] PROJECT_COLUMN_WIDTHS = {72, 180, 88, 88};
+    private static final int[] USER_COLUMN_WIDTHS = {96, 160, 88, 72};
 
     private final DefaultTableModel projectTableModel = readOnlyTableModel(PROJECT_COLUMNS);
     private final DefaultTableModel userTableModel = readOnlyTableModel(USER_COLUMNS);
@@ -56,21 +57,21 @@ final class AdminDashboardPanel extends JPanel implements AdminDashboardView {
     public void showDashboard(List<DashboardProjectSummary> projects, List<UserResult> users) {
         Objects.requireNonNull(projects, "projects");
         Objects.requireNonNull(users, "users");
-        runOnEdtAndWait(() -> {
+        Object[][] projectRows = projectRows(projects);
+        Object[][] userRows = userRows(users);
+        runOnEdt(() -> {
             messageLabel.setText(" ");
-            replaceRows(projectTableModel, projectRows(projects));
-            replaceRows(userTableModel, userRows(users));
+            replaceRows(projectTableModel, projectRows);
+            replaceRows(userTableModel, userRows);
         });
     }
 
     @Override
     public void showError(String message) {
-        runOnEdtAndWait(() -> {
-            String displayMessage = message == null || message.isBlank()
-                    ? "Dashboard data could not be loaded."
-                    : message;
-            messageLabel.setText(displayMessage);
-        });
+        String displayMessage = message == null || message.isBlank()
+                ? "Dashboard data could not be loaded."
+                : message;
+        runOnEdt(() -> messageLabel.setText(displayMessage));
     }
 
     private JPanel header(
@@ -134,8 +135,8 @@ final class AdminDashboardPanel extends JPanel implements AdminDashboardView {
     private JPanel tables() {
         JPanel tables = new JPanel(new GridLayout(1, 2, SwingStyles.SECTION_GAP, 0));
         tables.setOpaque(false);
-        tables.add(section("Projects", table("adminProjectTable", projectTableModel)));
-        tables.add(section("Users", table("adminUserTable", userTableModel)));
+        tables.add(section("Projects", table("adminProjectTable", projectTableModel, PROJECT_COLUMN_WIDTHS)));
+        tables.add(section("Users", table("adminUserTable", userTableModel, USER_COLUMN_WIDTHS)));
         return tables;
     }
 
@@ -153,25 +154,24 @@ final class AdminDashboardPanel extends JPanel implements AdminDashboardView {
         return section;
     }
 
-    private static JTable table(String name, DefaultTableModel model) {
+    private static JTable table(String name, DefaultTableModel model, int[] columnWidths) {
         JTable table = new JTable(model);
         table.setName(name);
         table.setFillsViewportHeight(true);
         table.setRowHeight(26);
         table.getTableHeader().setReorderingAllowed(false);
         table.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
-        applyColumnWidths(table);
+        applyColumnWidths(table, columnWidths);
         return table;
     }
 
-    private static void applyColumnWidths(JTable table) {
-        if (table.getColumnCount() != 4) {
+    private static void applyColumnWidths(JTable table, int[] columnWidths) {
+        if (table.getColumnCount() != columnWidths.length) {
             return;
         }
-        table.getColumnModel().getColumn(0).setPreferredWidth(72);
-        table.getColumnModel().getColumn(1).setPreferredWidth(160);
-        table.getColumnModel().getColumn(2).setPreferredWidth(88);
-        table.getColumnModel().getColumn(3).setPreferredWidth(112);
+        for (int index = 0; index < columnWidths.length; index++) {
+            table.getColumnModel().getColumn(index).setPreferredWidth(columnWidths[index]);
+        }
     }
 
     private static Object[][] projectRows(List<DashboardProjectSummary> projects) {
@@ -218,25 +218,11 @@ final class AdminDashboardPanel extends JPanel implements AdminDashboardView {
         };
     }
 
-    private static void runOnEdtAndWait(Runnable action) {
+    private static void runOnEdt(Runnable action) {
         if (SwingUtilities.isEventDispatchThread()) {
             action.run();
             return;
         }
-        try {
-            SwingUtilities.invokeAndWait(action);
-        } catch (InterruptedException exception) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted while updating Swing dashboard.", exception);
-        } catch (InvocationTargetException exception) {
-            Throwable cause = exception.getCause();
-            if (cause instanceof RuntimeException runtimeException) {
-                throw runtimeException;
-            }
-            if (cause instanceof Error error) {
-                throw error;
-            }
-            throw new IllegalStateException("Swing dashboard update failed.", cause);
-        }
+        SwingUtilities.invokeLater(action);
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPanel.java
@@ -223,6 +223,7 @@ final class AdminDashboardPanel extends JPanel implements AdminDashboardView {
             action.run();
             return;
         }
+        // Production dashboard loads call this from SwingWorker; direct EDT calls keep panel tests simple.
         SwingUtilities.invokeLater(action);
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPresenter.java
@@ -1,0 +1,31 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.controller.DashboardController;
+import java.util.Objects;
+
+final class AdminDashboardPresenter {
+
+    private final DashboardController dashboardController;
+    private final AdminDashboardView view;
+
+    AdminDashboardPresenter(DashboardController dashboardController, AdminDashboardView view) {
+        this.dashboardController = Objects.requireNonNull(dashboardController, "dashboardController");
+        this.view = Objects.requireNonNull(view, "view");
+    }
+
+    void load() {
+        try {
+            view.showDashboard(dashboardController.viewProjects(), dashboardController.viewUsers());
+        } catch (RuntimeException exception) {
+            view.showError(messageOf(exception));
+        }
+    }
+
+    private static String messageOf(RuntimeException exception) {
+        String message = exception.getMessage();
+        if (message == null || message.isBlank()) {
+            return "Dashboard data could not be loaded.";
+        }
+        return message;
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardView.java
@@ -1,0 +1,12 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.util.List;
+
+interface AdminDashboardView {
+
+    void showDashboard(List<DashboardProjectSummary> projects, List<UserResult> users);
+
+    void showError(String message);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/PlaceholderPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/PlaceholderPanel.java
@@ -14,6 +14,10 @@ import javax.swing.JPanel;
 final class PlaceholderPanel extends JPanel {
 
     PlaceholderPanel(String destination, UserResult user, Runnable onLogout) {
+        this(destination, user, null, onLogout);
+    }
+
+    PlaceholderPanel(String destination, UserResult user, Runnable onBack, Runnable onLogout) {
         Objects.requireNonNull(destination, "destination");
         Objects.requireNonNull(user, "user");
         Objects.requireNonNull(onLogout, "onLogout");
@@ -44,6 +48,15 @@ final class PlaceholderPanel extends JPanel {
         SwingStyles.applyMuted(userLabel);
         surface.add(userLabel);
         surface.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
+
+        if (onBack != null) {
+            JButton backButton = new JButton("Back");
+            backButton.setName("backButton");
+            backButton.setAlignmentX(Component.LEFT_ALIGNMENT);
+            backButton.addActionListener(event -> onBack.run());
+            surface.add(backButton);
+            surface.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+        }
 
         JButton logoutButton = new JButton("Logout");
         logoutButton.setName("logoutButton");

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
@@ -2,6 +2,7 @@ package com.github.marcellokim.issuetracker.ui.swing;
 
 import com.github.marcellokim.issuetracker.config.ApplicationContext;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
+import com.github.marcellokim.issuetracker.controller.DashboardController;
 import java.util.Objects;
 import javax.swing.JFrame;
 import javax.swing.WindowConstants;
@@ -13,12 +14,14 @@ public final class SwingAppFrame extends JFrame {
     private final SwingAppPanel appPanel;
 
     public SwingAppFrame(ApplicationContext context) {
-        this(Objects.requireNonNull(context, "context").authenticationController());
+        this(
+                Objects.requireNonNull(context, "context").authenticationController(),
+                context.dashboardController());
     }
 
-    SwingAppFrame(AuthenticationController authenticationController) {
+    SwingAppFrame(AuthenticationController authenticationController, DashboardController dashboardController) {
         super("Issue Tracker");
-        this.appPanel = new SwingAppPanel(authenticationController, this::setTitle);
+        this.appPanel = new SwingAppPanel(authenticationController, dashboardController, this::setTitle);
         setContentPane(appPanel);
         setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         setSize(SwingStyles.WINDOW_SIZE);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -2,10 +2,12 @@ package com.github.marcellokim.issuetracker.ui.swing;
 
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
 import com.github.marcellokim.issuetracker.service.UserResult;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.lang.reflect.InvocationTargetException;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -30,6 +32,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private final JPanel adminDashboardCard = new JPanel(new BorderLayout());
     private final JPanel projectListCard = new JPanel(new BorderLayout());
     private transient SwingWorker<Void, Void> loginWorker;
+    private transient volatile DashboardLoadWorker dashboardWorker;
 
     SwingAppPanel(
             AuthenticationController authenticationController,
@@ -53,6 +56,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     public void showLogin() {
         runOnEdtAndWait(() -> {
+            cancelDashboardWorker();
             titleUpdater.accept("Issue Tracker");
             loginPanel.showMessage(" ", false);
             loginPanel.clearPassword();
@@ -65,6 +69,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     public void showAdminDashboard(UserResult user) {
         Objects.requireNonNull(user, "user");
         SwingUtilities.invokeLater(() -> {
+            cancelDashboardWorker();
             titleUpdater.accept("Admin dashboard");
             AdminDashboardPanel panel = new AdminDashboardPanel(
                     user,
@@ -84,6 +89,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     public void showProjectList(UserResult user) {
         Objects.requireNonNull(user, "user");
         runOnEdtAndWait(() -> {
+            cancelDashboardWorker();
             titleUpdater.accept("Project list");
             showPlaceholder(projectListCard, "Project list", user);
             cardLayout.show(this, PROJECT_LIST_CARD);
@@ -91,6 +97,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     }
 
     void logout() {
+        cancelDashboardWorker();
         authenticationController.logout();
         showLogin();
     }
@@ -141,29 +148,42 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     }
 
     private void showPlaceholder(JPanel card, String destination, UserResult user) {
+        showPlaceholder(card, destination, user, null);
+    }
+
+    private void showPlaceholder(JPanel card, String destination, UserResult user, Runnable onBack) {
         card.removeAll();
-        card.add(new PlaceholderPanel(destination, user, this::logout), BorderLayout.CENTER);
+        card.add(new PlaceholderPanel(destination, user, onBack, this::logout), BorderLayout.CENTER);
         card.revalidate();
         card.repaint();
     }
 
     private void showAdminPlaceholder(String destination, UserResult user) {
-        runOnEdtAndWait(() -> {
+        SwingUtilities.invokeLater(() -> {
+            cancelDashboardWorker();
             titleUpdater.accept(destination);
-            showPlaceholder(adminDashboardCard, destination, user);
+            showPlaceholder(adminDashboardCard, destination, user, () -> showAdminDashboard(user));
             cardLayout.show(this, ADMIN_DASHBOARD_CARD);
         });
     }
 
     private void loadAdminDashboard(AdminDashboardPanel panel) {
-        AdminDashboardPresenter presenter = new AdminDashboardPresenter(dashboardController, panel);
-        new SwingWorker<Void, Void>() {
-            @Override
-            protected Void doInBackground() {
-                presenter.load();
-                return null;
-            }
-        }.execute();
+        DashboardLoadWorker worker = new DashboardLoadWorker(panel);
+        dashboardWorker = worker;
+        worker.execute();
+    }
+
+    private void cancelDashboardWorker() {
+        if (dashboardWorker != null && !dashboardWorker.isDone()) {
+            dashboardWorker.cancel(true);
+        }
+        dashboardWorker = null;
+    }
+
+    private void clearCompletedDashboardWorker(DashboardLoadWorker worker) {
+        if (dashboardWorker == worker) {
+            dashboardWorker = null;
+        }
     }
 
     private void showLoginFailure(String message) {
@@ -205,6 +225,58 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             throw error;
         }
         throw new IllegalStateException("Swing UI update failed.", cause);
+    }
+
+    private final class DashboardLoadWorker extends SwingWorker<Void, Void> {
+
+        private final AdminDashboardPanel panel;
+
+        private DashboardLoadWorker(AdminDashboardPanel panel) {
+            this.panel = Objects.requireNonNull(panel, "panel");
+        }
+
+        @Override
+        protected Void doInBackground() {
+            AdminDashboardPresenter presenter = new AdminDashboardPresenter(
+                    dashboardController,
+                    new CurrentDashboardView(panel, this));
+            presenter.load();
+            return null;
+        }
+
+        @Override
+        protected void done() {
+            clearCompletedDashboardWorker(this);
+        }
+    }
+
+    private final class CurrentDashboardView implements AdminDashboardView {
+
+        private final AdminDashboardPanel delegate;
+        private final DashboardLoadWorker worker;
+
+        private CurrentDashboardView(AdminDashboardPanel delegate, DashboardLoadWorker worker) {
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
+            this.worker = Objects.requireNonNull(worker, "worker");
+        }
+
+        @Override
+        public void showDashboard(List<DashboardProjectSummary> projects, List<UserResult> users) {
+            if (isCurrent()) {
+                delegate.showDashboard(projects, users);
+            }
+        }
+
+        @Override
+        public void showError(String message) {
+            if (isCurrent()) {
+                delegate.showError(message);
+            }
+        }
+
+        private boolean isCurrent() {
+            return dashboardWorker == worker && !worker.isCancelled();
+        }
     }
 
     private static final class CapturedLoginView implements LoginView {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -32,7 +32,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private final JPanel adminDashboardCard = new JPanel(new BorderLayout());
     private final JPanel projectListCard = new JPanel(new BorderLayout());
     private transient SwingWorker<Void, Void> loginWorker;
-    private transient volatile DashboardLoadWorker dashboardWorker;
+    private final transient AtomicReference<DashboardLoadWorker> dashboardWorker = new AtomicReference<>();
 
     SwingAppPanel(
             AuthenticationController authenticationController,
@@ -169,20 +169,14 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     private void loadAdminDashboard(AdminDashboardPanel panel) {
         DashboardLoadWorker worker = new DashboardLoadWorker(panel);
-        dashboardWorker = worker;
+        dashboardWorker.set(worker);
         worker.execute();
     }
 
     private void cancelDashboardWorker() {
-        if (dashboardWorker != null && !dashboardWorker.isDone()) {
-            dashboardWorker.cancel(true);
-        }
-        dashboardWorker = null;
-    }
-
-    private void clearCompletedDashboardWorker(DashboardLoadWorker worker) {
-        if (dashboardWorker == worker) {
-            dashboardWorker = null;
+        DashboardLoadWorker worker = dashboardWorker.getAndSet(null);
+        if (worker != null && !worker.isDone()) {
+            worker.cancel(true);
         }
     }
 
@@ -246,7 +240,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
         @Override
         protected void done() {
-            clearCompletedDashboardWorker(this);
+            dashboardWorker.compareAndSet(this, null);
         }
     }
 
@@ -275,7 +269,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         }
 
         private boolean isCurrent() {
-            return dashboardWorker == worker && !worker.isCancelled();
+            return dashboardWorker.get() == worker && !worker.isCancelled();
         }
     }
 

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -64,7 +64,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     @Override
     public void showAdminDashboard(UserResult user) {
         Objects.requireNonNull(user, "user");
-        AdminDashboardPanel dashboardPanel = callOnEdtAndWait(() -> {
+        SwingUtilities.invokeLater(() -> {
             titleUpdater.accept("Admin dashboard");
             AdminDashboardPanel panel = new AdminDashboardPanel(
                     user,
@@ -76,9 +76,8 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             adminDashboardCard.revalidate();
             adminDashboardCard.repaint();
             cardLayout.show(this, ADMIN_DASHBOARD_CARD);
-            return panel;
+            loadAdminDashboard(panel);
         });
-        loadAdminDashboard(dashboardPanel);
     }
 
     @Override
@@ -158,11 +157,6 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     private void loadAdminDashboard(AdminDashboardPanel panel) {
         AdminDashboardPresenter presenter = new AdminDashboardPresenter(dashboardController, panel);
-        if (!SwingUtilities.isEventDispatchThread()) {
-            presenter.load();
-            return;
-        }
-
         new SwingWorker<Void, Void>() {
             @Override
             protected Void doInBackground() {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -1,6 +1,7 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
+import com.github.marcellokim.issuetracker.controller.DashboardController;
 import com.github.marcellokim.issuetracker.service.UserResult;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
@@ -22,6 +23,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private static final String PROJECT_LIST_CARD = "projectList";
 
     private final transient AuthenticationController authenticationController;
+    private final transient DashboardController dashboardController;
     private final transient Consumer<String> titleUpdater;
     private final CardLayout cardLayout = new CardLayout();
     private final LoginPanel loginPanel = new LoginPanel();
@@ -29,8 +31,12 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private final JPanel projectListCard = new JPanel(new BorderLayout());
     private transient SwingWorker<Void, Void> loginWorker;
 
-    SwingAppPanel(AuthenticationController authenticationController, Consumer<String> titleUpdater) {
+    SwingAppPanel(
+            AuthenticationController authenticationController,
+            DashboardController dashboardController,
+            Consumer<String> titleUpdater) {
         this.authenticationController = Objects.requireNonNull(authenticationController, "authenticationController");
+        this.dashboardController = Objects.requireNonNull(dashboardController, "dashboardController");
         this.titleUpdater = Objects.requireNonNull(titleUpdater, "titleUpdater");
 
         setName("appCards");
@@ -58,11 +64,21 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     @Override
     public void showAdminDashboard(UserResult user) {
         Objects.requireNonNull(user, "user");
-        runOnEdtAndWait(() -> {
+        AdminDashboardPanel dashboardPanel = callOnEdtAndWait(() -> {
             titleUpdater.accept("Admin dashboard");
-            showPlaceholder(adminDashboardCard, "Admin dashboard", user);
+            AdminDashboardPanel panel = new AdminDashboardPanel(
+                    user,
+                    () -> showAdminPlaceholder("Account management", user),
+                    () -> showAdminPlaceholder("Project management", user),
+                    this::logout);
+            adminDashboardCard.removeAll();
+            adminDashboardCard.add(panel, BorderLayout.CENTER);
+            adminDashboardCard.revalidate();
+            adminDashboardCard.repaint();
             cardLayout.show(this, ADMIN_DASHBOARD_CARD);
+            return panel;
         });
+        loadAdminDashboard(dashboardPanel);
     }
 
     @Override
@@ -130,6 +146,30 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         card.add(new PlaceholderPanel(destination, user, this::logout), BorderLayout.CENTER);
         card.revalidate();
         card.repaint();
+    }
+
+    private void showAdminPlaceholder(String destination, UserResult user) {
+        runOnEdtAndWait(() -> {
+            titleUpdater.accept(destination);
+            showPlaceholder(adminDashboardCard, destination, user);
+            cardLayout.show(this, ADMIN_DASHBOARD_CARD);
+        });
+    }
+
+    private void loadAdminDashboard(AdminDashboardPanel panel) {
+        AdminDashboardPresenter presenter = new AdminDashboardPresenter(dashboardController, panel);
+        if (!SwingUtilities.isEventDispatchThread()) {
+            presenter.load();
+            return;
+        }
+
+        new SwingWorker<Void, Void>() {
+            @Override
+            protected Void doInBackground() {
+                presenter.load();
+                return null;
+            }
+        }.execute();
     }
 
     private void showLoginFailure(String message) {

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPanelTest.java
@@ -1,0 +1,102 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JTable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing admin dashboard panel")
+class AdminDashboardPanelTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("renders project and user tables")
+    void rendersProjectAndUserTables() throws Exception {
+        AtomicInteger accountClicks = new AtomicInteger();
+        AtomicInteger projectClicks = new AtomicInteger();
+        AtomicInteger logoutClicks = new AtomicInteger();
+
+        SwingComponentTestSupport.onEdt(() -> {
+            AdminDashboardPanel panel = new AdminDashboardPanel(
+                    userResult("admin", Role.ADMIN, true),
+                    accountClicks::incrementAndGet,
+                    projectClicks::incrementAndGet,
+                    logoutClicks::incrementAndGet);
+            panel.showDashboard(
+                    List.of(projectSummary(1L, "Alpha", 3, 7)),
+                    List.of(userResult("dev1", Role.DEV, true)));
+
+            JTable projects = SwingComponentTestSupport.find(panel, "adminProjectTable", JTable.class);
+            JTable users = SwingComponentTestSupport.find(panel, "adminUserTable", JTable.class);
+
+            assertEquals(1, projects.getRowCount());
+            assertEquals("Alpha", projects.getValueAt(0, 1));
+            assertEquals(7, projects.getValueAt(0, 3));
+            assertEquals(1, users.getRowCount());
+            assertEquals("dev1", users.getValueAt(0, 0));
+            assertEquals("DEV", users.getValueAt(0, 2));
+        });
+    }
+
+    @Test
+    @DisplayName("exposes navigation callbacks and dashboard error")
+    void exposesNavigationCallbacksAndError() throws Exception {
+        AtomicInteger accountClicks = new AtomicInteger();
+        AtomicInteger projectClicks = new AtomicInteger();
+        AtomicInteger logoutClicks = new AtomicInteger();
+
+        SwingComponentTestSupport.onEdt(() -> {
+            AdminDashboardPanel panel = new AdminDashboardPanel(
+                    userResult("admin", Role.ADMIN, true),
+                    accountClicks::incrementAndGet,
+                    projectClicks::incrementAndGet,
+                    logoutClicks::incrementAndGet);
+
+            SwingComponentTestSupport.find(panel, "accountManagementButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "projectManagementButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "adminLogoutButton", JButton.class).doClick();
+            panel.showError("Login is required.");
+
+            assertEquals(1, accountClicks.get());
+            assertEquals(1, projectClicks.get());
+            assertEquals(1, logoutClicks.get());
+            assertEquals(
+                    "Login is required.",
+                    SwingComponentTestSupport.find(panel, "adminDashboardMessage", JLabel.class).getText());
+        });
+    }
+
+    private static UserResult userResult(String loginId, Role role, boolean active) {
+        return UserResult.from(User.fromPersistence(loginId, loginId, "stored-password", role, active, NOW, NOW));
+    }
+
+    private static DashboardProjectSummary projectSummary(
+            long projectId,
+            String projectName,
+            int memberCount,
+            int visibleIssueCount) {
+        return new DashboardProjectSummary(
+                projectId,
+                projectName,
+                "Demo project",
+                memberCount,
+                1,
+                1,
+                1,
+                visibleIssueCount,
+                Map.of(IssueStatus.NEW, visibleIssueCount));
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPresenterTest.java
@@ -1,0 +1,198 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository;
+import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository.DashboardProjectSnapshot;
+import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
+import com.github.marcellokim.issuetracker.service.PasswordHashing;
+import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.technical.SessionStore;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing admin dashboard presenter")
+class AdminDashboardPresenterTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("loads projects and users through dashboard controller")
+    void loadsProjectsAndUsers() {
+        User admin = user("admin", Role.ADMIN, true);
+        DashboardProjectSummary expectedProject = projectSummary(1L, "Alpha", 3, 7);
+        UserResult expectedUser = UserResult.from(admin);
+        DashboardController controller = dashboardController(
+                admin,
+                List.of(snapshot(expectedProject)),
+                new InMemoryUserRepository(admin));
+        RecordingAdminDashboardView view = new RecordingAdminDashboardView();
+        AdminDashboardPresenter presenter = new AdminDashboardPresenter(controller, view);
+
+        presenter.load();
+
+        assertEquals(List.of(expectedProject), view.projects());
+        assertEquals(List.of(expectedUser), view.users());
+        assertNull(view.error());
+    }
+
+    @Test
+    @DisplayName("shows controller failure without rethrowing")
+    void showsControllerFailure() {
+        DashboardController controller = dashboardControllerWithoutLogin();
+        RecordingAdminDashboardView view = new RecordingAdminDashboardView();
+        AdminDashboardPresenter presenter = new AdminDashboardPresenter(controller, view);
+
+        presenter.load();
+
+        assertEquals("Login is required.", view.error());
+        assertTrue(view.projects().isEmpty());
+        assertTrue(view.users().isEmpty());
+    }
+
+    private static DashboardController dashboardController(
+            User currentUser,
+            List<DashboardProjectSnapshot> projects,
+            InMemoryUserRepository users) {
+        AuthenticationService authentication = new AuthenticationService(
+                users,
+                new AcceptingPasswordHashing(),
+                new SessionStore());
+        authentication.login(currentUser.getLoginId(), "password");
+        return new DashboardController(
+                authentication,
+                new DashboardSummaryService(
+                        new FakeDashboardSummaryRepository(projects),
+                        users,
+                        new PermissionPolicy()));
+    }
+
+    private static DashboardController dashboardControllerWithoutLogin() {
+        InMemoryUserRepository users = new InMemoryUserRepository(user("admin", Role.ADMIN, true));
+        return new DashboardController(
+                new AuthenticationService(users, new AcceptingPasswordHashing(), new SessionStore()),
+                new DashboardSummaryService(
+                        new FakeDashboardSummaryRepository(List.of()),
+                        users,
+                        new PermissionPolicy()));
+    }
+
+    private static User user(String loginId, Role role, boolean active) {
+        return User.fromPersistence(loginId, loginId, "stored-password", role, active, NOW, NOW);
+    }
+
+    private static DashboardProjectSummary projectSummary(
+            long projectId,
+            String projectName,
+            int memberCount,
+            int visibleIssueCount) {
+        return new DashboardProjectSummary(
+                projectId,
+                projectName,
+                "Demo project",
+                memberCount,
+                1,
+                1,
+                1,
+                visibleIssueCount,
+                Map.of(IssueStatus.NEW, visibleIssueCount));
+    }
+
+    private static DashboardProjectSnapshot snapshot(DashboardProjectSummary summary) {
+        return new DashboardProjectSnapshot(
+                summary.projectId(),
+                summary.projectName(),
+                summary.projectDescription(),
+                summary.memberCount(),
+                summary.projectLeaderCount(),
+                summary.developerCount(),
+                summary.testerCount(),
+                summary.visibleIssueCount(),
+                summary.statusCounts());
+    }
+
+    private static final class RecordingAdminDashboardView implements AdminDashboardView {
+
+        private List<DashboardProjectSummary> projects = List.of();
+        private List<UserResult> users = List.of();
+        private String error;
+
+        @Override
+        public void showDashboard(List<DashboardProjectSummary> projects, List<UserResult> users) {
+            this.projects = List.copyOf(projects);
+            this.users = List.copyOf(users);
+        }
+
+        @Override
+        public void showError(String message) {
+            this.error = message;
+        }
+
+        private List<DashboardProjectSummary> projects() {
+            return projects;
+        }
+
+        private List<UserResult> users() {
+            return users;
+        }
+
+        private String error() {
+            return error;
+        }
+    }
+
+    private record FakeDashboardSummaryRepository(
+            List<DashboardProjectSnapshot> projects) implements DashboardSummaryRepository {
+
+        @Override
+        public List<DashboardProjectSnapshot> findAllProjectSummaries() {
+            return projects;
+        }
+
+        @Override
+        public List<DashboardProjectSnapshot> findProjectSummariesByParticipant(String loginId) {
+            return List.of();
+        }
+    }
+
+    private static final class AcceptingPasswordHashing implements PasswordHashing {
+
+        @Override
+        public String hash(String password) {
+            return password;
+        }
+
+        @Override
+        public boolean matches(String password, String storedCredential) {
+            return true;
+        }
+
+        @Override
+        public boolean isHashed(String storedCredential) {
+            return true;
+        }
+
+        @Override
+        public String saltOf(String storedCredential) {
+            return "salt";
+        }
+
+        @Override
+        public String hashOf(String storedCredential) {
+            return storedCredential;
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -34,6 +34,7 @@ import javax.swing.SwingWorker;
 import javax.swing.SwingUtilities;
 import javax.swing.JTable;
 import javax.swing.JTextField;
+import javax.swing.Timer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -218,23 +219,37 @@ class SwingAppPanelTest {
     }
 
     private static void awaitProjectRows(SwingAppPanel panel, int expectedRows) throws Exception {
-        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-        while (System.nanoTime() < deadline) {
-            AtomicReference<Integer> rowCount = new AtomicReference<>();
-            try {
-                SwingComponentTestSupport.onEdt(() -> rowCount.set(
-                        SwingComponentTestSupport.find(panel, "adminProjectTable", JTable.class).getRowCount()));
-            } catch (AssertionError ignored) {
-                rowCount.set(-1);
+        CountDownLatch rowsReady = new CountDownLatch(1);
+        AtomicReference<Timer> timerRef = new AtomicReference<>();
+        SwingComponentTestSupport.onEdt(() -> {
+            Timer timer = new Timer(25, event -> {
+                try {
+                    int rowCount = SwingComponentTestSupport.find(panel, "adminProjectTable", JTable.class).getRowCount();
+                    if (rowCount == expectedRows) {
+                        ((Timer) event.getSource()).stop();
+                        rowsReady.countDown();
+                    }
+                } catch (AssertionError ignored) {
+                    // Dashboard panel is installed asynchronously after admin login.
+                }
+            });
+            timer.setRepeats(true);
+            timerRef.set(timer);
+            timer.start();
+        });
+
+        boolean ready = rowsReady.await(5, TimeUnit.SECONDS);
+        SwingComponentTestSupport.onEdt(() -> {
+            Timer timer = timerRef.get();
+            if (timer != null) {
+                timer.stop();
             }
-            if (rowCount.get() == expectedRows) {
-                return;
+            if (!ready) {
+                assertEquals(
+                        expectedRows,
+                        SwingComponentTestSupport.find(panel, "adminProjectTable", JTable.class).getRowCount());
             }
-            Thread.sleep(25);
-        }
-        SwingComponentTestSupport.onEdt(() -> assertEquals(
-                expectedRows,
-                SwingComponentTestSupport.find(panel, "adminProjectTable", JTable.class).getRowCount()));
+        });
     }
 
     private static SwingControllerFixture controllers(

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.JButton;
+import javax.swing.JLabel;
 import javax.swing.JPasswordField;
 import javax.swing.SwingWorker;
 import javax.swing.SwingUtilities;
@@ -157,6 +158,59 @@ class SwingAppPanelTest {
         });
     }
 
+    @Test
+    @DisplayName("admin placeholder can return to dashboard")
+    void adminPlaceholderCanReturnToDashboard() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        var panelRef = new AtomicReference<SwingAppPanel>();
+        var workerDone = new CountDownLatch(1);
+        SwingControllerFixture controllers = controllers(
+                passwordHashing,
+                List.of(projectSnapshot(1L, "Alpha", 3, 7)),
+                user("admin", Role.ADMIN));
+
+        SwingComponentTestSupport.onEdt(() -> {
+            SwingAppPanel panel = new SwingAppPanel(
+                    controllers.authenticationController(),
+                    controllers.dashboardController(),
+                    titles::update);
+            panelRef.set(panel);
+            SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText("admin");
+            SwingComponentTestSupport.find(panel, "passwordField", JPasswordField.class).setText("submitted-password");
+            SwingComponentTestSupport.find(panel, "signInButton", JButton.class).doClick();
+            SwingWorker<?, ?> worker = loginWorker(panel);
+            worker.addPropertyChangeListener(event -> {
+                if ("state".equals(event.getPropertyName())
+                        && SwingWorker.StateValue.DONE == event.getNewValue()) {
+                    workerDone.countDown();
+                }
+            });
+            if (SwingWorker.StateValue.DONE == worker.getState()) {
+                workerDone.countDown();
+            }
+        });
+
+        assertTrue(passwordHashing.awaitMatch());
+        assertTrue(titles.awaitAdminDashboard());
+        assertTrue(workerDone.await(5, TimeUnit.SECONDS));
+        awaitProjectRows(panelRef.get(), 1);
+
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panelRef.get(), "accountManagementButton", JButton.class).doClick());
+        SwingComponentTestSupport.onEdt(() -> {
+            assertEquals(
+                    "Account management",
+                    SwingComponentTestSupport.find(panelRef.get(), "placeholderTitle", JLabel.class).getText());
+            SwingComponentTestSupport.find(panelRef.get(), "backButton", JButton.class).doClick();
+        });
+
+        awaitProjectRows(panelRef.get(), 1);
+        SwingComponentTestSupport.onEdt(() -> assertEquals(
+                "Alpha",
+                SwingComponentTestSupport.find(panelRef.get(), "adminProjectTable", JTable.class).getValueAt(0, 1)));
+    }
+
     private static SwingWorker<?, ?> loginWorker(SwingAppPanel panel) throws ReflectiveOperationException {
         Field worker = SwingAppPanel.class.getDeclaredField("loginWorker");
         worker.setAccessible(true);
@@ -167,8 +221,12 @@ class SwingAppPanelTest {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
         while (System.nanoTime() < deadline) {
             AtomicReference<Integer> rowCount = new AtomicReference<>();
-            SwingComponentTestSupport.onEdt(() -> rowCount.set(
-                    SwingComponentTestSupport.find(panel, "adminProjectTable", JTable.class).getRowCount()));
+            try {
+                SwingComponentTestSupport.onEdt(() -> rowCount.set(
+                        SwingComponentTestSupport.find(panel, "adminProjectTable", JTable.class).getRowCount()));
+            } catch (AssertionError ignored) {
+                rowCount.set(-1);
+            }
             if (rowCount.get() == expectedRows) {
                 return;
             }

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -7,23 +7,31 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
+import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository;
+import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository.DashboardProjectSnapshot;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
 import com.github.marcellokim.issuetracker.service.PasswordHashing;
+import com.github.marcellokim.issuetracker.service.PermissionPolicy;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
 import com.github.marcellokim.issuetracker.technical.SessionStore;
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.JButton;
-import javax.swing.JLabel;
 import javax.swing.JPasswordField;
 import javax.swing.SwingWorker;
 import javax.swing.SwingUtilities;
+import javax.swing.JTable;
 import javax.swing.JTextField;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,10 +49,13 @@ class SwingAppPanelTest {
         var panelRef = new AtomicReference<SwingAppPanel>();
         var workerRef = new AtomicReference<SwingWorker<?, ?>>();
         var workerDone = new CountDownLatch(1);
-        AuthenticationController controller = controller(passwordHashing, user("admin", Role.ADMIN));
+        SwingControllerFixture controllers = controllers(passwordHashing, List.of(), user("admin", Role.ADMIN));
 
         SwingComponentTestSupport.onEdt(() -> {
-            var panel = new SwingAppPanel(controller, titles::update);
+            var panel = new SwingAppPanel(
+                    controllers.authenticationController(),
+                    controllers.dashboardController(),
+                    titles::update);
             panelRef.set(panel);
             JTextField loginId = SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class);
             JPasswordField password = SwingComponentTestSupport.find(panel, "passwordField", JPasswordField.class);
@@ -83,10 +94,10 @@ class SwingAppPanelTest {
 
         SwingComponentTestSupport.onEdt(() -> {
             SwingAppPanel panel = panelRef.get();
-            JLabel title = SwingComponentTestSupport.find(panel, "placeholderTitle", JLabel.class);
-            JButton logout = SwingComponentTestSupport.find(panel, "logoutButton", JButton.class);
+            JTable projects = SwingComponentTestSupport.find(panel, "adminProjectTable", JTable.class);
+            JButton logout = SwingComponentTestSupport.find(panel, "adminLogoutButton", JButton.class);
 
-            assertEquals("Admin dashboard", title.getText());
+            assertEquals(0, projects.getRowCount());
             logout.doClick();
 
             JTextField loginId = SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class);
@@ -100,20 +111,128 @@ class SwingAppPanelTest {
         });
     }
 
+    @Test
+    @DisplayName("admin login shows dashboard data")
+    void adminLoginShowsDashboardData() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        var panelRef = new AtomicReference<SwingAppPanel>();
+        var workerDone = new CountDownLatch(1);
+        SwingControllerFixture controllers = controllers(
+                passwordHashing,
+                List.of(projectSnapshot(1L, "Alpha", 3, 7)),
+                user("admin", Role.ADMIN));
+
+        SwingComponentTestSupport.onEdt(() -> {
+            SwingAppPanel panel = new SwingAppPanel(
+                    controllers.authenticationController(),
+                    controllers.dashboardController(),
+                    titles::update);
+            panelRef.set(panel);
+            SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText("admin");
+            SwingComponentTestSupport.find(panel, "passwordField", JPasswordField.class).setText("submitted-password");
+            SwingComponentTestSupport.find(panel, "signInButton", JButton.class).doClick();
+            SwingWorker<?, ?> worker = loginWorker(panel);
+            worker.addPropertyChangeListener(event -> {
+                if ("state".equals(event.getPropertyName())
+                        && SwingWorker.StateValue.DONE == event.getNewValue()) {
+                    workerDone.countDown();
+                }
+            });
+            if (SwingWorker.StateValue.DONE == worker.getState()) {
+                workerDone.countDown();
+            }
+        });
+
+        assertTrue(passwordHashing.awaitMatch());
+        assertTrue(titles.awaitAdminDashboard());
+        assertTrue(workerDone.await(5, TimeUnit.SECONDS));
+        awaitProjectRows(panelRef.get(), 1);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable projects = SwingComponentTestSupport.find(panelRef.get(), "adminProjectTable", JTable.class);
+            assertEquals(1, projects.getRowCount());
+            assertEquals("Alpha", projects.getValueAt(0, 1));
+            assertEquals(7, projects.getValueAt(0, 3));
+        });
+    }
+
     private static SwingWorker<?, ?> loginWorker(SwingAppPanel panel) throws ReflectiveOperationException {
         Field worker = SwingAppPanel.class.getDeclaredField("loginWorker");
         worker.setAccessible(true);
         return (SwingWorker<?, ?>) worker.get(panel);
     }
 
-    private static AuthenticationController controller(PasswordHashing passwordHashing, User... users) {
+    private static void awaitProjectRows(SwingAppPanel panel, int expectedRows) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            AtomicReference<Integer> rowCount = new AtomicReference<>();
+            SwingComponentTestSupport.onEdt(() -> rowCount.set(
+                    SwingComponentTestSupport.find(panel, "adminProjectTable", JTable.class).getRowCount()));
+            if (rowCount.get() == expectedRows) {
+                return;
+            }
+            Thread.sleep(25);
+        }
+        SwingComponentTestSupport.onEdt(() -> assertEquals(
+                expectedRows,
+                SwingComponentTestSupport.find(panel, "adminProjectTable", JTable.class).getRowCount()));
+    }
+
+    private static SwingControllerFixture controllers(
+            PasswordHashing passwordHashing,
+            List<DashboardProjectSnapshot> projects,
+            User... users) {
         var repository = new InMemoryUserRepository(users);
         var service = new AuthenticationService(repository, passwordHashing, new SessionStore());
-        return new AuthenticationController(service);
+        return new SwingControllerFixture(
+                new AuthenticationController(service),
+                new DashboardController(
+                        service,
+                        new DashboardSummaryService(
+                                new FakeDashboardSummaryRepository(projects),
+                                repository,
+                                new PermissionPolicy())));
     }
 
     private static User user(String loginId, Role role) {
         return User.fromPersistence(loginId, loginId, "stored-password", role, true, NOW, NOW);
+    }
+
+    private static DashboardProjectSnapshot projectSnapshot(
+            long projectId,
+            String projectName,
+            int memberCount,
+            int visibleIssueCount) {
+        return new DashboardProjectSnapshot(
+                projectId,
+                projectName,
+                "Demo project",
+                memberCount,
+                1,
+                1,
+                1,
+                visibleIssueCount,
+                Map.of(IssueStatus.NEW, visibleIssueCount));
+    }
+
+    private record SwingControllerFixture(
+            AuthenticationController authenticationController,
+            DashboardController dashboardController) {
+    }
+
+    private record FakeDashboardSummaryRepository(
+            List<DashboardProjectSnapshot> projects) implements DashboardSummaryRepository {
+
+        @Override
+        public List<DashboardProjectSnapshot> findAllProjectSummaries() {
+            return projects;
+        }
+
+        @Override
+        public List<DashboardProjectSnapshot> findProjectSummariesByParticipant(String loginId) {
+            return List.of();
+        }
     }
 
     private static final class RecordingPasswordHashing implements PasswordHashing {


### PR DESCRIPTION
## 요약
- 관련 이슈: Closes #203
- 변경 목적: Swing UI에서 관리자 로그인 후 프로젝트 목록과 사용자 목록을 같은 dashboard 화면에서 확인할 수 있게 한다.
- 과제 요구사항 관점: JavaFX와 별개로 Swing UI도 기존 controller/service 계약을 재사용하도록 연결해, UI toolkit 교체 시 backend/application 코드 재사용 흐름을 확인한다.

## 변경 분류
- [x] 기능 개발
- [ ] 버그 수정
- [x] 테스트 보강
- [ ] 문서화
- [ ] 환경설정 / 자동화

## 검증 내역
- [x] `./gradlew check --console=plain`
- [x] `./gradlew test --tests 'com.github.marcellokim.issuetracker.ui.swing.*' --tests 'com.github.marcellokim.issuetracker.MainSmokeTest' --console=plain`
- [x] `git diff --check`
- [x] Swing 화면 확인: 관리자 dashboard 1024x768 / 800x600, 오류 상태, Account/Project placeholder 이동 및 Back 복귀
- [ ] CI 통과 확인
- 결과 요약: 로컬 build/test는 통과. GitHub Actions 기준 metadata, label, project sync, workflow policy, build/test, SonarCloud, CodeQL, 보안 분석은 통과 확인. Oracle 통합 테스트는 현재 대기 상태.

## 과제 요구사항 영향
- [x] MVC 분리 관련 변경 반영
- [ ] Persistence 관련 변경 반영
- [x] 다중 UI toolkit 영향 확인
- [ ] 통계 / 추천 기능 영향 확인
- [ ] 해당 없음

## 문서 및 증빙
- [ ] README 반영
- [ ] docs/ 반영
- [ ] 스크린샷 또는 GIF 첨부
- [x] GitHub 프로젝트 상태 업데이트
- [ ] 해당 없음

## 리뷰 포인트
- 집중해서 봐야 할 부분: Swing UI가 `DashboardController.viewProjects()` / `viewUsers()`를 통해서만 데이터를 읽고, service/repository 정책을 우회하지 않는지 확인.
- 집중해서 봐야 할 부분: dashboard loading worker가 화면 전환, placeholder 이동, logout 시 stale UI update를 만들지 않는지 확인.
- 남아 있는 위험/후속 작업: Account management와 Project management는 이번 PR에서 placeholder까지만 연결하며, 실제 CRUD 화면은 후속 이슈에서 구현한다.
- 남아 있는 위험/후속 작업: 긴 프로젝트명과 사용자명이 좁은 창에서 table cell 폭에 따라 일부 줄임표 처리될 수 있다.

## purpose
Swing 관리자 화면의 첫 진입 지점을 만들고, 관리자에게 필요한 프로젝트/사용자 현황 조회를 read-only dashboard로 제공한다.

## non-goals
- Account management / Project management CRUD 화면 구현은 제외한다.
- JavaFX UI, backend service, repository, 권한 정책 변경은 제외한다.
- Swing 일반 사용자 화면 구현은 제외한다.

## diff map
- 핵심 변경: `AdminDashboardPanel`, `AdminDashboardPresenter`, `AdminDashboardView` 추가.
- 연결 변경: `SwingAppFrame`, `SwingAppPanel`에서 `DashboardController`를 주입하고 admin 로그인 후 dashboard card를 표시.
- UI 흐름: 프로젝트/사용자 read-only table, Account/Project management placeholder 이동, Back 복귀, Logout 처리.
- 테스트: presenter, panel, admin login wiring, placeholder 복귀, smoke test 보강.

## risk / rollback
- rollback은 추가된 `AdminDashboard*` Swing classes와 `SwingAppPanel` admin dashboard wiring을 되돌리면 된다.
- 후속 관리 화면 구현 시 placeholder card는 실제 화면으로 교체하면 된다.
