### PR TITLE
feat: Swing 계정 관리 화면 구현

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountCreateRequest.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountCreateRequest.java
@@ -1,0 +1,16 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.domain.Role;
+import java.util.Objects;
+
+record AccountCreateRequest(
+        String loginId,
+        String name,
+        String password,
+        Role role
+) {
+
+    AccountCreateRequest {
+        role = Objects.requireNonNull(role, "role");
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountDialogs.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountDialogs.java
@@ -1,0 +1,16 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.util.Optional;
+
+interface AccountDialogs {
+
+    Optional<AccountCreateRequest> requestCreate(AccountManagementPanel parent);
+
+    Optional<String> requestRename(AccountManagementPanel parent, UserResult selectedUser);
+
+    Optional<Role> requestRole(AccountManagementPanel parent, UserResult selectedUser);
+
+    boolean confirmActivation(AccountManagementPanel parent, UserResult selectedUser, boolean active);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanel.java
@@ -1,0 +1,411 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.ListSelectionModel;
+import javax.swing.SwingUtilities;
+import javax.swing.table.DefaultTableModel;
+
+final class AccountManagementPanel extends JPanel implements AccountManagementView {
+
+    private static final long serialVersionUID = 1L;
+    private static final String[] USER_COLUMNS = {"Login ID", "Name", "Role", "Active"};
+    private static final int[] USER_COLUMN_WIDTHS = {120, 180, 96, 72};
+
+    private final AccountDialogs dialogs;
+    private final Consumer<AccountCreateRequest> onCreate;
+    private final BiConsumer<String, String> onRename;
+    private final BiConsumer<String, Role> onRoleChange;
+    private final Consumer<String> onActivate;
+    private final Consumer<String> onDeactivate;
+    private final DefaultTableModel userTableModel = readOnlyTableModel();
+    private final JTable userTable = table();
+    private final JLabel messageLabel = new JLabel(" ");
+    private final JButton createButton = new JButton("Create account");
+    private final JButton renameButton = new JButton("Rename");
+    private final JButton roleButton = new JButton("Change role");
+    private final JButton activateButton = new JButton("Activate");
+    private final JButton deactivateButton = new JButton("Deactivate");
+    private final List<UserResult> users = new ArrayList<>();
+
+    AccountManagementPanel(
+            UserResult user,
+            AccountDialogs dialogs,
+            Consumer<AccountCreateRequest> onCreate,
+            BiConsumer<String, String> onRename,
+            BiConsumer<String, Role> onRoleChange,
+            Consumer<String> onActivate,
+            Consumer<String> onDeactivate,
+            Runnable onBack,
+            Runnable onLogout) {
+        Objects.requireNonNull(user, "user");
+        this.dialogs = Objects.requireNonNull(dialogs, "dialogs");
+        this.onCreate = Objects.requireNonNull(onCreate, "onCreate");
+        this.onRename = Objects.requireNonNull(onRename, "onRename");
+        this.onRoleChange = Objects.requireNonNull(onRoleChange, "onRoleChange");
+        this.onActivate = Objects.requireNonNull(onActivate, "onActivate");
+        this.onDeactivate = Objects.requireNonNull(onDeactivate, "onDeactivate");
+        Objects.requireNonNull(onBack, "onBack");
+        Objects.requireNonNull(onLogout, "onLogout");
+
+        setName("accountManagementPanel");
+        setLayout(new BorderLayout(SwingStyles.SECTION_GAP, SwingStyles.SECTION_GAP));
+        setBackground(SwingStyles.BACKGROUND);
+        setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING));
+
+        add(header(user, onBack, onLogout), BorderLayout.NORTH);
+        add(tableSection(), BorderLayout.CENTER);
+        add(actions(), BorderLayout.SOUTH);
+        updateSelectionActions();
+    }
+
+    @Override
+    public void showUsers(List<UserResult> users) {
+        Objects.requireNonNull(users, "users");
+        List<UserResult> snapshot = List.copyOf(users);
+        runOnEdt(() -> {
+            String selectedLoginId = selectedUser()
+                    .map(UserResult::loginId)
+                    .orElse(null);
+            this.users.clear();
+            this.users.addAll(snapshot);
+            replaceRows(snapshot);
+            restoreSelection(selectedLoginId);
+            updateSelectionActions();
+        });
+    }
+
+    @Override
+    public void showMessage(String message, boolean error) {
+        String displayMessage = message == null || message.isBlank() ? " " : message;
+        runOnEdt(() -> {
+            messageLabel.setText(displayMessage);
+            messageLabel.setForeground(error ? SwingStyles.ERROR_TEXT : SwingStyles.MUTED_TEXT);
+        });
+    }
+
+    void setBusy(boolean busy) {
+        runOnEdt(() -> {
+            boolean enabled = !busy;
+            userTable.setEnabled(enabled);
+            createButton.setEnabled(enabled);
+            updateSelectionActions(enabled);
+        });
+    }
+
+    private JPanel header(UserResult user, Runnable onBack, Runnable onLogout) {
+        JPanel header = new JPanel(new BorderLayout(0, SwingStyles.ROW_GAP));
+        header.setBackground(SwingStyles.SURFACE);
+        header.setBorder(SwingStyles.surfaceBorder());
+
+        JPanel topRow = new JPanel(new BorderLayout(SwingStyles.SECTION_GAP, 0));
+        topRow.setOpaque(false);
+
+        JPanel titles = new JPanel();
+        titles.setOpaque(false);
+        titles.setLayout(new BoxLayout(titles, BoxLayout.Y_AXIS));
+
+        JLabel title = new JLabel("Account management");
+        title.setName("accountManagementTitle");
+        title.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyTitle(title);
+        titles.add(title);
+
+        JLabel userLabel = new JLabel(user.name() + " (" + user.role() + ")");
+        userLabel.setName("accountManagementUser");
+        userLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyMuted(userLabel);
+        titles.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+        titles.add(userLabel);
+
+        JPanel nav = new JPanel();
+        nav.setOpaque(false);
+        JButton backButton = new JButton("Back");
+        backButton.setName("accountBackButton");
+        backButton.addActionListener(event -> onBack.run());
+        nav.add(backButton);
+
+        JButton logoutButton = new JButton("Logout");
+        logoutButton.setName("accountLogoutButton");
+        logoutButton.addActionListener(event -> onLogout.run());
+        nav.add(logoutButton);
+
+        messageLabel.setName("accountManagementMessage");
+        messageLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyMuted(messageLabel);
+
+        topRow.add(titles, BorderLayout.CENTER);
+        topRow.add(nav, BorderLayout.EAST);
+        header.add(topRow, BorderLayout.CENTER);
+        header.add(messageLabel, BorderLayout.SOUTH);
+        return header;
+    }
+
+    private JPanel tableSection() {
+        JPanel section = new JPanel(new BorderLayout(0, SwingStyles.ROW_GAP));
+        section.setBackground(SwingStyles.SURFACE);
+        section.setBorder(SwingStyles.surfaceBorder());
+
+        JLabel title = new JLabel("Users");
+        SwingStyles.applySectionTitle(title);
+        section.add(title, BorderLayout.NORTH);
+        section.add(new JScrollPane(userTable), BorderLayout.CENTER);
+        return section;
+    }
+
+    private JPanel actions() {
+        JPanel panel = new JPanel();
+        panel.setBackground(SwingStyles.SURFACE);
+        panel.setBorder(SwingStyles.surfaceBorder());
+
+        createButton.setName("createAccountButton");
+        createButton.addActionListener(event -> dialogs.requestCreate(this).ifPresent(onCreate));
+        panel.add(createButton);
+
+        renameButton.setName("renameAccountButton");
+        renameButton.addActionListener(event -> selectedUser().flatMap(user -> dialogs.requestRename(this, user)
+                .map(name -> new RenameRequest(user.loginId(), name)))
+                .ifPresent(request -> onRename.accept(request.loginId(), request.name())));
+        panel.add(renameButton);
+
+        roleButton.setName("changeRoleButton");
+        roleButton.addActionListener(event -> selectedUser().flatMap(user -> dialogs.requestRole(this, user)
+                .map(role -> new RoleChangeRequest(user.loginId(), role)))
+                .ifPresent(request -> onRoleChange.accept(request.loginId(), request.role())));
+        panel.add(roleButton);
+
+        activateButton.setName("activateAccountButton");
+        activateButton.addActionListener(event -> selectedUser()
+                .filter(user -> dialogs.confirmActivation(this, user, true))
+                .ifPresent(user -> onActivate.accept(user.loginId())));
+        panel.add(activateButton);
+
+        deactivateButton.setName("deactivateAccountButton");
+        deactivateButton.addActionListener(event -> selectedUser()
+                .filter(user -> dialogs.confirmActivation(this, user, false))
+                .ifPresent(user -> onDeactivate.accept(user.loginId())));
+        panel.add(deactivateButton);
+
+        return panel;
+    }
+
+    private JTable table() {
+        JTable table = new JTable(userTableModel);
+        table.setName("accountUserTable");
+        table.setFillsViewportHeight(true);
+        table.setRowHeight(26);
+        table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        table.getTableHeader().setReorderingAllowed(false);
+        table.getSelectionModel().addListSelectionListener(event -> {
+            if (!event.getValueIsAdjusting()) {
+                updateSelectionActions();
+            }
+        });
+        applyColumnWidths(table);
+        return table;
+    }
+
+    private Optional<UserResult> selectedUser() {
+        int selectedRow = userTable.getSelectedRow();
+        if (selectedRow < 0) {
+            return Optional.empty();
+        }
+        int modelRow = userTable.convertRowIndexToModel(selectedRow);
+        if (modelRow >= users.size()) {
+            return Optional.empty();
+        }
+        return Optional.of(users.get(modelRow));
+    }
+
+    private void replaceRows(List<UserResult> users) {
+        userTableModel.setRowCount(0);
+        for (UserResult user : users) {
+            userTableModel.addRow(new Object[]{
+                    user.loginId(),
+                    user.name(),
+                    user.role().name(),
+                    user.active() ? "Yes" : "No"
+            });
+        }
+    }
+
+    private void restoreSelection(String selectedLoginId) {
+        if (selectedLoginId == null) {
+            return;
+        }
+        for (int row = 0; row < users.size(); row++) {
+            if (selectedLoginId.equals(users.get(row).loginId())) {
+                userTable.setRowSelectionInterval(row, row);
+                return;
+            }
+        }
+    }
+
+    private void updateSelectionActions() {
+        updateSelectionActions(userTable.isEnabled());
+    }
+
+    private void updateSelectionActions(boolean enabled) {
+        Optional<UserResult> selected = selectedUser();
+        boolean hasSelection = enabled && selected.isPresent();
+        boolean selectedActive = selected.map(UserResult::active).orElse(false);
+        renameButton.setEnabled(hasSelection);
+        roleButton.setEnabled(hasSelection);
+        activateButton.setEnabled(hasSelection && !selectedActive);
+        deactivateButton.setEnabled(hasSelection && selectedActive);
+    }
+
+    private static DefaultTableModel readOnlyTableModel() {
+        return new DefaultTableModel(USER_COLUMNS, 0) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return false;
+            }
+        };
+    }
+
+    private static void applyColumnWidths(JTable table) {
+        for (int index = 0; index < USER_COLUMN_WIDTHS.length; index++) {
+            table.getColumnModel().getColumn(index).setPreferredWidth(USER_COLUMN_WIDTHS[index]);
+        }
+    }
+
+    private static void runOnEdt(Runnable action) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            action.run();
+            return;
+        }
+        SwingUtilities.invokeLater(action);
+    }
+
+    private record RenameRequest(String loginId, String name) {
+    }
+
+    private record RoleChangeRequest(String loginId, Role role) {
+    }
+
+    static final class JOptionPaneAccountDialogs implements AccountDialogs {
+
+        @Override
+        public Optional<AccountCreateRequest> requestCreate(AccountManagementPanel parent) {
+            JTextField loginId = new JTextField();
+            JTextField name = new JTextField();
+            JPasswordField password = new JPasswordField();
+            JComboBox<Role> role = new JComboBox<>(Role.values());
+            JPanel form = formPanel(
+                    new JLabel("Login ID"), loginId,
+                    new JLabel("Name"), name,
+                    new JLabel("Password"), password,
+                    new JLabel("Role"), role);
+            int result = JOptionPane.showConfirmDialog(
+                    parent,
+                    form,
+                    "Create account",
+                    JOptionPane.OK_CANCEL_OPTION,
+                    JOptionPane.PLAIN_MESSAGE);
+            if (result != JOptionPane.OK_OPTION) {
+                return Optional.empty();
+            }
+            char[] passwordChars = password.getPassword();
+            try {
+                return Optional.of(new AccountCreateRequest(
+                        loginId.getText(),
+                        name.getText(),
+                        new String(passwordChars),
+                        (Role) role.getSelectedItem()));
+            } finally {
+                Arrays.fill(passwordChars, '\0');
+            }
+        }
+
+        @Override
+        public Optional<String> requestRename(AccountManagementPanel parent, UserResult selectedUser) {
+            String name = (String) JOptionPane.showInputDialog(
+                    parent,
+                    "Name",
+                    "Rename account",
+                    JOptionPane.PLAIN_MESSAGE,
+                    null,
+                    null,
+                    selectedUser.name());
+            return Optional.ofNullable(name);
+        }
+
+        @Override
+        public Optional<Role> requestRole(AccountManagementPanel parent, UserResult selectedUser) {
+            JComboBox<Role> role = new JComboBox<>(Role.values());
+            role.setSelectedItem(selectedUser.role());
+            int result = JOptionPane.showConfirmDialog(
+                    parent,
+                    role,
+                    "Change role",
+                    JOptionPane.OK_CANCEL_OPTION,
+                    JOptionPane.PLAIN_MESSAGE);
+            if (result != JOptionPane.OK_OPTION) {
+                return Optional.empty();
+            }
+            return Optional.of((Role) role.getSelectedItem());
+        }
+
+        @Override
+        public boolean confirmActivation(AccountManagementPanel parent, UserResult selectedUser, boolean active) {
+            String action = active ? "activate" : "deactivate";
+            int result = JOptionPane.showConfirmDialog(
+                    parent,
+                    "Do you want to " + action + " " + selectedUser.loginId() + "?",
+                    active ? "Activate account" : "Deactivate account",
+                    JOptionPane.OK_CANCEL_OPTION,
+                    JOptionPane.QUESTION_MESSAGE);
+            return result == JOptionPane.OK_OPTION;
+        }
+
+        private static JPanel formPanel(Object... components) {
+            JPanel panel = new JPanel(new GridBagLayout());
+            GridBagConstraints constraints = new GridBagConstraints();
+            constraints.insets = new Insets(4, 4, 4, 4);
+            constraints.fill = GridBagConstraints.HORIZONTAL;
+            constraints.weightx = 1.0;
+            for (int index = 0; index < components.length; index += 2) {
+                constraints.gridy = index / 2;
+                constraints.gridx = 0;
+                constraints.weightx = 0.0;
+                panel.add((Component) components[index], constraints);
+                constraints.gridx = 1;
+                constraints.weightx = 1.0;
+                Component field = (Component) components[index + 1];
+                field.setPreferredSize(new Dimension(220, SwingStyles.FIELD_HEIGHT));
+                panel.add(field, constraints);
+            }
+            return panel;
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanel.java
@@ -13,8 +13,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -38,11 +36,11 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
     private static final int[] USER_COLUMN_WIDTHS = {120, 180, 96, 72};
 
     private final AccountDialogs dialogs;
-    private final Consumer<AccountCreateRequest> onCreate;
-    private final BiConsumer<String, String> onRename;
-    private final BiConsumer<String, Role> onRoleChange;
-    private final Consumer<String> onActivate;
-    private final Consumer<String> onDeactivate;
+    private final PanelConsumer<AccountCreateRequest> onCreate;
+    private final PanelBiConsumer<String, String> onRename;
+    private final PanelBiConsumer<String, Role> onRoleChange;
+    private final PanelConsumer<String> onActivate;
+    private final PanelConsumer<String> onDeactivate;
     private final DefaultTableModel userTableModel = readOnlyTableModel();
     private final JTable userTable = table();
     private final JLabel messageLabel = new JLabel(" ");
@@ -56,11 +54,11 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
     AccountManagementPanel(
             UserResult user,
             AccountDialogs dialogs,
-            Consumer<AccountCreateRequest> onCreate,
-            BiConsumer<String, String> onRename,
-            BiConsumer<String, Role> onRoleChange,
-            Consumer<String> onActivate,
-            Consumer<String> onDeactivate,
+            PanelConsumer<AccountCreateRequest> onCreate,
+            PanelBiConsumer<String, String> onRename,
+            PanelBiConsumer<String, Role> onRoleChange,
+            PanelConsumer<String> onActivate,
+            PanelConsumer<String> onDeactivate,
             Runnable onBack,
             Runnable onLogout) {
         Objects.requireNonNull(user, "user");
@@ -188,31 +186,32 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
         panel.setBorder(SwingStyles.surfaceBorder());
 
         createButton.setName("createAccountButton");
-        createButton.addActionListener(event -> dialogs.requestCreate(this).ifPresent(onCreate));
+        createButton.addActionListener(event -> dialogs.requestCreate(this)
+                .ifPresent(request -> onCreate.accept(this, request)));
         panel.add(createButton);
 
         renameButton.setName("renameAccountButton");
         renameButton.addActionListener(event -> selectedUser().flatMap(user -> dialogs.requestRename(this, user)
                 .map(name -> new RenameRequest(user.loginId(), name)))
-                .ifPresent(request -> onRename.accept(request.loginId(), request.name())));
+                .ifPresent(request -> onRename.accept(this, request.loginId(), request.name())));
         panel.add(renameButton);
 
         roleButton.setName("changeRoleButton");
         roleButton.addActionListener(event -> selectedUser().flatMap(user -> dialogs.requestRole(this, user)
                 .map(role -> new RoleChangeRequest(user.loginId(), role)))
-                .ifPresent(request -> onRoleChange.accept(request.loginId(), request.role())));
+                .ifPresent(request -> onRoleChange.accept(this, request.loginId(), request.role())));
         panel.add(roleButton);
 
         activateButton.setName("activateAccountButton");
         activateButton.addActionListener(event -> selectedUser()
                 .filter(user -> dialogs.confirmActivation(this, user, true))
-                .ifPresent(user -> onActivate.accept(user.loginId())));
+                .ifPresent(user -> onActivate.accept(this, user.loginId())));
         panel.add(activateButton);
 
         deactivateButton.setName("deactivateAccountButton");
         deactivateButton.addActionListener(event -> selectedUser()
                 .filter(user -> dialogs.confirmActivation(this, user, false))
-                .ifPresent(user -> onDeactivate.accept(user.loginId())));
+                .ifPresent(user -> onDeactivate.accept(this, user.loginId())));
         panel.add(deactivateButton);
 
         return panel;
@@ -314,6 +313,18 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
     }
 
     private record RoleChangeRequest(String loginId, Role role) {
+    }
+
+    @FunctionalInterface
+    interface PanelConsumer<T> {
+
+        void accept(AccountManagementPanel panel, T value);
+    }
+
+    @FunctionalInterface
+    interface PanelBiConsumer<T, U> {
+
+        void accept(AccountManagementPanel panel, T first, U second);
     }
 
     static final class JOptionPaneAccountDialogs implements AccountDialogs {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanel.java
@@ -240,7 +240,7 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
             return Optional.empty();
         }
         int modelRow = userTable.convertRowIndexToModel(selectedRow);
-        if (modelRow >= users.size()) {
+        if (modelRow < 0 || modelRow >= users.size()) {
             return Optional.empty();
         }
         return Optional.of(users.get(modelRow));
@@ -264,7 +264,10 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
         }
         for (int row = 0; row < users.size(); row++) {
             if (selectedLoginId.equals(users.get(row).loginId())) {
-                userTable.setRowSelectionInterval(row, row);
+                int viewRow = userTable.convertRowIndexToView(row);
+                if (viewRow >= 0) {
+                    userTable.setRowSelectionInterval(viewRow, viewRow);
+                }
                 return;
             }
         }
@@ -388,7 +391,7 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
             return result == JOptionPane.OK_OPTION;
         }
 
-        private static JPanel formPanel(Object... components) {
+        private static JPanel formPanel(Component... components) {
             JPanel panel = new JPanel(new GridBagLayout());
             GridBagConstraints constraints = new GridBagConstraints();
             constraints.insets = new Insets(4, 4, 4, 4);
@@ -398,10 +401,10 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
                 constraints.gridy = index / 2;
                 constraints.gridx = 0;
                 constraints.weightx = 0.0;
-                panel.add((Component) components[index], constraints);
+                panel.add(components[index], constraints);
                 constraints.gridx = 1;
                 constraints.weightx = 1.0;
-                Component field = (Component) components[index + 1];
+                Component field = components[index + 1];
                 field.setPreferredSize(new Dimension(220, SwingStyles.FIELD_HEIGHT));
                 panel.add(field, constraints);
             }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanel.java
@@ -323,7 +323,7 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
             JTextField loginId = new JTextField();
             JTextField name = new JTextField();
             JPasswordField password = new JPasswordField();
-            JComboBox<Role> role = new JComboBox<>(Role.values());
+            JComboBox<Role> role = new JComboBox<>(manageableRoles());
             JPanel form = formPanel(
                     new JLabel("Login ID"), loginId,
                     new JLabel("Name"), name,
@@ -365,7 +365,7 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
 
         @Override
         public Optional<Role> requestRole(AccountManagementPanel parent, UserResult selectedUser) {
-            JComboBox<Role> role = new JComboBox<>(Role.values());
+            JComboBox<Role> role = new JComboBox<>(manageableRoles());
             role.setSelectedItem(selectedUser.role());
             int result = JOptionPane.showConfirmDialog(
                     parent,
@@ -409,6 +409,12 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
                 panel.add(field, constraints);
             }
             return panel;
+        }
+
+        private static Role[] manageableRoles() {
+            return Arrays.stream(Role.values())
+                    .filter(role -> role != Role.ADMIN)
+                    .toArray(Role[]::new);
         }
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPresenter.java
@@ -1,0 +1,62 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.controller.AccountController;
+import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.domain.Role;
+import java.util.Objects;
+
+final class AccountManagementPresenter {
+
+    private final DashboardController dashboardController;
+    private final AccountController accountController;
+    private final AccountManagementView view;
+
+    AccountManagementPresenter(
+            DashboardController dashboardController,
+            AccountController accountController,
+            AccountManagementView view) {
+        this.dashboardController = Objects.requireNonNull(dashboardController, "dashboardController");
+        this.accountController = Objects.requireNonNull(accountController, "accountController");
+        this.view = Objects.requireNonNull(view, "view");
+    }
+
+    void loadUsers() {
+        run(" ", () -> {
+        });
+    }
+
+    void createAccount(AccountCreateRequest request) {
+        Objects.requireNonNull(request, "request");
+        run("Account created: " + request.loginId(), () -> accountController.createAccount(
+                request.loginId(),
+                request.name(),
+                request.password(),
+                request.role()));
+    }
+
+    void renameAccount(String loginId, String name) {
+        run("Account renamed: " + loginId, () -> accountController.renameAccount(loginId, name));
+    }
+
+    void changeAccountRole(String loginId, Role role) {
+        run("Account role changed: " + loginId, () -> accountController.changeAccountRole(loginId, role));
+    }
+
+    void activateAccount(String loginId) {
+        run("Account activated: " + loginId, () -> accountController.activateAccount(loginId));
+    }
+
+    void deactivateAccount(String loginId) {
+        run("Account deactivated: " + loginId, () -> accountController.deactivateAccount(loginId));
+    }
+
+    private void run(String successMessage, Runnable action) {
+        try {
+            action.run();
+            view.showUsers(dashboardController.viewUsers());
+            view.showMessage(successMessage, false);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementView.java
@@ -1,0 +1,11 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.util.List;
+
+interface AccountManagementView {
+
+    void showUsers(List<UserResult> users);
+
+    void showMessage(String message, boolean error);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
@@ -1,6 +1,7 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
 import com.github.marcellokim.issuetracker.config.ApplicationContext;
+import com.github.marcellokim.issuetracker.controller.AccountController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
 import java.util.Objects;
@@ -16,12 +17,16 @@ public final class SwingAppFrame extends JFrame {
     public SwingAppFrame(ApplicationContext context) {
         this(
                 Objects.requireNonNull(context, "context").authenticationController(),
-                context.dashboardController());
+                context.dashboardController(),
+                context.accountController());
     }
 
-    SwingAppFrame(AuthenticationController authenticationController, DashboardController dashboardController) {
+    SwingAppFrame(
+            AuthenticationController authenticationController,
+            DashboardController dashboardController,
+            AccountController accountController) {
         super("Issue Tracker");
-        this.appPanel = new SwingAppPanel(authenticationController, dashboardController, this::setTitle);
+        this.appPanel = new SwingAppPanel(authenticationController, dashboardController, accountController, this::setTitle);
         setContentPane(appPanel);
         setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         setSize(SwingStyles.WINDOW_SIZE);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -1,5 +1,6 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
+import com.github.marcellokim.issuetracker.controller.AccountController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
 import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
@@ -26,6 +27,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     private final transient AuthenticationController authenticationController;
     private final transient DashboardController dashboardController;
+    private final transient AccountController accountController;
     private final transient Consumer<String> titleUpdater;
     private final CardLayout cardLayout = new CardLayout();
     private final LoginPanel loginPanel = new LoginPanel();
@@ -33,13 +35,16 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private final JPanel projectListCard = new JPanel(new BorderLayout());
     private transient SwingWorker<Void, Void> loginWorker;
     private final transient AtomicReference<DashboardLoadWorker> dashboardWorker = new AtomicReference<>();
+    private final transient AtomicReference<AccountManagementWorker> accountWorker = new AtomicReference<>();
 
     SwingAppPanel(
             AuthenticationController authenticationController,
             DashboardController dashboardController,
+            AccountController accountController,
             Consumer<String> titleUpdater) {
         this.authenticationController = Objects.requireNonNull(authenticationController, "authenticationController");
         this.dashboardController = Objects.requireNonNull(dashboardController, "dashboardController");
+        this.accountController = Objects.requireNonNull(accountController, "accountController");
         this.titleUpdater = Objects.requireNonNull(titleUpdater, "titleUpdater");
 
         setName("appCards");
@@ -57,6 +62,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     public void showLogin() {
         runOnEdtAndWait(() -> {
             cancelDashboardWorker();
+            cancelAccountWorker();
             titleUpdater.accept("Issue Tracker");
             loginPanel.showMessage(" ", false);
             loginPanel.clearPassword();
@@ -70,10 +76,11 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         Objects.requireNonNull(user, "user");
         SwingUtilities.invokeLater(() -> {
             cancelDashboardWorker();
+            cancelAccountWorker();
             titleUpdater.accept("Admin dashboard");
             AdminDashboardPanel panel = new AdminDashboardPanel(
                     user,
-                    () -> showAdminPlaceholder("Account management", user),
+                    () -> showAccountManagement(user),
                     () -> showAdminPlaceholder("Project management", user),
                     this::logout);
             adminDashboardCard.removeAll();
@@ -90,6 +97,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         Objects.requireNonNull(user, "user");
         runOnEdtAndWait(() -> {
             cancelDashboardWorker();
+            cancelAccountWorker();
             titleUpdater.accept("Project list");
             showPlaceholder(projectListCard, "Project list", user);
             cardLayout.show(this, PROJECT_LIST_CARD);
@@ -98,6 +106,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     void logout() {
         cancelDashboardWorker();
+        cancelAccountWorker();
         authenticationController.logout();
         showLogin();
     }
@@ -161,9 +170,36 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private void showAdminPlaceholder(String destination, UserResult user) {
         SwingUtilities.invokeLater(() -> {
             cancelDashboardWorker();
+            cancelAccountWorker();
             titleUpdater.accept(destination);
             showPlaceholder(adminDashboardCard, destination, user, () -> showAdminDashboard(user));
             cardLayout.show(this, ADMIN_DASHBOARD_CARD);
+        });
+    }
+
+    private void showAccountManagement(UserResult user) {
+        SwingUtilities.invokeLater(() -> {
+            cancelDashboardWorker();
+            cancelAccountWorker();
+            titleUpdater.accept("Account management");
+            AtomicReference<AccountManagementPanel> panelRef = new AtomicReference<>();
+            AccountManagementPanel panel = new AccountManagementPanel(
+                    user,
+                    new AccountManagementPanel.JOptionPaneAccountDialogs(),
+                    request -> startAccountTask(panelRef.get(), presenter -> presenter.createAccount(request)),
+                    (loginId, name) -> startAccountTask(panelRef.get(), presenter -> presenter.renameAccount(loginId, name)),
+                    (loginId, role) -> startAccountTask(panelRef.get(), presenter -> presenter.changeAccountRole(loginId, role)),
+                    loginId -> startAccountTask(panelRef.get(), presenter -> presenter.activateAccount(loginId)),
+                    loginId -> startAccountTask(panelRef.get(), presenter -> presenter.deactivateAccount(loginId)),
+                    () -> showAdminDashboard(user),
+                    this::logout);
+            panelRef.set(panel);
+            adminDashboardCard.removeAll();
+            adminDashboardCard.add(panel, BorderLayout.CENTER);
+            adminDashboardCard.revalidate();
+            adminDashboardCard.repaint();
+            cardLayout.show(this, ADMIN_DASHBOARD_CARD);
+            startAccountTask(panel, AccountManagementPresenter::loadUsers);
         });
     }
 
@@ -175,6 +211,23 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     private void cancelDashboardWorker() {
         DashboardLoadWorker worker = dashboardWorker.getAndSet(null);
+        if (worker != null && !worker.isDone()) {
+            worker.cancel(true);
+        }
+    }
+
+    private void startAccountTask(AccountManagementPanel panel, AccountTask task) {
+        Objects.requireNonNull(panel, "panel");
+        Objects.requireNonNull(task, "task");
+        cancelAccountWorker();
+        panel.setBusy(true);
+        AccountManagementWorker worker = new AccountManagementWorker(panel, task);
+        accountWorker.set(worker);
+        worker.execute();
+    }
+
+    private void cancelAccountWorker() {
+        AccountManagementWorker worker = accountWorker.getAndSet(null);
         if (worker != null && !worker.isDone()) {
             worker.cancel(true);
         }
@@ -242,6 +295,81 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         protected void done() {
             dashboardWorker.compareAndSet(this, null);
         }
+    }
+
+    private final class AccountManagementWorker extends SwingWorker<Void, Void> {
+
+        private final AccountManagementPanel panel;
+        private final AccountTask task;
+
+        private AccountManagementWorker(AccountManagementPanel panel, AccountTask task) {
+            this.panel = Objects.requireNonNull(panel, "panel");
+            this.task = Objects.requireNonNull(task, "task");
+        }
+
+        @Override
+        protected Void doInBackground() {
+            AccountManagementPresenter presenter = new AccountManagementPresenter(
+                    dashboardController,
+                    accountController,
+                    new CurrentAccountManagementView(panel, this));
+            task.run(presenter);
+            return null;
+        }
+
+        @Override
+        protected void done() {
+            if (!accountWorker.compareAndSet(this, null)) {
+                return;
+            }
+            panel.setBusy(false);
+            if (isCancelled()) {
+                return;
+            }
+            try {
+                get();
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                panel.showMessage("Account management was interrupted. Please try again.", true);
+            } catch (ExecutionException exception) {
+                panel.showMessage("Account management failed. Please try again.", true);
+            }
+        }
+    }
+
+    private final class CurrentAccountManagementView implements AccountManagementView {
+
+        private final AccountManagementPanel delegate;
+        private final AccountManagementWorker worker;
+
+        private CurrentAccountManagementView(AccountManagementPanel delegate, AccountManagementWorker worker) {
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
+            this.worker = Objects.requireNonNull(worker, "worker");
+        }
+
+        @Override
+        public void showUsers(List<UserResult> users) {
+            if (isCurrent()) {
+                delegate.showUsers(users);
+            }
+        }
+
+        @Override
+        public void showMessage(String message, boolean error) {
+            if (isCurrent()) {
+                delegate.showMessage(message, error);
+            }
+        }
+
+        private boolean isCurrent() {
+            return accountWorker.get() == worker && !worker.isCancelled();
+        }
+    }
+
+    @FunctionalInterface
+    private interface AccountTask {
+
+        void run(AccountManagementPresenter presenter);
     }
 
     private final class CurrentDashboardView implements AdminDashboardView {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -182,18 +182,18 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelDashboardWorker();
             cancelAccountWorker();
             titleUpdater.accept("Account management");
-            AtomicReference<AccountManagementPanel> panelRef = new AtomicReference<>();
             AccountManagementPanel panel = new AccountManagementPanel(
                     user,
                     new AccountManagementPanel.JOptionPaneAccountDialogs(),
-                    request -> startAccountTask(panelRef.get(), presenter -> presenter.createAccount(request)),
-                    (loginId, name) -> startAccountTask(panelRef.get(), presenter -> presenter.renameAccount(loginId, name)),
-                    (loginId, role) -> startAccountTask(panelRef.get(), presenter -> presenter.changeAccountRole(loginId, role)),
-                    loginId -> startAccountTask(panelRef.get(), presenter -> presenter.activateAccount(loginId)),
-                    loginId -> startAccountTask(panelRef.get(), presenter -> presenter.deactivateAccount(loginId)),
+                    (panelRef, request) -> startAccountTask(panelRef, presenter -> presenter.createAccount(request)),
+                    (panelRef, loginId, name) ->
+                            startAccountTask(panelRef, presenter -> presenter.renameAccount(loginId, name)),
+                    (panelRef, loginId, role) ->
+                            startAccountTask(panelRef, presenter -> presenter.changeAccountRole(loginId, role)),
+                    (panelRef, loginId) -> startAccountTask(panelRef, presenter -> presenter.activateAccount(loginId)),
+                    (panelRef, loginId) -> startAccountTask(panelRef, presenter -> presenter.deactivateAccount(loginId)),
                     () -> showAdminDashboard(user),
                     this::logout);
-            panelRef.set(panel);
             adminDashboardCard.removeAll();
             adminDashboardCard.add(panel, BorderLayout.CENTER);
             adminDashboardCard.revalidate();

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanelTest.java
@@ -1,0 +1,145 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JTable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing account management panel")
+class AccountManagementPanelTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("renders users and selection-sensitive actions")
+    void rendersUsersAndSelectionActions() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            AccountManagementPanel panel = panel(new FixedAccountDialogs());
+            panel.showUsers(List.of(
+                    userResult("dev1", Role.DEV, true),
+                    userResult("tester1", Role.TESTER, false)));
+
+            JTable table = SwingComponentTestSupport.find(panel, "accountUserTable", JTable.class);
+            JButton rename = SwingComponentTestSupport.find(panel, "renameAccountButton", JButton.class);
+            JButton activate = SwingComponentTestSupport.find(panel, "activateAccountButton", JButton.class);
+            JButton deactivate = SwingComponentTestSupport.find(panel, "deactivateAccountButton", JButton.class);
+
+            assertEquals(2, table.getRowCount());
+            assertEquals("dev1", table.getValueAt(0, 0));
+            assertEquals("Yes", table.getValueAt(0, 3));
+            assertEquals(false, rename.isEnabled());
+
+            table.setRowSelectionInterval(1, 1);
+
+            assertEquals(true, rename.isEnabled());
+            assertEquals(true, activate.isEnabled());
+            assertEquals(false, deactivate.isEnabled());
+        });
+    }
+
+    @Test
+    @DisplayName("uses dialogs and selected row to publish account actions")
+    void publishesAccountActions() throws Exception {
+        var createRef = new AtomicReference<AccountCreateRequest>();
+        var renameRef = new AtomicReference<String>();
+        var roleRef = new AtomicReference<Role>();
+        var activateRef = new AtomicReference<String>();
+        var deactivateRef = new AtomicReference<String>();
+        var backClicks = new AtomicInteger();
+        var logoutClicks = new AtomicInteger();
+        FixedAccountDialogs dialogs = new FixedAccountDialogs();
+
+        SwingComponentTestSupport.onEdt(() -> {
+            AccountManagementPanel panel = new AccountManagementPanel(
+                    userResult("admin", Role.ADMIN, true),
+                    dialogs,
+                    createRef::set,
+                    (loginId, name) -> renameRef.set(loginId + ":" + name),
+                    (loginId, role) -> roleRef.set(role),
+                    activateRef::set,
+                    deactivateRef::set,
+                    backClicks::incrementAndGet,
+                    logoutClicks::incrementAndGet);
+            panel.showUsers(List.of(userResult("dev1", Role.DEV, true)));
+            JTable table = SwingComponentTestSupport.find(panel, "accountUserTable", JTable.class);
+            table.setRowSelectionInterval(0, 0);
+
+            SwingComponentTestSupport.find(panel, "createAccountButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "renameAccountButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "changeRoleButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "deactivateAccountButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "accountBackButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "accountLogoutButton", JButton.class).doClick();
+
+            panel.showUsers(List.of(userResult("tester1", Role.TESTER, false)));
+            table.setRowSelectionInterval(0, 0);
+            SwingComponentTestSupport.find(panel, "activateAccountButton", JButton.class).doClick();
+        });
+
+        assertEquals(new AccountCreateRequest("newdev", "New Dev", "password", Role.DEV), createRef.get());
+        assertEquals("dev1:Renamed User", renameRef.get());
+        assertEquals(Role.TESTER, roleRef.get());
+        assertEquals("dev1", deactivateRef.get());
+        assertEquals("tester1", activateRef.get());
+        assertEquals(1, backClicks.get());
+        assertEquals(1, logoutClicks.get());
+    }
+
+    private static AccountManagementPanel panel(FixedAccountDialogs dialogs) {
+        return new AccountManagementPanel(
+                userResult("admin", Role.ADMIN, true),
+                dialogs,
+                ignored -> {
+                },
+                (loginId, name) -> {
+                },
+                (loginId, role) -> {
+                },
+                ignored -> {
+                },
+                ignored -> {
+                },
+                () -> {
+                },
+                () -> {
+                });
+    }
+
+    private static UserResult userResult(String loginId, Role role, boolean active) {
+        return UserResult.from(User.fromPersistence(loginId, loginId, "stored-password", role, active, NOW, NOW));
+    }
+
+    private static final class FixedAccountDialogs implements AccountDialogs {
+
+        @Override
+        public Optional<AccountCreateRequest> requestCreate(AccountManagementPanel parent) {
+            return Optional.of(new AccountCreateRequest("newdev", "New Dev", "password", Role.DEV));
+        }
+
+        @Override
+        public Optional<String> requestRename(AccountManagementPanel parent, UserResult selectedUser) {
+            return Optional.of("Renamed User");
+        }
+
+        @Override
+        public Optional<Role> requestRole(AccountManagementPanel parent, UserResult selectedUser) {
+            return Optional.of(Role.TESTER);
+        }
+
+        @Override
+        public boolean confirmActivation(AccountManagementPanel parent, UserResult selectedUser, boolean active) {
+            return true;
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanelTest.java
@@ -64,11 +64,11 @@ class AccountManagementPanelTest {
             AccountManagementPanel panel = new AccountManagementPanel(
                     userResult("admin", Role.ADMIN, true),
                     dialogs,
-                    createRef::set,
-                    (loginId, name) -> renameRef.set(loginId + ":" + name),
-                    (loginId, role) -> roleRef.set(role),
-                    activateRef::set,
-                    deactivateRef::set,
+                    (source, request) -> createRef.set(request),
+                    (source, loginId, name) -> renameRef.set(loginId + ":" + name),
+                    (source, loginId, role) -> roleRef.set(role),
+                    (source, loginId) -> activateRef.set(loginId),
+                    (source, loginId) -> deactivateRef.set(loginId),
                     backClicks::incrementAndGet,
                     logoutClicks::incrementAndGet);
             panel.showUsers(List.of(userResult("dev1", Role.DEV, true)));
@@ -100,15 +100,15 @@ class AccountManagementPanelTest {
         return new AccountManagementPanel(
                 userResult("admin", Role.ADMIN, true),
                 dialogs,
-                ignored -> {
+                (panel, ignored) -> {
                 },
-                (loginId, name) -> {
+                (panel, loginId, name) -> {
                 },
-                (loginId, role) -> {
+                (panel, loginId, role) -> {
                 },
-                ignored -> {
+                (panel, ignored) -> {
                 },
-                ignored -> {
+                (panel, ignored) -> {
                 },
                 () -> {
                 },

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPresenterTest.java
@@ -1,0 +1,218 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.controller.AccountController;
+import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository;
+import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository.DashboardProjectSnapshot;
+import com.github.marcellokim.issuetracker.service.AccountService;
+import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
+import com.github.marcellokim.issuetracker.service.PasswordHashing;
+import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.technical.SessionStore;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing account management presenter")
+class AccountManagementPresenterTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("loads users through dashboard controller")
+    void loadsUsers() {
+        ControllerFixture fixture = controllers(
+                user("admin", Role.ADMIN, true),
+                user("dev1", Role.DEV, true));
+        RecordingAccountManagementView view = new RecordingAccountManagementView();
+        AccountManagementPresenter presenter = new AccountManagementPresenter(
+                fixture.dashboardController(),
+                fixture.accountController(),
+                view);
+
+        presenter.loadUsers();
+
+        assertEquals(List.of("admin", "dev1"), view.loginIds());
+        assertEquals(" ", view.message());
+    }
+
+    @Test
+    @DisplayName("creates account and refreshes users after success")
+    void createsAccountAndRefreshesUsers() {
+        ControllerFixture fixture = controllers(user("admin", Role.ADMIN, true));
+        RecordingAccountManagementView view = new RecordingAccountManagementView();
+        AccountManagementPresenter presenter = new AccountManagementPresenter(
+                fixture.dashboardController(),
+                fixture.accountController(),
+                view);
+
+        presenter.createAccount(new AccountCreateRequest("tester1", "Tester One", "password", Role.TESTER));
+
+        assertEquals(List.of("admin", "tester1"), view.loginIds());
+        assertEquals("Account created: tester1", view.message());
+    }
+
+    @Test
+    @DisplayName("renames, changes role, deactivates, and activates an account through controller")
+    void updatesAccountLifecycle() {
+        ControllerFixture fixture = controllers(
+                user("admin", Role.ADMIN, true),
+                user("dev1", Role.DEV, true));
+        RecordingAccountManagementView view = new RecordingAccountManagementView();
+        AccountManagementPresenter presenter = new AccountManagementPresenter(
+                fixture.dashboardController(),
+                fixture.accountController(),
+                view);
+
+        presenter.renameAccount("dev1", "Developer One");
+        presenter.changeAccountRole("dev1", Role.TESTER);
+        presenter.deactivateAccount("dev1");
+        presenter.activateAccount("dev1");
+
+        UserResult updated = view.users().stream()
+                .filter(user -> user.loginId().equals("dev1"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("Developer One", updated.name());
+        assertEquals(Role.TESTER, updated.role());
+        assertTrue(updated.active());
+        assertEquals("Account activated: dev1", view.message());
+    }
+
+    @Test
+    @DisplayName("shows controller errors without replacing the current user list")
+    void showsControllerError() {
+        ControllerFixture fixture = controllers(
+                user("admin", Role.ADMIN, true),
+                user("dev1", Role.DEV, true));
+        RecordingAccountManagementView view = new RecordingAccountManagementView();
+        AccountManagementPresenter presenter = new AccountManagementPresenter(
+                fixture.dashboardController(),
+                fixture.accountController(),
+                view);
+        presenter.loadUsers();
+
+        presenter.renameAccount("dev1", "dev1");
+
+        assertEquals(List.of("admin", "dev1"), view.loginIds());
+        assertEquals("name is same with current name.", view.message());
+    }
+
+    private static ControllerFixture controllers(User... users) {
+        InMemoryUserRepository userRepository = new InMemoryUserRepository(users);
+        AuthenticationService authentication = new AuthenticationService(
+                userRepository,
+                new AcceptingPasswordHashing(),
+                new SessionStore());
+        authentication.login("admin", "password");
+        PermissionPolicy permissionPolicy = new PermissionPolicy();
+        return new ControllerFixture(
+                new DashboardController(
+                        authentication,
+                        new DashboardSummaryService(
+                                new EmptyDashboardSummaryRepository(),
+                                userRepository,
+                                permissionPolicy)),
+                new AccountController(
+                        authentication,
+                        new AccountService(
+                                permissionPolicy,
+                                userRepository,
+                                new InMemoryProjectRepository(),
+                                new InMemoryIssueRepository(),
+                                new AcceptingPasswordHashing(),
+                                () -> NOW)));
+    }
+
+    private static User user(String loginId, Role role, boolean active) {
+        return User.fromPersistence(loginId, loginId, "stored-password", role, active, NOW, NOW);
+    }
+
+    private record ControllerFixture(
+            DashboardController dashboardController,
+            AccountController accountController) {
+    }
+
+    private static final class RecordingAccountManagementView implements AccountManagementView {
+
+        private List<UserResult> users = List.of();
+        private String message = " ";
+
+        @Override
+        public void showUsers(List<UserResult> users) {
+            this.users = List.copyOf(users);
+            this.message = " ";
+        }
+
+        @Override
+        public void showMessage(String message, boolean error) {
+            this.message = message;
+        }
+
+        private List<UserResult> users() {
+            return users;
+        }
+
+        private List<String> loginIds() {
+            return users.stream()
+                    .map(UserResult::loginId)
+                    .toList();
+        }
+
+        private String message() {
+            return message;
+        }
+    }
+
+    private static final class EmptyDashboardSummaryRepository implements DashboardSummaryRepository {
+
+        @Override
+        public List<DashboardProjectSnapshot> findAllProjectSummaries() {
+            return List.of();
+        }
+
+        @Override
+        public List<DashboardProjectSnapshot> findProjectSummariesByParticipant(String loginId) {
+            return List.of();
+        }
+    }
+
+    private static final class AcceptingPasswordHashing implements PasswordHashing {
+
+        @Override
+        public String hash(String password) {
+            return "hashed-" + password;
+        }
+
+        @Override
+        public boolean matches(String password, String storedCredential) {
+            return true;
+        }
+
+        @Override
+        public boolean isHashed(String storedCredential) {
+            return true;
+        }
+
+        @Override
+        public String saltOf(String storedCredential) {
+            return "salt";
+        }
+
+        @Override
+        public String hashOf(String storedCredential) {
+            return storedCredential;
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.marcellokim.issuetracker.controller.AccountController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
@@ -13,10 +14,13 @@ import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.User;
 import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository;
 import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository.DashboardProjectSnapshot;
+import com.github.marcellokim.issuetracker.service.AccountService;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
 import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
 import com.github.marcellokim.issuetracker.service.PasswordHashing;
 import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
 import com.github.marcellokim.issuetracker.technical.SessionStore;
 import java.lang.reflect.Field;
@@ -57,6 +61,7 @@ class SwingAppPanelTest {
             var panel = new SwingAppPanel(
                     controllers.authenticationController(),
                     controllers.dashboardController(),
+                    controllers.accountController(),
                     titles::update);
             panelRef.set(panel);
             JTextField loginId = SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class);
@@ -129,6 +134,7 @@ class SwingAppPanelTest {
             SwingAppPanel panel = new SwingAppPanel(
                     controllers.authenticationController(),
                     controllers.dashboardController(),
+                    controllers.accountController(),
                     titles::update);
             panelRef.set(panel);
             SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText("admin");
@@ -175,6 +181,62 @@ class SwingAppPanelTest {
             SwingAppPanel panel = new SwingAppPanel(
                     controllers.authenticationController(),
                     controllers.dashboardController(),
+                    controllers.accountController(),
+                    titles::update);
+            panelRef.set(panel);
+            SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText("admin");
+            SwingComponentTestSupport.find(panel, "passwordField", JPasswordField.class).setText("submitted-password");
+            SwingComponentTestSupport.find(panel, "signInButton", JButton.class).doClick();
+            SwingWorker<?, ?> worker = loginWorker(panel);
+            worker.addPropertyChangeListener(event -> {
+                if ("state".equals(event.getPropertyName())
+                        && SwingWorker.StateValue.DONE == event.getNewValue()) {
+                    workerDone.countDown();
+                }
+            });
+            if (SwingWorker.StateValue.DONE == worker.getState()) {
+                workerDone.countDown();
+            }
+        });
+
+        assertTrue(passwordHashing.awaitMatch());
+        assertTrue(titles.awaitAdminDashboard());
+        assertTrue(workerDone.await(5, TimeUnit.SECONDS));
+        awaitProjectRows(panelRef.get(), 1);
+
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panelRef.get(), "projectManagementButton", JButton.class).doClick());
+        SwingComponentTestSupport.onEdt(() -> {
+            assertEquals(
+                    "Project management",
+                    SwingComponentTestSupport.find(panelRef.get(), "placeholderTitle", JLabel.class).getText());
+            SwingComponentTestSupport.find(panelRef.get(), "backButton", JButton.class).doClick();
+        });
+
+        awaitProjectRows(panelRef.get(), 1);
+        SwingComponentTestSupport.onEdt(() -> assertEquals(
+                "Alpha",
+                SwingComponentTestSupport.find(panelRef.get(), "adminProjectTable", JTable.class).getValueAt(0, 1)));
+    }
+
+    @Test
+    @DisplayName("admin account management shows user table")
+    void adminAccountManagementShowsUserTable() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        var panelRef = new AtomicReference<SwingAppPanel>();
+        var workerDone = new CountDownLatch(1);
+        SwingControllerFixture controllers = controllers(
+                passwordHashing,
+                List.of(projectSnapshot(1L, "Alpha", 3, 7)),
+                user("admin", Role.ADMIN),
+                user("dev1", Role.DEV));
+
+        SwingComponentTestSupport.onEdt(() -> {
+            SwingAppPanel panel = new SwingAppPanel(
+                    controllers.authenticationController(),
+                    controllers.dashboardController(),
+                    controllers.accountController(),
                     titles::update);
             panelRef.set(panel);
             SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText("admin");
@@ -199,17 +261,16 @@ class SwingAppPanelTest {
 
         SwingComponentTestSupport.onEdt(() ->
                 SwingComponentTestSupport.find(panelRef.get(), "accountManagementButton", JButton.class).doClick());
+        awaitAccountRows(panelRef.get(), 2);
+
         SwingComponentTestSupport.onEdt(() -> {
             assertEquals(
                     "Account management",
-                    SwingComponentTestSupport.find(panelRef.get(), "placeholderTitle", JLabel.class).getText());
-            SwingComponentTestSupport.find(panelRef.get(), "backButton", JButton.class).doClick();
+                    SwingComponentTestSupport.find(panelRef.get(), "accountManagementTitle", JLabel.class).getText());
+            JTable users = SwingComponentTestSupport.find(panelRef.get(), "accountUserTable", JTable.class);
+            assertEquals("admin", users.getValueAt(0, 0));
+            assertEquals("dev1", users.getValueAt(1, 0));
         });
-
-        awaitProjectRows(panelRef.get(), 1);
-        SwingComponentTestSupport.onEdt(() -> assertEquals(
-                "Alpha",
-                SwingComponentTestSupport.find(panelRef.get(), "adminProjectTable", JTable.class).getValueAt(0, 1)));
     }
 
     private static SwingWorker<?, ?> loginWorker(SwingAppPanel panel) throws ReflectiveOperationException {
@@ -219,12 +280,20 @@ class SwingAppPanelTest {
     }
 
     private static void awaitProjectRows(SwingAppPanel panel, int expectedRows) throws Exception {
+        awaitRows(panel, "adminProjectTable", expectedRows);
+    }
+
+    private static void awaitAccountRows(SwingAppPanel panel, int expectedRows) throws Exception {
+        awaitRows(panel, "accountUserTable", expectedRows);
+    }
+
+    private static void awaitRows(SwingAppPanel panel, String tableName, int expectedRows) throws Exception {
         CountDownLatch rowsReady = new CountDownLatch(1);
         AtomicReference<Timer> timerRef = new AtomicReference<>();
         SwingComponentTestSupport.onEdt(() -> {
             Timer timer = new Timer(25, event -> {
                 try {
-                    int rowCount = SwingComponentTestSupport.find(panel, "adminProjectTable", JTable.class).getRowCount();
+                    int rowCount = SwingComponentTestSupport.find(panel, tableName, JTable.class).getRowCount();
                     if (rowCount == expectedRows) {
                         ((Timer) event.getSource()).stop();
                         rowsReady.countDown();
@@ -247,7 +316,7 @@ class SwingAppPanelTest {
             if (!ready) {
                 assertEquals(
                         expectedRows,
-                        SwingComponentTestSupport.find(panel, "adminProjectTable", JTable.class).getRowCount());
+                        SwingComponentTestSupport.find(panel, tableName, JTable.class).getRowCount());
             }
         });
     }
@@ -258,6 +327,7 @@ class SwingAppPanelTest {
             User... users) {
         var repository = new InMemoryUserRepository(users);
         var service = new AuthenticationService(repository, passwordHashing, new SessionStore());
+        PermissionPolicy permissionPolicy = new PermissionPolicy();
         return new SwingControllerFixture(
                 new AuthenticationController(service),
                 new DashboardController(
@@ -265,7 +335,16 @@ class SwingAppPanelTest {
                         new DashboardSummaryService(
                                 new FakeDashboardSummaryRepository(projects),
                                 repository,
-                                new PermissionPolicy())));
+                                permissionPolicy)),
+                new AccountController(
+                        service,
+                        new AccountService(
+                                permissionPolicy,
+                                repository,
+                                new InMemoryProjectRepository(),
+                                new InMemoryIssueRepository(),
+                                passwordHashing,
+                                () -> NOW)));
     }
 
     private static User user(String loginId, Role role) {
@@ -291,7 +370,8 @@ class SwingAppPanelTest {
 
     private record SwingControllerFixture(
             AuthenticationController authenticationController,
-            DashboardController dashboardController) {
+            DashboardController dashboardController,
+            AccountController accountController) {
     }
 
     private record FakeDashboardSummaryRepository(


### PR DESCRIPTION
## 요약
- 관련 이슈: Closes #204
- 변경 목적: Swing 관리자 화면에서 계정 목록 조회와 계정 생성/수정/활성화/비활성화 action을 수행할 수 있게 한다.
- 과제 요구사항 관점: Swing UI가 JavaFX와 별개로 같은 controller/service 계약을 재사용하는 흐름을 확장한다.

## 변경 분류
- [x] 기능 개발
- [ ] 버그 수정
- [x] 테스트 보강
- [ ] 문서화
- [ ] 환경설정 / 자동화

## 검증 내역
- [x] `./gradlew check --console=plain`
- [x] `./gradlew test --tests 'com.github.marcellokim.issuetracker.ui.swing.*' --tests 'com.github.marcellokim.issuetracker.MainSmokeTest' --console=plain`
- [x] `git diff --check`
- [x] Swing visual QA: account management 1024x768, 800x600 selected error state offscreen render 확인
- [ ] CI 통과 확인
- 결과 요약: 로컬 build/test는 통과. Oracle 통합 테스트는 로컬 환경에서 skip됨.

## 과제 요구사항 영향
- [x] MVC 분리 관련 변경 반영
- [ ] Persistence 관련 변경 반영
- [x] 다중 UI toolkit 영향 확인
- [ ] 통계 / 추천 기능 영향 확인
- [ ] 해당 없음

## 문서 및 증빙
- [ ] README 반영
- [ ] docs/ 반영
- [x] 스크린샷 또는 GIF 확인
- [ ] GitHub 프로젝트 상태 업데이트
- [ ] 해당 없음

## 리뷰 포인트
- 집중해서 봐야 할 부분: Swing UI가 `DashboardController.viewUsers()`와 `AccountController`만 호출하고 service/repository 정책을 우회하지 않는지 확인.
- 집중해서 봐야 할 부분: 계정 생성/수정/활성화/비활성화 작업이 SwingWorker를 통해 EDT 밖에서 실행되는지 확인.
- 남아 있는 위험/후속 작업: 관리자 project management 화면은 #205에서 별도 구현한다.

## purpose
Swing 관리자 계정 관리 화면을 구현해 admin이 사용자 목록을 보고 계정 작업을 수행할 수 있게 한다.

## non-goals
- JavaFX 화면 수정은 제외한다.
- 계정 정책 재구현, service/repository 직접 호출, persistence 변경은 제외한다.
- 프로젝트 관리 화면 구현은 제외한다.

## diff map
- 핵심 변경: `AccountManagementPanel`, `AccountManagementPresenter`, `AccountManagementView`, dialog/request 타입 추가.
- 연결 변경: `SwingAppFrame`, `SwingAppPanel`에서 `AccountController`를 주입하고 dashboard Account button을 실제 화면으로 연결.
- 테스트: presenter, panel, app navigation/wiring 테스트 추가.

## risk / rollback
- 좁은 창에서는 긴 login id가 table cell에서 줄임표 처리될 수 있다.
- rollback은 추가된 `AccountManagement*` Swing classes와 `SwingAppPanel` account-management wiring을 되돌리면 된다.