### PR TITLE
feat: Swing 프로젝트 관리 화면 구현

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanel.java
@@ -3,19 +3,12 @@ package com.github.marcellokim.issuetracker.ui.swing;
 import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.service.UserResult;
 import java.awt.BorderLayout;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
@@ -34,6 +27,13 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
     private static final long serialVersionUID = 1L;
     private static final String[] USER_COLUMNS = {"Login ID", "Name", "Role", "Active"};
     private static final int[] USER_COLUMN_WIDTHS = {120, 180, 96, 72};
+    private static final SwingPanelSections.HeaderLabels HEADER_LABELS = new SwingPanelSections.HeaderLabels(
+            "Account management",
+            "accountManagementTitle",
+            "accountManagementUser",
+            "accountManagementMessage",
+            "accountBackButton",
+            "accountLogoutButton");
 
     private final AccountDialogs dialogs;
     private final PanelConsumer<AccountCreateRequest> onCreate;
@@ -121,51 +121,11 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
     }
 
     private JPanel header(UserResult user, Runnable onBack, Runnable onLogout) {
-        JPanel header = new JPanel(new BorderLayout(0, SwingStyles.ROW_GAP));
-        header.setBackground(SwingStyles.SURFACE);
-        header.setBorder(SwingStyles.surfaceBorder());
-
-        JPanel topRow = new JPanel(new BorderLayout(SwingStyles.SECTION_GAP, 0));
-        topRow.setOpaque(false);
-
-        JPanel titles = new JPanel();
-        titles.setOpaque(false);
-        titles.setLayout(new BoxLayout(titles, BoxLayout.Y_AXIS));
-
-        JLabel title = new JLabel("Account management");
-        title.setName("accountManagementTitle");
-        title.setAlignmentX(Component.LEFT_ALIGNMENT);
-        SwingStyles.applyTitle(title);
-        titles.add(title);
-
-        JLabel userLabel = new JLabel(user.name() + " (" + user.role() + ")");
-        userLabel.setName("accountManagementUser");
-        userLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
-        SwingStyles.applyMuted(userLabel);
-        titles.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
-        titles.add(userLabel);
-
-        JPanel nav = new JPanel();
-        nav.setOpaque(false);
-        JButton backButton = new JButton("Back");
-        backButton.setName("accountBackButton");
-        backButton.addActionListener(event -> onBack.run());
-        nav.add(backButton);
-
-        JButton logoutButton = new JButton("Logout");
-        logoutButton.setName("accountLogoutButton");
-        logoutButton.addActionListener(event -> onLogout.run());
-        nav.add(logoutButton);
-
-        messageLabel.setName("accountManagementMessage");
-        messageLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
-        SwingStyles.applyMuted(messageLabel);
-
-        topRow.add(titles, BorderLayout.CENTER);
-        topRow.add(nav, BorderLayout.EAST);
-        header.add(topRow, BorderLayout.CENTER);
-        header.add(messageLabel, BorderLayout.SOUTH);
-        return header;
+        return SwingPanelSections.managementHeader(
+                HEADER_LABELS,
+                user,
+                messageLabel,
+                new SwingPanelSections.NavigationActions(onBack, onLogout));
     }
 
     private JPanel tableSection() {
@@ -335,7 +295,8 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
             JTextField name = new JTextField();
             JPasswordField password = new JPasswordField();
             JComboBox<Role> role = new JComboBox<>(manageableRoles());
-            JPanel form = formPanel(
+            JPanel form = SwingPanelSections.formPanel(
+                    220,
                     new JLabel("Login ID"), loginId,
                     new JLabel("Name"), name,
                     new JLabel("Password"), password,
@@ -400,26 +361,6 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
                     JOptionPane.OK_CANCEL_OPTION,
                     JOptionPane.QUESTION_MESSAGE);
             return result == JOptionPane.OK_OPTION;
-        }
-
-        private static JPanel formPanel(Component... components) {
-            JPanel panel = new JPanel(new GridBagLayout());
-            GridBagConstraints constraints = new GridBagConstraints();
-            constraints.insets = new Insets(4, 4, 4, 4);
-            constraints.fill = GridBagConstraints.HORIZONTAL;
-            constraints.weightx = 1.0;
-            for (int index = 0; index < components.length; index += 2) {
-                constraints.gridy = index / 2;
-                constraints.gridx = 0;
-                constraints.weightx = 0.0;
-                panel.add(components[index], constraints);
-                constraints.gridx = 1;
-                constraints.weightx = 1.0;
-                Component field = components[index + 1];
-                field.setPreferredSize(new Dimension(220, SwingStyles.FIELD_HEIGHT));
-                panel.add(field, constraints);
-            }
-            return panel;
         }
 
         private static Role[] manageableRoles() {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectCreateRequest.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectCreateRequest.java
@@ -1,0 +1,7 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+record ProjectCreateRequest(
+        String name,
+        String description
+) {
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectDialogs.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectDialogs.java
@@ -1,0 +1,15 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import java.util.Optional;
+
+interface ProjectDialogs {
+
+    Optional<ProjectCreateRequest> requestCreate(ProjectManagementPanel parent);
+
+    Optional<String> requestRename(ProjectManagementPanel parent, DashboardProjectSummary selectedProject);
+
+    Optional<String> requestDescription(ProjectManagementPanel parent, DashboardProjectSummary selectedProject);
+
+    boolean confirmDelete(ProjectManagementPanel parent, DashboardProjectSummary selectedProject);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanel.java
@@ -38,6 +38,7 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
     private static final Color SELECTION_BACKGROUND = new Color(219, 234, 254);
     private static final Color EVEN_ROW_BACKGROUND = Color.WHITE;
     private static final Color ODD_ROW_BACKGROUND = new Color(248, 250, 252);
+    private static final String DEFAULT_ERROR_MESSAGE = "Project management failed. Please try again.";
 
     private final ProjectDialogs dialogs;
     private final PanelConsumer<ProjectCreateRequest> onCreate;
@@ -108,7 +109,9 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
 
     @Override
     public void showMessage(String message, boolean error) {
-        String displayMessage = message == null || message.isBlank() ? " " : message;
+        String displayMessage = message == null || message.isBlank()
+                ? (error ? DEFAULT_ERROR_MESSAGE : " ")
+                : message;
         runOnEdt(() -> {
             messageLabel.setText(displayMessage);
             messageLabel.setForeground(error ? SwingStyles.ERROR_TEXT : SwingStyles.MUTED_TEXT);
@@ -421,7 +424,10 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
             return result == JOptionPane.OK_OPTION;
         }
 
-        private static JPanel formPanel(Component... components) {
+        static JPanel formPanel(Component... components) {
+            if (components.length % 2 != 0) {
+                throw new IllegalArgumentException("Form components must be label-field pairs.");
+            }
             JPanel panel = new JPanel(new GridBagLayout());
             GridBagConstraints constraints = new GridBagConstraints();
             constraints.insets = new Insets(4, 4, 4, 4);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanel.java
@@ -171,7 +171,10 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
         deleteButton.setName("deleteProjectButton");
         deleteButton.addActionListener(event -> selectedProject()
                 .filter(project -> dialogs.confirmDelete(this, project))
-                .ifPresent(project -> actions.onDelete().accept(this, project.projectId())));
+                .ifPresent(project -> actions.onDelete().accept(
+                        this,
+                        project.projectId(),
+                        project.projectName())));
         panel.add(deleteButton);
 
         return panel;
@@ -317,7 +320,7 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
             PanelConsumer<Long> onOpenDetail,
             PanelBiConsumer<Long, String> onRename,
             PanelBiConsumer<Long, String> onDescriptionChange,
-            PanelConsumer<Long> onDelete,
+            PanelBiConsumer<Long, String> onDelete,
             Runnable onBack,
             Runnable onLogout) {
 

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanel.java
@@ -1,0 +1,444 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.ListSelectionModel;
+import javax.swing.SwingUtilities;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+
+final class ProjectManagementPanel extends JPanel implements ProjectManagementView {
+
+    private static final long serialVersionUID = 1L;
+    private static final String[] PROJECT_COLUMNS = {"ID", "Project", "Description", "Members", "Issues"};
+    private static final int[] PROJECT_COLUMN_WIDTHS = {72, 180, 280, 88, 88};
+    private static final Color SELECTION_BACKGROUND = new Color(219, 234, 254);
+    private static final Color EVEN_ROW_BACKGROUND = Color.WHITE;
+    private static final Color ODD_ROW_BACKGROUND = new Color(248, 250, 252);
+
+    private final ProjectDialogs dialogs;
+    private final PanelConsumer<ProjectCreateRequest> onCreate;
+    private final PanelConsumer<Long> onOpenDetail;
+    private final PanelBiConsumer<Long, String> onRename;
+    private final PanelBiConsumer<Long, String> onDescriptionChange;
+    private final PanelConsumer<Long> onDelete;
+    private final DefaultTableModel projectTableModel = readOnlyTableModel();
+    private final JTable projectTable = table();
+    private final JLabel messageLabel = new JLabel(" ");
+    private final JButton createButton = new JButton("Create project");
+    private final JButton openButton = new JButton("Open detail");
+    private final JButton renameButton = new JButton("Rename");
+    private final JButton descriptionButton = new JButton("Change description");
+    private final JButton deleteButton = new JButton("Delete");
+    private final List<DashboardProjectSummary> projects = new ArrayList<>();
+
+    ProjectManagementPanel(
+            UserResult user,
+            ProjectDialogs dialogs,
+            PanelConsumer<ProjectCreateRequest> onCreate,
+            PanelConsumer<Long> onOpenDetail,
+            PanelBiConsumer<Long, String> onRename,
+            PanelBiConsumer<Long, String> onDescriptionChange,
+            PanelConsumer<Long> onDelete,
+            Runnable onBack,
+            Runnable onLogout) {
+        Objects.requireNonNull(user, "user");
+        this.dialogs = Objects.requireNonNull(dialogs, "dialogs");
+        this.onCreate = Objects.requireNonNull(onCreate, "onCreate");
+        this.onOpenDetail = Objects.requireNonNull(onOpenDetail, "onOpenDetail");
+        this.onRename = Objects.requireNonNull(onRename, "onRename");
+        this.onDescriptionChange = Objects.requireNonNull(onDescriptionChange, "onDescriptionChange");
+        this.onDelete = Objects.requireNonNull(onDelete, "onDelete");
+        Objects.requireNonNull(onBack, "onBack");
+        Objects.requireNonNull(onLogout, "onLogout");
+
+        setName("projectManagementPanel");
+        setLayout(new BorderLayout(SwingStyles.SECTION_GAP, SwingStyles.SECTION_GAP));
+        setBackground(SwingStyles.BACKGROUND);
+        setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING));
+
+        add(header(user, onBack, onLogout), BorderLayout.NORTH);
+        add(tableSection(), BorderLayout.CENTER);
+        add(actions(), BorderLayout.SOUTH);
+        updateSelectionActions();
+    }
+
+    @Override
+    public void showProjects(List<DashboardProjectSummary> projects) {
+        Objects.requireNonNull(projects, "projects");
+        List<DashboardProjectSummary> snapshot = List.copyOf(projects);
+        runOnEdt(() -> {
+            Long selectedProjectId = selectedProject()
+                    .map(DashboardProjectSummary::projectId)
+                    .orElse(null);
+            this.projects.clear();
+            this.projects.addAll(snapshot);
+            replaceRows(snapshot);
+            restoreSelection(selectedProjectId);
+            updateSelectionActions();
+        });
+    }
+
+    @Override
+    public void showMessage(String message, boolean error) {
+        String displayMessage = message == null || message.isBlank() ? " " : message;
+        runOnEdt(() -> {
+            messageLabel.setText(displayMessage);
+            messageLabel.setForeground(error ? SwingStyles.ERROR_TEXT : SwingStyles.MUTED_TEXT);
+        });
+    }
+
+    void setBusy(boolean busy) {
+        runOnEdt(() -> {
+            boolean enabled = !busy;
+            projectTable.setEnabled(enabled);
+            createButton.setEnabled(enabled);
+            updateSelectionActions(enabled);
+        });
+    }
+
+    private JPanel header(UserResult user, Runnable onBack, Runnable onLogout) {
+        JPanel header = new JPanel(new BorderLayout(0, SwingStyles.ROW_GAP));
+        header.setBackground(SwingStyles.SURFACE);
+        header.setBorder(SwingStyles.surfaceBorder());
+
+        JPanel topRow = new JPanel(new BorderLayout(SwingStyles.SECTION_GAP, 0));
+        topRow.setOpaque(false);
+
+        JPanel titles = new JPanel();
+        titles.setOpaque(false);
+        titles.setLayout(new BoxLayout(titles, BoxLayout.Y_AXIS));
+
+        JLabel title = new JLabel("Project management");
+        title.setName("projectManagementTitle");
+        title.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyTitle(title);
+        titles.add(title);
+
+        JLabel userLabel = new JLabel(user.name() + " (" + user.role() + ")");
+        userLabel.setName("projectManagementUser");
+        userLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyMuted(userLabel);
+        titles.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+        titles.add(userLabel);
+
+        JPanel nav = new JPanel();
+        nav.setOpaque(false);
+        JButton backButton = new JButton("Back");
+        backButton.setName("projectManagementBackButton");
+        backButton.addActionListener(event -> onBack.run());
+        nav.add(backButton);
+
+        JButton logoutButton = new JButton("Logout");
+        logoutButton.setName("projectManagementLogoutButton");
+        logoutButton.addActionListener(event -> onLogout.run());
+        nav.add(logoutButton);
+
+        messageLabel.setName("projectManagementMessage");
+        messageLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyMuted(messageLabel);
+
+        topRow.add(titles, BorderLayout.CENTER);
+        topRow.add(nav, BorderLayout.EAST);
+        header.add(topRow, BorderLayout.CENTER);
+        header.add(messageLabel, BorderLayout.SOUTH);
+        return header;
+    }
+
+    private JPanel tableSection() {
+        JPanel section = new JPanel(new BorderLayout(0, SwingStyles.ROW_GAP));
+        section.setBackground(SwingStyles.SURFACE);
+        section.setBorder(SwingStyles.surfaceBorder());
+
+        JLabel title = new JLabel("Projects");
+        SwingStyles.applySectionTitle(title);
+        section.add(title, BorderLayout.NORTH);
+        JScrollPane scrollPane = new JScrollPane(projectTable);
+        scrollPane.setColumnHeaderView(projectTable.getTableHeader());
+        section.add(scrollPane, BorderLayout.CENTER);
+        return section;
+    }
+
+    private JPanel actions() {
+        JPanel panel = new JPanel();
+        panel.setBackground(SwingStyles.SURFACE);
+        panel.setBorder(SwingStyles.surfaceBorder());
+
+        createButton.setName("createProjectButton");
+        createButton.addActionListener(event -> dialogs.requestCreate(this)
+                .ifPresent(request -> onCreate.accept(this, request)));
+        panel.add(createButton);
+
+        openButton.setName("openProjectDetailButton");
+        openButton.addActionListener(event -> selectedProject()
+                .ifPresent(project -> onOpenDetail.accept(this, project.projectId())));
+        panel.add(openButton);
+
+        renameButton.setName("renameProjectButton");
+        renameButton.addActionListener(event -> selectedProject().flatMap(project -> dialogs.requestRename(this, project)
+                .map(name -> new RenameRequest(project.projectId(), name)))
+                .ifPresent(request -> onRename.accept(this, request.projectId(), request.name())));
+        panel.add(renameButton);
+
+        descriptionButton.setName("changeProjectDescriptionButton");
+        descriptionButton.addActionListener(event -> selectedProject()
+                .flatMap(project -> dialogs.requestDescription(this, project)
+                        .map(description -> new DescriptionRequest(project.projectId(), description)))
+                .ifPresent(request -> onDescriptionChange.accept(
+                        this,
+                        request.projectId(),
+                        request.description())));
+        panel.add(descriptionButton);
+
+        deleteButton.setName("deleteProjectButton");
+        deleteButton.addActionListener(event -> selectedProject()
+                .filter(project -> dialogs.confirmDelete(this, project))
+                .ifPresent(project -> onDelete.accept(this, project.projectId())));
+        panel.add(deleteButton);
+
+        return panel;
+    }
+
+    private JTable table() {
+        JTable table = new JTable(projectTableModel) {
+            @Override
+            public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
+                Component component = super.prepareRenderer(renderer, row, column);
+                component.setForeground(SwingStyles.BODY_TEXT);
+                if (isRowSelected(row)) {
+                    component.setBackground(SELECTION_BACKGROUND);
+                } else {
+                    component.setBackground(row % 2 == 0 ? EVEN_ROW_BACKGROUND : ODD_ROW_BACKGROUND);
+                }
+                return component;
+            }
+        };
+        table.setName("projectManagementTable");
+        table.setFillsViewportHeight(true);
+        table.setRowHeight(26);
+        table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        table.setSelectionBackground(SELECTION_BACKGROUND);
+        table.setSelectionForeground(SwingStyles.BODY_TEXT);
+        table.getTableHeader().setReorderingAllowed(false);
+        table.getSelectionModel().addListSelectionListener(event -> {
+            if (!event.getValueIsAdjusting()) {
+                updateSelectionActions();
+            }
+        });
+        table.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent event) {
+                if (event.getClickCount() == 2 && table.getSelectedRow() >= 0 && table.isEnabled()) {
+                    selectedProject().ifPresent(project ->
+                            onOpenDetail.accept(ProjectManagementPanel.this, project.projectId()));
+                }
+            }
+        });
+        applyColumnWidths(table);
+        return table;
+    }
+
+    private Optional<DashboardProjectSummary> selectedProject() {
+        int selectedRow = projectTable.getSelectedRow();
+        if (selectedRow < 0) {
+            return Optional.empty();
+        }
+        int modelRow = projectTable.convertRowIndexToModel(selectedRow);
+        if (modelRow < 0 || modelRow >= projects.size()) {
+            return Optional.empty();
+        }
+        return Optional.of(projects.get(modelRow));
+    }
+
+    private void replaceRows(List<DashboardProjectSummary> projects) {
+        projectTableModel.setRowCount(0);
+        for (DashboardProjectSummary project : projects) {
+            projectTableModel.addRow(new Object[]{
+                    project.projectId(),
+                    project.projectName(),
+                    project.projectDescription(),
+                    project.memberCount(),
+                    project.visibleIssueCount()
+            });
+        }
+    }
+
+    private void restoreSelection(Long selectedProjectId) {
+        if (selectedProjectId == null) {
+            return;
+        }
+        for (int row = 0; row < projects.size(); row++) {
+            if (selectedProjectId == projects.get(row).projectId()) {
+                int viewRow = projectTable.convertRowIndexToView(row);
+                if (viewRow >= 0) {
+                    projectTable.setRowSelectionInterval(viewRow, viewRow);
+                }
+                return;
+            }
+        }
+    }
+
+    private void updateSelectionActions() {
+        updateSelectionActions(projectTable.isEnabled());
+    }
+
+    private void updateSelectionActions(boolean enabled) {
+        boolean hasSelection = enabled && selectedProject().isPresent();
+        openButton.setEnabled(hasSelection);
+        renameButton.setEnabled(hasSelection);
+        descriptionButton.setEnabled(hasSelection);
+        deleteButton.setEnabled(hasSelection);
+    }
+
+    private void applyColumnWidths(JTable table) {
+        if (table.getColumnCount() != PROJECT_COLUMN_WIDTHS.length) {
+            return;
+        }
+        for (int index = 0; index < PROJECT_COLUMN_WIDTHS.length; index++) {
+            table.getColumnModel().getColumn(index).setPreferredWidth(PROJECT_COLUMN_WIDTHS[index]);
+        }
+    }
+
+    private static DefaultTableModel readOnlyTableModel() {
+        return new DefaultTableModel(PROJECT_COLUMNS, 0) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return false;
+            }
+        };
+    }
+
+    private static void runOnEdt(Runnable action) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            action.run();
+            return;
+        }
+        SwingUtilities.invokeLater(action);
+    }
+
+    private record RenameRequest(long projectId, String name) {
+    }
+
+    private record DescriptionRequest(long projectId, String description) {
+    }
+
+    @FunctionalInterface
+    interface PanelConsumer<T> {
+
+        void accept(ProjectManagementPanel panel, T value);
+    }
+
+    @FunctionalInterface
+    interface PanelBiConsumer<T, U> {
+
+        void accept(ProjectManagementPanel panel, T first, U second);
+    }
+
+    static final class JOptionPaneProjectDialogs implements ProjectDialogs {
+
+        @Override
+        public Optional<ProjectCreateRequest> requestCreate(ProjectManagementPanel parent) {
+            JTextField name = new JTextField();
+            JTextField description = new JTextField();
+            JPanel form = formPanel(
+                    new JLabel("Name"), name,
+                    new JLabel("Description"), description);
+            int result = JOptionPane.showConfirmDialog(
+                    parent,
+                    form,
+                    "Create project",
+                    JOptionPane.OK_CANCEL_OPTION,
+                    JOptionPane.PLAIN_MESSAGE);
+            if (result != JOptionPane.OK_OPTION) {
+                return Optional.empty();
+            }
+            return Optional.of(new ProjectCreateRequest(name.getText(), description.getText()));
+        }
+
+        @Override
+        public Optional<String> requestRename(ProjectManagementPanel parent, DashboardProjectSummary selectedProject) {
+            String name = (String) JOptionPane.showInputDialog(
+                    parent,
+                    "Name",
+                    "Rename project",
+                    JOptionPane.PLAIN_MESSAGE,
+                    null,
+                    null,
+                    selectedProject.projectName());
+            return Optional.ofNullable(name);
+        }
+
+        @Override
+        public Optional<String> requestDescription(
+                ProjectManagementPanel parent,
+                DashboardProjectSummary selectedProject) {
+            String description = (String) JOptionPane.showInputDialog(
+                    parent,
+                    "Description",
+                    "Change project description",
+                    JOptionPane.PLAIN_MESSAGE,
+                    null,
+                    null,
+                    selectedProject.projectDescription());
+            return Optional.ofNullable(description);
+        }
+
+        @Override
+        public boolean confirmDelete(ProjectManagementPanel parent, DashboardProjectSummary selectedProject) {
+            int result = JOptionPane.showConfirmDialog(
+                    parent,
+                    "Delete project \"" + selectedProject.projectName() + "\"?",
+                    "Delete project",
+                    JOptionPane.OK_CANCEL_OPTION,
+                    JOptionPane.WARNING_MESSAGE);
+            return result == JOptionPane.OK_OPTION;
+        }
+
+        private static JPanel formPanel(Component... components) {
+            JPanel panel = new JPanel(new GridBagLayout());
+            GridBagConstraints constraints = new GridBagConstraints();
+            constraints.insets = new Insets(4, 4, 4, 4);
+            constraints.fill = GridBagConstraints.HORIZONTAL;
+            constraints.weightx = 1.0;
+            for (int index = 0; index < components.length; index += 2) {
+                constraints.gridy = index / 2;
+                constraints.gridx = 0;
+                constraints.weightx = 0.0;
+                panel.add(components[index], constraints);
+                constraints.gridx = 1;
+                constraints.weightx = 1.0;
+                Component field = components[index + 1];
+                field.setPreferredSize(new Dimension(260, SwingStyles.FIELD_HEIGHT));
+                panel.add(field, constraints);
+            }
+            return panel;
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanel.java
@@ -5,10 +5,6 @@ import com.github.marcellokim.issuetracker.service.UserResult;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
@@ -16,8 +12,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -33,19 +27,23 @@ import javax.swing.table.TableCellRenderer;
 final class ProjectManagementPanel extends JPanel implements ProjectManagementView {
 
     private static final long serialVersionUID = 1L;
-    private static final String[] PROJECT_COLUMNS = {"ID", "Project", "Description", "Members", "Issues"};
+    private static final String DESCRIPTION_TEXT = "Description";
+    private static final String[] PROJECT_COLUMNS = {"ID", "Project", DESCRIPTION_TEXT, "Members", "Issues"};
     private static final int[] PROJECT_COLUMN_WIDTHS = {72, 180, 280, 88, 88};
     private static final Color SELECTION_BACKGROUND = new Color(219, 234, 254);
     private static final Color EVEN_ROW_BACKGROUND = Color.WHITE;
     private static final Color ODD_ROW_BACKGROUND = new Color(248, 250, 252);
     private static final String DEFAULT_ERROR_MESSAGE = "Project management failed. Please try again.";
+    private static final SwingPanelSections.HeaderLabels HEADER_LABELS = new SwingPanelSections.HeaderLabels(
+            "Project management",
+            "projectManagementTitle",
+            "projectManagementUser",
+            "projectManagementMessage",
+            "projectManagementBackButton",
+            "projectManagementLogoutButton");
 
-    private final ProjectDialogs dialogs;
-    private final PanelConsumer<ProjectCreateRequest> onCreate;
-    private final PanelConsumer<Long> onOpenDetail;
-    private final PanelBiConsumer<Long, String> onRename;
-    private final PanelBiConsumer<Long, String> onDescriptionChange;
-    private final PanelConsumer<Long> onDelete;
+    private final transient ProjectDialogs dialogs;
+    private final transient ProjectManagementActions actions;
     private final DefaultTableModel projectTableModel = readOnlyTableModel();
     private final JTable projectTable = table();
     private final JLabel messageLabel = new JLabel(" ");
@@ -59,22 +57,10 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
     ProjectManagementPanel(
             UserResult user,
             ProjectDialogs dialogs,
-            PanelConsumer<ProjectCreateRequest> onCreate,
-            PanelConsumer<Long> onOpenDetail,
-            PanelBiConsumer<Long, String> onRename,
-            PanelBiConsumer<Long, String> onDescriptionChange,
-            PanelConsumer<Long> onDelete,
-            Runnable onBack,
-            Runnable onLogout) {
+            ProjectManagementActions actions) {
         Objects.requireNonNull(user, "user");
         this.dialogs = Objects.requireNonNull(dialogs, "dialogs");
-        this.onCreate = Objects.requireNonNull(onCreate, "onCreate");
-        this.onOpenDetail = Objects.requireNonNull(onOpenDetail, "onOpenDetail");
-        this.onRename = Objects.requireNonNull(onRename, "onRename");
-        this.onDescriptionChange = Objects.requireNonNull(onDescriptionChange, "onDescriptionChange");
-        this.onDelete = Objects.requireNonNull(onDelete, "onDelete");
-        Objects.requireNonNull(onBack, "onBack");
-        Objects.requireNonNull(onLogout, "onLogout");
+        this.actions = Objects.requireNonNull(actions, "actions");
 
         setName("projectManagementPanel");
         setLayout(new BorderLayout(SwingStyles.SECTION_GAP, SwingStyles.SECTION_GAP));
@@ -85,7 +71,7 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
                 SwingStyles.OUTER_PADDING,
                 SwingStyles.OUTER_PADDING));
 
-        add(header(user, onBack, onLogout), BorderLayout.NORTH);
+        add(header(user), BorderLayout.NORTH);
         add(tableSection(), BorderLayout.CENTER);
         add(actions(), BorderLayout.SOUTH);
         updateSelectionActions();
@@ -109,11 +95,13 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
 
     @Override
     public void showMessage(String message, boolean error) {
-        String displayMessage = message == null || message.isBlank()
-                ? (error ? DEFAULT_ERROR_MESSAGE : " ")
-                : message;
+        String displayMessage = message;
+        if (displayMessage == null || displayMessage.isBlank()) {
+            displayMessage = error ? DEFAULT_ERROR_MESSAGE : " ";
+        }
+        String text = displayMessage;
         runOnEdt(() -> {
-            messageLabel.setText(displayMessage);
+            messageLabel.setText(text);
             messageLabel.setForeground(error ? SwingStyles.ERROR_TEXT : SwingStyles.MUTED_TEXT);
         });
     }
@@ -127,52 +115,12 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
         });
     }
 
-    private JPanel header(UserResult user, Runnable onBack, Runnable onLogout) {
-        JPanel header = new JPanel(new BorderLayout(0, SwingStyles.ROW_GAP));
-        header.setBackground(SwingStyles.SURFACE);
-        header.setBorder(SwingStyles.surfaceBorder());
-
-        JPanel topRow = new JPanel(new BorderLayout(SwingStyles.SECTION_GAP, 0));
-        topRow.setOpaque(false);
-
-        JPanel titles = new JPanel();
-        titles.setOpaque(false);
-        titles.setLayout(new BoxLayout(titles, BoxLayout.Y_AXIS));
-
-        JLabel title = new JLabel("Project management");
-        title.setName("projectManagementTitle");
-        title.setAlignmentX(Component.LEFT_ALIGNMENT);
-        SwingStyles.applyTitle(title);
-        titles.add(title);
-
-        JLabel userLabel = new JLabel(user.name() + " (" + user.role() + ")");
-        userLabel.setName("projectManagementUser");
-        userLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
-        SwingStyles.applyMuted(userLabel);
-        titles.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
-        titles.add(userLabel);
-
-        JPanel nav = new JPanel();
-        nav.setOpaque(false);
-        JButton backButton = new JButton("Back");
-        backButton.setName("projectManagementBackButton");
-        backButton.addActionListener(event -> onBack.run());
-        nav.add(backButton);
-
-        JButton logoutButton = new JButton("Logout");
-        logoutButton.setName("projectManagementLogoutButton");
-        logoutButton.addActionListener(event -> onLogout.run());
-        nav.add(logoutButton);
-
-        messageLabel.setName("projectManagementMessage");
-        messageLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
-        SwingStyles.applyMuted(messageLabel);
-
-        topRow.add(titles, BorderLayout.CENTER);
-        topRow.add(nav, BorderLayout.EAST);
-        header.add(topRow, BorderLayout.CENTER);
-        header.add(messageLabel, BorderLayout.SOUTH);
-        return header;
+    private JPanel header(UserResult user) {
+        return SwingPanelSections.managementHeader(
+                HEADER_LABELS,
+                user,
+                messageLabel,
+                new SwingPanelSections.NavigationActions(actions.onBack(), actions.onLogout()));
     }
 
     private JPanel tableSection() {
@@ -196,25 +144,25 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
 
         createButton.setName("createProjectButton");
         createButton.addActionListener(event -> dialogs.requestCreate(this)
-                .ifPresent(request -> onCreate.accept(this, request)));
+                .ifPresent(request -> actions.onCreate().accept(this, request)));
         panel.add(createButton);
 
         openButton.setName("openProjectDetailButton");
         openButton.addActionListener(event -> selectedProject()
-                .ifPresent(project -> onOpenDetail.accept(this, project.projectId())));
+                .ifPresent(project -> actions.onOpenDetail().accept(this, project.projectId())));
         panel.add(openButton);
 
         renameButton.setName("renameProjectButton");
         renameButton.addActionListener(event -> selectedProject().flatMap(project -> dialogs.requestRename(this, project)
                 .map(name -> new RenameRequest(project.projectId(), name)))
-                .ifPresent(request -> onRename.accept(this, request.projectId(), request.name())));
+                .ifPresent(request -> actions.onRename().accept(this, request.projectId(), request.name())));
         panel.add(renameButton);
 
         descriptionButton.setName("changeProjectDescriptionButton");
         descriptionButton.addActionListener(event -> selectedProject()
                 .flatMap(project -> dialogs.requestDescription(this, project)
                         .map(description -> new DescriptionRequest(project.projectId(), description)))
-                .ifPresent(request -> onDescriptionChange.accept(
+                .ifPresent(request -> actions.onDescriptionChange().accept(
                         this,
                         request.projectId(),
                         request.description())));
@@ -223,7 +171,7 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
         deleteButton.setName("deleteProjectButton");
         deleteButton.addActionListener(event -> selectedProject()
                 .filter(project -> dialogs.confirmDelete(this, project))
-                .ifPresent(project -> onDelete.accept(this, project.projectId())));
+                .ifPresent(project -> actions.onDelete().accept(this, project.projectId())));
         panel.add(deleteButton);
 
         return panel;
@@ -260,7 +208,7 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
             public void mouseClicked(MouseEvent event) {
                 if (event.getClickCount() == 2 && table.getSelectedRow() >= 0 && table.isEnabled()) {
                     selectedProject().ifPresent(project ->
-                            onOpenDetail.accept(ProjectManagementPanel.this, project.projectId()));
+                            actions.onOpenDetail().accept(ProjectManagementPanel.this, project.projectId()));
                 }
             }
         });
@@ -364,15 +312,36 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
         void accept(ProjectManagementPanel panel, T first, U second);
     }
 
+    record ProjectManagementActions(
+            PanelConsumer<ProjectCreateRequest> onCreate,
+            PanelConsumer<Long> onOpenDetail,
+            PanelBiConsumer<Long, String> onRename,
+            PanelBiConsumer<Long, String> onDescriptionChange,
+            PanelConsumer<Long> onDelete,
+            Runnable onBack,
+            Runnable onLogout) {
+
+        ProjectManagementActions {
+            Objects.requireNonNull(onCreate, "onCreate");
+            Objects.requireNonNull(onOpenDetail, "onOpenDetail");
+            Objects.requireNonNull(onRename, "onRename");
+            Objects.requireNonNull(onDescriptionChange, "onDescriptionChange");
+            Objects.requireNonNull(onDelete, "onDelete");
+            Objects.requireNonNull(onBack, "onBack");
+            Objects.requireNonNull(onLogout, "onLogout");
+        }
+    }
+
     static final class JOptionPaneProjectDialogs implements ProjectDialogs {
 
         @Override
         public Optional<ProjectCreateRequest> requestCreate(ProjectManagementPanel parent) {
             JTextField name = new JTextField();
             JTextField description = new JTextField();
-            JPanel form = formPanel(
+            JPanel form = SwingPanelSections.formPanel(
+                    260,
                     new JLabel("Name"), name,
-                    new JLabel("Description"), description);
+                    new JLabel(DESCRIPTION_TEXT), description);
             int result = JOptionPane.showConfirmDialog(
                     parent,
                     form,
@@ -404,7 +373,7 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
                 DashboardProjectSummary selectedProject) {
             String description = (String) JOptionPane.showInputDialog(
                     parent,
-                    "Description",
+                    DESCRIPTION_TEXT,
                     "Change project description",
                     JOptionPane.PLAIN_MESSAGE,
                     null,
@@ -424,27 +393,5 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
             return result == JOptionPane.OK_OPTION;
         }
 
-        static JPanel formPanel(Component... components) {
-            if (components.length % 2 != 0) {
-                throw new IllegalArgumentException("Form components must be label-field pairs.");
-            }
-            JPanel panel = new JPanel(new GridBagLayout());
-            GridBagConstraints constraints = new GridBagConstraints();
-            constraints.insets = new Insets(4, 4, 4, 4);
-            constraints.fill = GridBagConstraints.HORIZONTAL;
-            constraints.weightx = 1.0;
-            for (int index = 0; index < components.length; index += 2) {
-                constraints.gridy = index / 2;
-                constraints.gridx = 0;
-                constraints.weightx = 0.0;
-                panel.add(components[index], constraints);
-                constraints.gridx = 1;
-                constraints.weightx = 1.0;
-                Component field = components[index + 1];
-                field.setPreferredSize(new Dimension(260, SwingStyles.FIELD_HEIGHT));
-                panel.add(field, constraints);
-            }
-            return panel;
-        }
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPresenter.java
@@ -53,8 +53,9 @@ final class ProjectManagementPresenter {
         }
     }
 
-    void deleteProject(long projectId) {
-        run("Project deleted: " + projectId, () -> projectController.deleteProject(projectId));
+    void deleteProject(long projectId, String projectName) {
+        Objects.requireNonNull(projectName, "projectName");
+        run("Project deleted: " + projectName, () -> projectController.deleteProject(projectId));
     }
 
     private void run(String successMessage, Runnable action) {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPresenter.java
@@ -1,0 +1,73 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.controller.ProjectController;
+import com.github.marcellokim.issuetracker.service.ProjectResult;
+import java.util.Objects;
+
+final class ProjectManagementPresenter {
+
+    private final DashboardController dashboardController;
+    private final ProjectController projectController;
+    private final ProjectManagementView view;
+
+    ProjectManagementPresenter(
+            DashboardController dashboardController,
+            ProjectController projectController,
+            ProjectManagementView view) {
+        this.dashboardController = Objects.requireNonNull(dashboardController, "dashboardController");
+        this.projectController = Objects.requireNonNull(projectController, "projectController");
+        this.view = Objects.requireNonNull(view, "view");
+    }
+
+    void loadProjects() {
+        run(" ", () -> {
+        });
+    }
+
+    void createProject(ProjectCreateRequest request) {
+        Objects.requireNonNull(request, "request");
+        try {
+            ProjectResult created = projectController.createProject(request.name(), request.description());
+            refresh("Project created: " + created.name());
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    void renameProject(long projectId, String name) {
+        try {
+            ProjectResult renamed = projectController.renameProject(projectId, name);
+            refresh("Project renamed: " + renamed.name());
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    void changeProjectDescription(long projectId, String description) {
+        try {
+            ProjectResult changed = projectController.changeProjectDescription(projectId, description);
+            refresh("Project description changed: " + changed.name());
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    void deleteProject(long projectId) {
+        run("Project deleted: " + projectId, () -> projectController.deleteProject(projectId));
+    }
+
+    private void run(String successMessage, Runnable action) {
+        try {
+            action.run();
+            refresh(successMessage);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    private void refresh(String successMessage) {
+        view.showProjects(dashboardController.viewProjects());
+        view.showMessage(successMessage, false);
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementView.java
@@ -1,0 +1,11 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import java.util.List;
+
+interface ProjectManagementView {
+
+    void showProjects(List<DashboardProjectSummary> projects);
+
+    void showMessage(String message, boolean error);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
@@ -4,6 +4,7 @@ import com.github.marcellokim.issuetracker.config.ApplicationContext;
 import com.github.marcellokim.issuetracker.controller.AccountController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.controller.ProjectController;
 import java.util.Objects;
 import javax.swing.JFrame;
 import javax.swing.WindowConstants;
@@ -18,15 +19,22 @@ public final class SwingAppFrame extends JFrame {
         this(
                 Objects.requireNonNull(context, "context").authenticationController(),
                 context.dashboardController(),
-                context.accountController());
+                context.accountController(),
+                context.projectController());
     }
 
     SwingAppFrame(
             AuthenticationController authenticationController,
             DashboardController dashboardController,
-            AccountController accountController) {
+            AccountController accountController,
+            ProjectController projectController) {
         super("Issue Tracker");
-        this.appPanel = new SwingAppPanel(authenticationController, dashboardController, accountController, this::setTitle);
+        this.appPanel = new SwingAppPanel(
+                authenticationController,
+                dashboardController,
+                accountController,
+                projectController,
+                this::setTitle);
         setContentPane(appPanel);
         setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         setSize(SwingStyles.WINDOW_SIZE);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -3,6 +3,7 @@ package com.github.marcellokim.issuetracker.ui.swing;
 import com.github.marcellokim.issuetracker.controller.AccountController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.controller.ProjectController;
 import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
 import com.github.marcellokim.issuetracker.service.UserResult;
 import java.awt.BorderLayout;
@@ -28,6 +29,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private final transient AuthenticationController authenticationController;
     private final transient DashboardController dashboardController;
     private final transient AccountController accountController;
+    private final transient ProjectController projectController;
     private final transient Consumer<String> titleUpdater;
     private final CardLayout cardLayout = new CardLayout();
     private final LoginPanel loginPanel = new LoginPanel();
@@ -36,15 +38,18 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private transient SwingWorker<Void, Void> loginWorker;
     private final transient AtomicReference<DashboardLoadWorker> dashboardWorker = new AtomicReference<>();
     private final transient AtomicReference<AccountManagementWorker> accountWorker = new AtomicReference<>();
+    private final transient AtomicReference<ProjectManagementWorker> projectWorker = new AtomicReference<>();
 
     SwingAppPanel(
             AuthenticationController authenticationController,
             DashboardController dashboardController,
             AccountController accountController,
+            ProjectController projectController,
             Consumer<String> titleUpdater) {
         this.authenticationController = Objects.requireNonNull(authenticationController, "authenticationController");
         this.dashboardController = Objects.requireNonNull(dashboardController, "dashboardController");
         this.accountController = Objects.requireNonNull(accountController, "accountController");
+        this.projectController = Objects.requireNonNull(projectController, "projectController");
         this.titleUpdater = Objects.requireNonNull(titleUpdater, "titleUpdater");
 
         setName("appCards");
@@ -63,6 +68,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         runOnEdtAndWait(() -> {
             cancelDashboardWorker();
             cancelAccountWorker();
+            cancelProjectWorker();
             titleUpdater.accept("Issue Tracker");
             loginPanel.showMessage(" ", false);
             loginPanel.clearPassword();
@@ -77,11 +83,12 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         SwingUtilities.invokeLater(() -> {
             cancelDashboardWorker();
             cancelAccountWorker();
+            cancelProjectWorker();
             titleUpdater.accept("Admin dashboard");
             AdminDashboardPanel panel = new AdminDashboardPanel(
                     user,
                     () -> showAccountManagement(user),
-                    () -> showAdminPlaceholder("Project management", user),
+                    () -> showProjectManagement(user),
                     this::logout);
             adminDashboardCard.removeAll();
             adminDashboardCard.add(panel, BorderLayout.CENTER);
@@ -98,6 +105,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         runOnEdtAndWait(() -> {
             cancelDashboardWorker();
             cancelAccountWorker();
+            cancelProjectWorker();
             titleUpdater.accept("Project list");
             showPlaceholder(projectListCard, "Project list", user);
             cardLayout.show(this, PROJECT_LIST_CARD);
@@ -107,6 +115,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     void logout() {
         cancelDashboardWorker();
         cancelAccountWorker();
+        cancelProjectWorker();
         authenticationController.logout();
         showLogin();
     }
@@ -171,6 +180,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         SwingUtilities.invokeLater(() -> {
             cancelDashboardWorker();
             cancelAccountWorker();
+            cancelProjectWorker();
             titleUpdater.accept(destination);
             showPlaceholder(adminDashboardCard, destination, user, () -> showAdminDashboard(user));
             cardLayout.show(this, ADMIN_DASHBOARD_CARD);
@@ -181,6 +191,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         SwingUtilities.invokeLater(() -> {
             cancelDashboardWorker();
             cancelAccountWorker();
+            cancelProjectWorker();
             titleUpdater.accept("Account management");
             AccountManagementPanel panel = new AccountManagementPanel(
                     user,
@@ -200,6 +211,35 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             adminDashboardCard.repaint();
             cardLayout.show(this, ADMIN_DASHBOARD_CARD);
             startAccountTask(panel, AccountManagementPresenter::loadUsers);
+        });
+    }
+
+    private void showProjectManagement(UserResult user) {
+        SwingUtilities.invokeLater(() -> {
+            cancelDashboardWorker();
+            cancelAccountWorker();
+            cancelProjectWorker();
+            titleUpdater.accept("Project management");
+            ProjectManagementPanel panel = new ProjectManagementPanel(
+                    user,
+                    new ProjectManagementPanel.JOptionPaneProjectDialogs(),
+                    (panelRef, request) -> startProjectTask(panelRef, presenter -> presenter.createProject(request)),
+                    (panelRef, projectId) -> showAdminPlaceholder("Project detail #" + projectId, user),
+                    (panelRef, projectId, name) ->
+                            startProjectTask(panelRef, presenter -> presenter.renameProject(projectId, name)),
+                    (panelRef, projectId, description) ->
+                            startProjectTask(
+                                    panelRef,
+                                    presenter -> presenter.changeProjectDescription(projectId, description)),
+                    (panelRef, projectId) -> startProjectTask(panelRef, presenter -> presenter.deleteProject(projectId)),
+                    () -> showAdminDashboard(user),
+                    this::logout);
+            adminDashboardCard.removeAll();
+            adminDashboardCard.add(panel, BorderLayout.CENTER);
+            adminDashboardCard.revalidate();
+            adminDashboardCard.repaint();
+            cardLayout.show(this, ADMIN_DASHBOARD_CARD);
+            startProjectTask(panel, ProjectManagementPresenter::loadProjects);
         });
     }
 
@@ -228,6 +268,23 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     private void cancelAccountWorker() {
         AccountManagementWorker worker = accountWorker.getAndSet(null);
+        if (worker != null && !worker.isDone()) {
+            worker.cancel(true);
+        }
+    }
+
+    private void startProjectTask(ProjectManagementPanel panel, ProjectTask task) {
+        Objects.requireNonNull(panel, "panel");
+        Objects.requireNonNull(task, "task");
+        cancelProjectWorker();
+        panel.setBusy(true);
+        ProjectManagementWorker worker = new ProjectManagementWorker(panel, task);
+        projectWorker.set(worker);
+        worker.execute();
+    }
+
+    private void cancelProjectWorker() {
+        ProjectManagementWorker worker = projectWorker.getAndSet(null);
         if (worker != null && !worker.isDone()) {
             worker.cancel(true);
         }
@@ -337,6 +394,46 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         }
     }
 
+    private final class ProjectManagementWorker extends SwingWorker<Void, Void> {
+
+        private final ProjectManagementPanel panel;
+        private final ProjectTask task;
+
+        private ProjectManagementWorker(ProjectManagementPanel panel, ProjectTask task) {
+            this.panel = Objects.requireNonNull(panel, "panel");
+            this.task = Objects.requireNonNull(task, "task");
+        }
+
+        @Override
+        protected Void doInBackground() {
+            ProjectManagementPresenter presenter = new ProjectManagementPresenter(
+                    dashboardController,
+                    projectController,
+                    new CurrentProjectManagementView(panel, this));
+            task.run(presenter);
+            return null;
+        }
+
+        @Override
+        protected void done() {
+            if (!projectWorker.compareAndSet(this, null)) {
+                return;
+            }
+            panel.setBusy(false);
+            if (isCancelled()) {
+                return;
+            }
+            try {
+                get();
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                panel.showMessage("Project management was interrupted. Please try again.", true);
+            } catch (ExecutionException exception) {
+                panel.showMessage("Project management failed. Please try again.", true);
+            }
+        }
+    }
+
     private final class CurrentAccountManagementView implements AccountManagementView {
 
         private final AccountManagementPanel delegate;
@@ -366,10 +463,45 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         }
     }
 
+    private final class CurrentProjectManagementView implements ProjectManagementView {
+
+        private final ProjectManagementPanel delegate;
+        private final ProjectManagementWorker worker;
+
+        private CurrentProjectManagementView(ProjectManagementPanel delegate, ProjectManagementWorker worker) {
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
+            this.worker = Objects.requireNonNull(worker, "worker");
+        }
+
+        @Override
+        public void showProjects(List<DashboardProjectSummary> projects) {
+            if (isCurrent()) {
+                delegate.showProjects(projects);
+            }
+        }
+
+        @Override
+        public void showMessage(String message, boolean error) {
+            if (isCurrent()) {
+                delegate.showMessage(message, error);
+            }
+        }
+
+        private boolean isCurrent() {
+            return projectWorker.get() == worker && !worker.isCancelled();
+        }
+    }
+
     @FunctionalInterface
     private interface AccountTask {
 
         void run(AccountManagementPresenter presenter);
+    }
+
+    @FunctionalInterface
+    private interface ProjectTask {
+
+        void run(ProjectManagementPresenter presenter);
     }
 
     private final class CurrentDashboardView implements AdminDashboardView {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -234,8 +234,10 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
                                     startProjectTask(
                                             panelRef,
                                             presenter -> presenter.changeProjectDescription(projectId, description)),
-                            (panelRef, projectId) ->
-                                    startProjectTask(panelRef, presenter -> presenter.deleteProject(projectId)),
+                            (panelRef, projectId, projectName) ->
+                                    startProjectTask(
+                                            panelRef,
+                                            presenter -> presenter.deleteProject(projectId, projectName)),
                             () -> showAdminDashboard(user),
                             this::logout));
             adminDashboardCard.removeAll();

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -25,6 +25,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private static final String LOGIN_CARD = "login";
     private static final String ADMIN_DASHBOARD_CARD = "adminDashboard";
     private static final String PROJECT_LIST_CARD = "projectList";
+    private static final String WORKER_NAME = "worker";
 
     private final transient AuthenticationController authenticationController;
     private final transient DashboardController dashboardController;
@@ -223,17 +224,20 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             ProjectManagementPanel panel = new ProjectManagementPanel(
                     user,
                     new ProjectManagementPanel.JOptionPaneProjectDialogs(),
-                    (panelRef, request) -> startProjectTask(panelRef, presenter -> presenter.createProject(request)),
-                    (panelRef, projectId) -> showAdminPlaceholder("Project detail #" + projectId, user),
-                    (panelRef, projectId, name) ->
-                            startProjectTask(panelRef, presenter -> presenter.renameProject(projectId, name)),
-                    (panelRef, projectId, description) ->
-                            startProjectTask(
-                                    panelRef,
-                                    presenter -> presenter.changeProjectDescription(projectId, description)),
-                    (panelRef, projectId) -> startProjectTask(panelRef, presenter -> presenter.deleteProject(projectId)),
-                    () -> showAdminDashboard(user),
-                    this::logout);
+                    new ProjectManagementPanel.ProjectManagementActions(
+                            (panelRef, request) ->
+                                    startProjectTask(panelRef, presenter -> presenter.createProject(request)),
+                            (panelRef, projectId) -> showAdminPlaceholder("Project detail #" + projectId, user),
+                            (panelRef, projectId, name) ->
+                                    startProjectTask(panelRef, presenter -> presenter.renameProject(projectId, name)),
+                            (panelRef, projectId, description) ->
+                                    startProjectTask(
+                                            panelRef,
+                                            presenter -> presenter.changeProjectDescription(projectId, description)),
+                            (panelRef, projectId) ->
+                                    startProjectTask(panelRef, presenter -> presenter.deleteProject(projectId)),
+                            () -> showAdminDashboard(user),
+                            this::logout));
             adminDashboardCard.removeAll();
             adminDashboardCard.add(panel, BorderLayout.CENTER);
             adminDashboardCard.revalidate();
@@ -441,7 +445,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
         private CurrentAccountManagementView(AccountManagementPanel delegate, AccountManagementWorker worker) {
             this.delegate = Objects.requireNonNull(delegate, "delegate");
-            this.worker = Objects.requireNonNull(worker, "worker");
+            this.worker = Objects.requireNonNull(worker, WORKER_NAME);
         }
 
         @Override
@@ -470,7 +474,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
         private CurrentProjectManagementView(ProjectManagementPanel delegate, ProjectManagementWorker worker) {
             this.delegate = Objects.requireNonNull(delegate, "delegate");
-            this.worker = Objects.requireNonNull(worker, "worker");
+            this.worker = Objects.requireNonNull(worker, WORKER_NAME);
         }
 
         @Override
@@ -511,7 +515,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
         private CurrentDashboardView(AdminDashboardPanel delegate, DashboardLoadWorker worker) {
             this.delegate = Objects.requireNonNull(delegate, "delegate");
-            this.worker = Objects.requireNonNull(worker, "worker");
+            this.worker = Objects.requireNonNull(worker, WORKER_NAME);
         }
 
         @Override

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingPanelSections.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingPanelSections.java
@@ -1,0 +1,129 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.Objects;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+final class SwingPanelSections {
+
+    private static final String FORM_PAIR_ERROR = "Form components must be label-field pairs.";
+
+    private SwingPanelSections() {
+    }
+
+    static JPanel managementHeader(
+            HeaderLabels labels,
+            UserResult user,
+            JLabel messageLabel,
+            NavigationActions navigation) {
+        Objects.requireNonNull(labels, "labels");
+        Objects.requireNonNull(user, "user");
+        Objects.requireNonNull(messageLabel, "messageLabel");
+        Objects.requireNonNull(navigation, "navigation");
+
+        JPanel header = new JPanel(new BorderLayout(0, SwingStyles.ROW_GAP));
+        header.setBackground(SwingStyles.SURFACE);
+        header.setBorder(SwingStyles.surfaceBorder());
+
+        JPanel topRow = new JPanel(new BorderLayout(SwingStyles.SECTION_GAP, 0));
+        topRow.setOpaque(false);
+
+        JPanel titles = new JPanel();
+        titles.setOpaque(false);
+        titles.setLayout(new BoxLayout(titles, BoxLayout.Y_AXIS));
+
+        JLabel title = new JLabel(labels.title());
+        title.setName(labels.titleName());
+        title.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyTitle(title);
+        titles.add(title);
+
+        JLabel userLabel = new JLabel(user.name() + " (" + user.role() + ")");
+        userLabel.setName(labels.userName());
+        userLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyMuted(userLabel);
+        titles.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+        titles.add(userLabel);
+
+        JPanel nav = new JPanel();
+        nav.setOpaque(false);
+        JButton backButton = new JButton("Back");
+        backButton.setName(labels.backButtonName());
+        backButton.addActionListener(event -> navigation.onBack().run());
+        nav.add(backButton);
+
+        JButton logoutButton = new JButton("Logout");
+        logoutButton.setName(labels.logoutButtonName());
+        logoutButton.addActionListener(event -> navigation.onLogout().run());
+        nav.add(logoutButton);
+
+        messageLabel.setName(labels.messageName());
+        messageLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyMuted(messageLabel);
+
+        topRow.add(titles, BorderLayout.CENTER);
+        topRow.add(nav, BorderLayout.EAST);
+        header.add(topRow, BorderLayout.CENTER);
+        header.add(messageLabel, BorderLayout.SOUTH);
+        return header;
+    }
+
+    static JPanel formPanel(int fieldWidth, Component... components) {
+        if (components.length % 2 != 0) {
+            throw new IllegalArgumentException(FORM_PAIR_ERROR);
+        }
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.insets = new Insets(4, 4, 4, 4);
+        constraints.fill = GridBagConstraints.HORIZONTAL;
+        constraints.weightx = 1.0;
+        for (int index = 0; index < components.length; index += 2) {
+            constraints.gridy = index / 2;
+            constraints.gridx = 0;
+            constraints.weightx = 0.0;
+            panel.add(components[index], constraints);
+            constraints.gridx = 1;
+            constraints.weightx = 1.0;
+            Component field = components[index + 1];
+            field.setPreferredSize(new Dimension(fieldWidth, SwingStyles.FIELD_HEIGHT));
+            panel.add(field, constraints);
+        }
+        return panel;
+    }
+
+    record HeaderLabels(
+            String title,
+            String titleName,
+            String userName,
+            String messageName,
+            String backButtonName,
+            String logoutButtonName) {
+
+        HeaderLabels {
+            Objects.requireNonNull(title, "title");
+            Objects.requireNonNull(titleName, "titleName");
+            Objects.requireNonNull(userName, "userName");
+            Objects.requireNonNull(messageName, "messageName");
+            Objects.requireNonNull(backButtonName, "backButtonName");
+            Objects.requireNonNull(logoutButtonName, "logoutButtonName");
+        }
+    }
+
+    record NavigationActions(Runnable onBack, Runnable onLogout) {
+
+        NavigationActions {
+            Objects.requireNonNull(onBack, "onBack");
+            Objects.requireNonNull(onLogout, "onLogout");
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanelTest.java
@@ -1,0 +1,244 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.imageio.ImageIO;
+import javax.swing.JButton;
+import javax.swing.JTable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing project management panel")
+class ProjectManagementPanelTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("renders projects and selection-sensitive actions")
+    void rendersProjectsAndSelectionActions() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            ProjectManagementPanel panel = panel(new FixedProjectDialogs());
+            panel.showProjects(List.of(
+                    projectSummary(1L, "Alpha", "Alpha project", 3, 7),
+                    projectSummary(2L, "Beta", "Beta project", 1, 0)));
+
+            JTable table = SwingComponentTestSupport.find(panel, "projectManagementTable", JTable.class);
+            JButton create = SwingComponentTestSupport.find(panel, "createProjectButton", JButton.class);
+            JButton open = SwingComponentTestSupport.find(panel, "openProjectDetailButton", JButton.class);
+            JButton rename = SwingComponentTestSupport.find(panel, "renameProjectButton", JButton.class);
+            JButton description = SwingComponentTestSupport.find(
+                    panel,
+                    "changeProjectDescriptionButton",
+                    JButton.class);
+            JButton delete = SwingComponentTestSupport.find(panel, "deleteProjectButton", JButton.class);
+
+            assertEquals(2, table.getRowCount());
+            assertEquals("Alpha", table.getValueAt(0, 1));
+            assertEquals("Alpha project", table.getValueAt(0, 2));
+            assertEquals(true, create.isEnabled());
+            assertEquals(false, open.isEnabled());
+            assertEquals(false, rename.isEnabled());
+            assertEquals(false, description.isEnabled());
+            assertEquals(false, delete.isEnabled());
+
+            table.setRowSelectionInterval(1, 1);
+
+            assertEquals(true, open.isEnabled());
+            assertEquals(true, rename.isEnabled());
+            assertEquals(true, description.isEnabled());
+            assertEquals(true, delete.isEnabled());
+        });
+    }
+
+    @Test
+    @DisplayName("uses dialogs and selected project to publish project actions")
+    void publishesProjectActions() throws Exception {
+        var createRef = new AtomicReference<ProjectCreateRequest>();
+        var openRef = new AtomicLong();
+        var renameRef = new AtomicReference<String>();
+        var descriptionRef = new AtomicReference<String>();
+        var deleteRef = new AtomicLong();
+        var backClicks = new AtomicInteger();
+        var logoutClicks = new AtomicInteger();
+        FixedProjectDialogs dialogs = new FixedProjectDialogs();
+
+        SwingComponentTestSupport.onEdt(() -> {
+            ProjectManagementPanel panel = new ProjectManagementPanel(
+                    userResult("admin", Role.ADMIN, true),
+                    dialogs,
+                    (source, request) -> createRef.set(request),
+                    (source, projectId) -> openRef.set(projectId),
+                    (source, projectId, name) -> renameRef.set(projectId + ":" + name),
+                    (source, projectId, description) -> descriptionRef.set(projectId + ":" + description),
+                    (source, projectId) -> deleteRef.set(projectId),
+                    backClicks::incrementAndGet,
+                    logoutClicks::incrementAndGet);
+            panel.showProjects(List.of(projectSummary(7L, "Alpha", "Alpha project", 3, 7)));
+            JTable table = SwingComponentTestSupport.find(panel, "projectManagementTable", JTable.class);
+            table.setRowSelectionInterval(0, 0);
+
+            SwingComponentTestSupport.find(panel, "createProjectButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "openProjectDetailButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "renameProjectButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "changeProjectDescriptionButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "deleteProjectButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "projectManagementBackButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "projectManagementLogoutButton", JButton.class).doClick();
+        });
+
+        assertEquals(new ProjectCreateRequest("New Project", "New project description"), createRef.get());
+        assertEquals(7L, openRef.get());
+        assertEquals("7:Renamed Project", renameRef.get());
+        assertEquals("7:Updated project description", descriptionRef.get());
+        assertEquals(7L, deleteRef.get());
+        assertEquals(1, backClicks.get());
+        assertEquals(1, logoutClicks.get());
+    }
+
+    @Test
+    @DisplayName("renders project management screen snapshot")
+    void rendersProjectManagementSnapshot() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            ProjectManagementPanel panel = panel(new FixedProjectDialogs());
+            panel.showProjects(List.of(
+                    projectSummary(1L, "Alpha", "Alpha project", 3, 7),
+                    projectSummary(2L, "Beta", "Beta project", 1, 0)));
+            panel.setSize(SwingStyles.WINDOW_SIZE);
+            layoutRecursively(panel);
+
+            BufferedImage initial = render(panel, Path.of("build/reports/ui/project-management-panel.png"));
+            assertTrue(hasRenderedContent(initial));
+
+            JTable table = SwingComponentTestSupport.find(panel, "projectManagementTable", JTable.class);
+            table.setRowSelectionInterval(0, 0);
+            BufferedImage selected = render(panel, Path.of("build/reports/ui/project-management-panel-selected.png"));
+            assertTrue(hasRenderedContent(selected));
+        });
+    }
+
+    private static ProjectManagementPanel panel(FixedProjectDialogs dialogs) {
+        return new ProjectManagementPanel(
+                userResult("admin", Role.ADMIN, true),
+                dialogs,
+                (source, ignored) -> {
+                },
+                (source, ignored) -> {
+                },
+                (source, projectId, name) -> {
+                },
+                (source, projectId, description) -> {
+                },
+                (source, ignored) -> {
+                },
+                () -> {
+                },
+                () -> {
+                });
+    }
+
+    private static DashboardProjectSummary projectSummary(
+            long projectId,
+            String name,
+            String description,
+            int memberCount,
+            int issueCount) {
+        return new DashboardProjectSummary(
+                projectId,
+                name,
+                description,
+                memberCount,
+                1,
+                1,
+                1,
+                issueCount,
+                Map.of(IssueStatus.NEW, issueCount));
+    }
+
+    private static UserResult userResult(String loginId, Role role, boolean active) {
+        return UserResult.from(User.fromPersistence(loginId, loginId, "stored-password", role, active, NOW, NOW));
+    }
+
+    private static void layoutRecursively(Container container) {
+        container.doLayout();
+        for (java.awt.Component child : container.getComponents()) {
+            if (child instanceof Container nested) {
+                layoutRecursively(nested);
+            }
+        }
+    }
+
+    private static BufferedImage render(ProjectManagementPanel panel, Path output) throws java.io.IOException {
+        BufferedImage image = new BufferedImage(
+                SwingStyles.WINDOW_SIZE.width,
+                SwingStyles.WINDOW_SIZE.height,
+                BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            panel.printAll(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        Files.createDirectories(output.getParent());
+        ImageIO.write(image, "png", output.toFile());
+        return image;
+    }
+
+    private static boolean hasRenderedContent(BufferedImage image) {
+        int background = SwingStyles.BACKGROUND.getRGB();
+        int white = Color.WHITE.getRGB();
+        int contentPixels = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                int pixel = image.getRGB(x, y);
+                if (pixel != background && pixel != white) {
+                    contentPixels++;
+                }
+            }
+        }
+        return contentPixels > 10_000;
+    }
+
+    private static final class FixedProjectDialogs implements ProjectDialogs {
+
+        @Override
+        public Optional<ProjectCreateRequest> requestCreate(ProjectManagementPanel parent) {
+            return Optional.of(new ProjectCreateRequest("New Project", "New project description"));
+        }
+
+        @Override
+        public Optional<String> requestRename(ProjectManagementPanel parent, DashboardProjectSummary selectedProject) {
+            return Optional.of("Renamed Project");
+        }
+
+        @Override
+        public Optional<String> requestDescription(
+                ProjectManagementPanel parent,
+                DashboardProjectSummary selectedProject) {
+            return Optional.of("Updated project description");
+        }
+
+        @Override
+        public boolean confirmDelete(ProjectManagementPanel parent, DashboardProjectSummary selectedProject) {
+            return true;
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanelTest.java
@@ -78,7 +78,7 @@ class ProjectManagementPanelTest {
         var openRef = new AtomicLong();
         var renameRef = new AtomicReference<String>();
         var descriptionRef = new AtomicReference<String>();
-        var deleteRef = new AtomicLong();
+        var deleteRef = new AtomicReference<String>();
         var backClicks = new AtomicInteger();
         var logoutClicks = new AtomicInteger();
         FixedProjectDialogs dialogs = new FixedProjectDialogs();
@@ -93,7 +93,7 @@ class ProjectManagementPanelTest {
                             (source, projectId, name) -> renameRef.set(projectId + ":" + name),
                             (source, projectId, description) ->
                                     descriptionRef.set(projectId + ":" + description),
-                            (source, projectId) -> deleteRef.set(projectId),
+                            (source, projectId, projectName) -> deleteRef.set(projectId + ":" + projectName),
                             backClicks::incrementAndGet,
                             logoutClicks::incrementAndGet));
             panel.showProjects(List.of(projectSummary(7L, "Alpha", "Alpha project", 3, 7)));
@@ -113,7 +113,7 @@ class ProjectManagementPanelTest {
         assertEquals(7L, openRef.get());
         assertEquals("7:Renamed Project", renameRef.get());
         assertEquals("7:Updated project description", descriptionRef.get());
-        assertEquals(7L, deleteRef.get());
+        assertEquals("7:Alpha", deleteRef.get());
         assertEquals(1, backClicks.get());
         assertEquals(1, logoutClicks.get());
     }
@@ -175,7 +175,7 @@ class ProjectManagementPanelTest {
                         },
                         (source, projectId, description) -> {
                         },
-                        (source, ignored) -> {
+                        (source, projectId, projectName) -> {
                         },
                         () -> {
                         },

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanelTest.java
@@ -1,6 +1,7 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
@@ -23,6 +24,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.imageio.ImageIO;
 import javax.swing.JButton;
+import javax.swing.JLabel;
 import javax.swing.JTable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -112,6 +114,27 @@ class ProjectManagementPanelTest {
         assertEquals(7L, deleteRef.get());
         assertEquals(1, backClicks.get());
         assertEquals(1, logoutClicks.get());
+    }
+
+    @Test
+    @DisplayName("shows fallback text for blank error messages")
+    void showsFallbackTextForBlankErrors() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            ProjectManagementPanel panel = panel(new FixedProjectDialogs());
+            panel.showMessage(" ", true);
+
+            JLabel message = SwingComponentTestSupport.find(panel, "projectManagementMessage", JLabel.class);
+
+            assertEquals("Project management failed. Please try again.", message.getText());
+        });
+    }
+
+    @Test
+    @DisplayName("rejects invalid dialog form component pairs")
+    void rejectsInvalidDialogFormComponentPairs() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ProjectManagementPanel.JOptionPaneProjectDialogs.formPanel(new JLabel("Name")));
     }
 
     @Test

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanelTest.java
@@ -87,13 +87,15 @@ class ProjectManagementPanelTest {
             ProjectManagementPanel panel = new ProjectManagementPanel(
                     userResult("admin", Role.ADMIN, true),
                     dialogs,
-                    (source, request) -> createRef.set(request),
-                    (source, projectId) -> openRef.set(projectId),
-                    (source, projectId, name) -> renameRef.set(projectId + ":" + name),
-                    (source, projectId, description) -> descriptionRef.set(projectId + ":" + description),
-                    (source, projectId) -> deleteRef.set(projectId),
-                    backClicks::incrementAndGet,
-                    logoutClicks::incrementAndGet);
+                    new ProjectManagementPanel.ProjectManagementActions(
+                            (source, request) -> createRef.set(request),
+                            (source, projectId) -> openRef.set(projectId),
+                            (source, projectId, name) -> renameRef.set(projectId + ":" + name),
+                            (source, projectId, description) ->
+                                    descriptionRef.set(projectId + ":" + description),
+                            (source, projectId) -> deleteRef.set(projectId),
+                            backClicks::incrementAndGet,
+                            logoutClicks::incrementAndGet));
             panel.showProjects(List.of(projectSummary(7L, "Alpha", "Alpha project", 3, 7)));
             JTable table = SwingComponentTestSupport.find(panel, "projectManagementTable", JTable.class);
             table.setRowSelectionInterval(0, 0);
@@ -132,9 +134,11 @@ class ProjectManagementPanelTest {
     @Test
     @DisplayName("rejects invalid dialog form component pairs")
     void rejectsInvalidDialogFormComponentPairs() {
+        JLabel nameLabel = new JLabel("Name");
+
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ProjectManagementPanel.JOptionPaneProjectDialogs.formPanel(new JLabel("Name")));
+                () -> SwingPanelSections.formPanel(260, nameLabel));
     }
 
     @Test
@@ -162,20 +166,21 @@ class ProjectManagementPanelTest {
         return new ProjectManagementPanel(
                 userResult("admin", Role.ADMIN, true),
                 dialogs,
-                (source, ignored) -> {
-                },
-                (source, ignored) -> {
-                },
-                (source, projectId, name) -> {
-                },
-                (source, projectId, description) -> {
-                },
-                (source, ignored) -> {
-                },
-                () -> {
-                },
-                () -> {
-                });
+                new ProjectManagementPanel.ProjectManagementActions(
+                        (source, ignored) -> {
+                        },
+                        (source, ignored) -> {
+                        },
+                        (source, projectId, name) -> {
+                        },
+                        (source, projectId, description) -> {
+                        },
+                        (source, ignored) -> {
+                        },
+                        () -> {
+                        },
+                        () -> {
+                        }));
     }
 
     private static DashboardProjectSummary projectSummary(

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPresenterTest.java
@@ -91,10 +91,10 @@ class ProjectManagementPresenterTest {
                 fixture.projectController(),
                 view);
 
-        presenter.deleteProject(1L);
+        presenter.deleteProject(1L, "Alpha");
 
         assertEquals(List.of(), view.projectNames());
-        assertEquals("Project deleted: 1", view.message());
+        assertEquals("Project deleted: Alpha", view.message());
     }
 
     @Test

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPresenterTest.java
@@ -9,7 +9,6 @@ import com.github.marcellokim.issuetracker.domain.Project;
 import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.User;
 import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository;
-import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository.DashboardProjectSnapshot;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
 import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
 import com.github.marcellokim.issuetracker.service.DashboardSummaryService;

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPresenterTest.java
@@ -1,0 +1,245 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.controller.ProjectController;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Project;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository;
+import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository.DashboardProjectSnapshot;
+import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
+import com.github.marcellokim.issuetracker.service.PasswordHashing;
+import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.service.ProjectService;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.technical.SessionStore;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing project management presenter")
+class ProjectManagementPresenterTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("loads projects through dashboard controller")
+    void loadsProjects() {
+        ControllerFixture fixture = controllers(project(1L, "Alpha", "Alpha project"));
+        RecordingProjectManagementView view = new RecordingProjectManagementView();
+        ProjectManagementPresenter presenter = new ProjectManagementPresenter(
+                fixture.dashboardController(),
+                fixture.projectController(),
+                view);
+
+        presenter.loadProjects();
+
+        assertEquals(List.of("Alpha"), view.projectNames());
+        assertEquals(" ", view.message());
+    }
+
+    @Test
+    @DisplayName("creates project and refreshes projects after success")
+    void createsProjectAndRefreshesProjects() {
+        ControllerFixture fixture = controllers();
+        RecordingProjectManagementView view = new RecordingProjectManagementView();
+        ProjectManagementPresenter presenter = new ProjectManagementPresenter(
+                fixture.dashboardController(),
+                fixture.projectController(),
+                view);
+
+        presenter.createProject(new ProjectCreateRequest("Beta", "Beta project"));
+
+        assertEquals(List.of("Beta"), view.projectNames());
+        assertEquals("Project created: Beta", view.message());
+    }
+
+    @Test
+    @DisplayName("renames and changes project description through controller")
+    void updatesProjectFields() {
+        ControllerFixture fixture = controllers(project(1L, "Alpha", "Alpha project"));
+        RecordingProjectManagementView view = new RecordingProjectManagementView();
+        ProjectManagementPresenter presenter = new ProjectManagementPresenter(
+                fixture.dashboardController(),
+                fixture.projectController(),
+                view);
+
+        presenter.renameProject(1L, "Renamed");
+        presenter.changeProjectDescription(1L, "Updated project");
+
+        DashboardProjectSummary updated = view.projects().get(0);
+        assertEquals("Renamed", updated.projectName());
+        assertEquals("Updated project", updated.projectDescription());
+        assertEquals("Project description changed: Renamed", view.message());
+    }
+
+    @Test
+    @DisplayName("deletes project through controller and refreshes projects")
+    void deletesProject() {
+        ControllerFixture fixture = controllers(project(1L, "Alpha", "Alpha project"));
+        RecordingProjectManagementView view = new RecordingProjectManagementView();
+        ProjectManagementPresenter presenter = new ProjectManagementPresenter(
+                fixture.dashboardController(),
+                fixture.projectController(),
+                view);
+
+        presenter.deleteProject(1L);
+
+        assertEquals(List.of(), view.projectNames());
+        assertEquals("Project deleted: 1", view.message());
+    }
+
+    @Test
+    @DisplayName("shows controller errors without replacing the current project list")
+    void showsControllerError() {
+        ControllerFixture fixture = controllers(project(1L, "Alpha", "Alpha project"));
+        RecordingProjectManagementView view = new RecordingProjectManagementView();
+        ProjectManagementPresenter presenter = new ProjectManagementPresenter(
+                fixture.dashboardController(),
+                fixture.projectController(),
+                view);
+        presenter.loadProjects();
+
+        presenter.renameProject(1L, "Alpha");
+
+        assertEquals(List.of("Alpha"), view.projectNames());
+        assertEquals("Project name is same as current name.", view.message());
+    }
+
+    private static ControllerFixture controllers(Project... projects) {
+        InMemoryUserRepository users = new InMemoryUserRepository(user("admin", Role.ADMIN, true));
+        InMemoryProjectRepository projectRepository = new InMemoryProjectRepository(projects);
+        AuthenticationService authentication = new AuthenticationService(
+                users,
+                new AcceptingPasswordHashing(),
+                new SessionStore());
+        authentication.login("admin", "password");
+        PermissionPolicy permissionPolicy = new PermissionPolicy();
+        DashboardController dashboardController = new DashboardController(
+                authentication,
+                new DashboardSummaryService(
+                        new ProjectBackedDashboardSummaryRepository(projectRepository),
+                        users,
+                        permissionPolicy));
+        ProjectController projectController = new ProjectController(
+                authentication,
+                new ProjectService(
+                        projectRepository,
+                        new InMemoryIssueRepository(),
+                        users,
+                        permissionPolicy,
+                        () -> NOW));
+        return new ControllerFixture(dashboardController, projectController);
+    }
+
+    private static Project project(long id, String name, String description) {
+        return Project.fromPersistence(id, name, description, "admin", NOW, NOW);
+    }
+
+    private static User user(String loginId, Role role, boolean active) {
+        return User.fromPersistence(loginId, loginId, "stored-password", role, active, NOW, NOW);
+    }
+
+    private record ControllerFixture(
+            DashboardController dashboardController,
+            ProjectController projectController) {
+    }
+
+    private static final class RecordingProjectManagementView implements ProjectManagementView {
+
+        private List<DashboardProjectSummary> projects = List.of();
+        private String message = " ";
+
+        @Override
+        public void showProjects(List<DashboardProjectSummary> projects) {
+            this.projects = List.copyOf(projects);
+            this.message = " ";
+        }
+
+        @Override
+        public void showMessage(String message, boolean error) {
+            this.message = message;
+        }
+
+        private List<DashboardProjectSummary> projects() {
+            return projects;
+        }
+
+        private List<String> projectNames() {
+            return projects.stream()
+                    .map(DashboardProjectSummary::projectName)
+                    .toList();
+        }
+
+        private String message() {
+            return message;
+        }
+    }
+
+    private record ProjectBackedDashboardSummaryRepository(
+            InMemoryProjectRepository projects) implements DashboardSummaryRepository {
+
+        @Override
+        public List<DashboardProjectSnapshot> findAllProjectSummaries() {
+            return projects.findAll().stream()
+                    .map(this::snapshot)
+                    .toList();
+        }
+
+        @Override
+        public List<DashboardProjectSnapshot> findProjectSummariesByParticipant(String loginId) {
+            return List.of();
+        }
+
+        private DashboardProjectSnapshot snapshot(Project project) {
+            int memberCount = projects.findParticipants(project.getId()).size();
+            return new DashboardProjectSnapshot(
+                    project.getId(),
+                    project.getName(),
+                    project.getDescription(),
+                    memberCount,
+                    0,
+                    0,
+                    0,
+                    0,
+                    Map.of(IssueStatus.NEW, 0));
+        }
+    }
+
+    private static final class AcceptingPasswordHashing implements PasswordHashing {
+
+        @Override
+        public String hash(String password) {
+            return "hashed-" + password;
+        }
+
+        @Override
+        public boolean matches(String password, String storedCredential) {
+            return true;
+        }
+
+        @Override
+        public boolean isHashed(String storedCredential) {
+            return true;
+        }
+
+        @Override
+        public String saltOf(String storedCredential) {
+            return "salt";
+        }
+
+        @Override
+        public String hashOf(String storedCredential) {
+            return storedCredential;
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.github.marcellokim.issuetracker.controller.AccountController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.controller.ProjectController;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.User;
@@ -19,6 +20,7 @@ import com.github.marcellokim.issuetracker.service.AuthenticationService;
 import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
 import com.github.marcellokim.issuetracker.service.PasswordHashing;
 import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.service.ProjectService;
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
@@ -62,6 +64,7 @@ class SwingAppPanelTest {
                     controllers.authenticationController(),
                     controllers.dashboardController(),
                     controllers.accountController(),
+                    controllers.projectController(),
                     titles::update);
             panelRef.set(panel);
             JTextField loginId = SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class);
@@ -135,6 +138,7 @@ class SwingAppPanelTest {
                     controllers.authenticationController(),
                     controllers.dashboardController(),
                     controllers.accountController(),
+                    controllers.projectController(),
                     titles::update);
             panelRef.set(panel);
             SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText("admin");
@@ -166,8 +170,8 @@ class SwingAppPanelTest {
     }
 
     @Test
-    @DisplayName("admin placeholder can return to dashboard")
-    void adminPlaceholderCanReturnToDashboard() throws Exception {
+    @DisplayName("admin project management shows project table")
+    void adminProjectManagementShowsProjectTable() throws Exception {
         var passwordHashing = new RecordingPasswordHashing();
         var titles = new RecordingTitleUpdater();
         var panelRef = new AtomicReference<SwingAppPanel>();
@@ -182,6 +186,7 @@ class SwingAppPanelTest {
                     controllers.authenticationController(),
                     controllers.dashboardController(),
                     controllers.accountController(),
+                    controllers.projectController(),
                     titles::update);
             panelRef.set(panel);
             SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText("admin");
@@ -206,11 +211,15 @@ class SwingAppPanelTest {
 
         SwingComponentTestSupport.onEdt(() ->
                 SwingComponentTestSupport.find(panelRef.get(), "projectManagementButton", JButton.class).doClick());
+        awaitManagedProjectRows(panelRef.get(), 1);
+
         SwingComponentTestSupport.onEdt(() -> {
             assertEquals(
                     "Project management",
-                    SwingComponentTestSupport.find(panelRef.get(), "placeholderTitle", JLabel.class).getText());
-            SwingComponentTestSupport.find(panelRef.get(), "backButton", JButton.class).doClick();
+                    SwingComponentTestSupport.find(panelRef.get(), "projectManagementTitle", JLabel.class).getText());
+            JTable projects = SwingComponentTestSupport.find(panelRef.get(), "projectManagementTable", JTable.class);
+            assertEquals("Alpha", projects.getValueAt(0, 1));
+            SwingComponentTestSupport.find(panelRef.get(), "projectManagementBackButton", JButton.class).doClick();
         });
 
         awaitProjectRows(panelRef.get(), 1);
@@ -237,6 +246,7 @@ class SwingAppPanelTest {
                     controllers.authenticationController(),
                     controllers.dashboardController(),
                     controllers.accountController(),
+                    controllers.projectController(),
                     titles::update);
             panelRef.set(panel);
             SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText("admin");
@@ -287,6 +297,10 @@ class SwingAppPanelTest {
         awaitRows(panel, "accountUserTable", expectedRows);
     }
 
+    private static void awaitManagedProjectRows(SwingAppPanel panel, int expectedRows) throws Exception {
+        awaitRows(panel, "projectManagementTable", expectedRows);
+    }
+
     private static void awaitRows(SwingAppPanel panel, String tableName, int expectedRows) throws Exception {
         CountDownLatch rowsReady = new CountDownLatch(1);
         AtomicReference<Timer> timerRef = new AtomicReference<>();
@@ -326,6 +340,7 @@ class SwingAppPanelTest {
             List<DashboardProjectSnapshot> projects,
             User... users) {
         var repository = new InMemoryUserRepository(users);
+        var projectRepository = new InMemoryProjectRepository();
         var service = new AuthenticationService(repository, passwordHashing, new SessionStore());
         PermissionPolicy permissionPolicy = new PermissionPolicy();
         return new SwingControllerFixture(
@@ -341,9 +356,17 @@ class SwingAppPanelTest {
                         new AccountService(
                                 permissionPolicy,
                                 repository,
-                                new InMemoryProjectRepository(),
+                                projectRepository,
                                 new InMemoryIssueRepository(),
                                 passwordHashing,
+                                () -> NOW)),
+                new ProjectController(
+                        service,
+                        new ProjectService(
+                                projectRepository,
+                                new InMemoryIssueRepository(),
+                                repository,
+                                permissionPolicy,
                                 () -> NOW)));
     }
 
@@ -371,7 +394,8 @@ class SwingAppPanelTest {
     private record SwingControllerFixture(
             AuthenticationController authenticationController,
             DashboardController dashboardController,
-            AccountController accountController) {
+            AccountController accountController,
+            ProjectController projectController) {
     }
 
     private record FakeDashboardSummaryRepository(


### PR DESCRIPTION
## purpose
Swing 전체 UI에서 Admin 프로젝트 관리 화면을 구현한다. 프로젝트 목록, 생성, 수정 진입점, 삭제 action을 기존 controller 계약에 연결한다.

## non-goals
- 프로젝트 상세/참여자 관리 화면 구현은 #206 범위로 남긴다.
- 프로젝트 중복, 삭제 가능 여부 같은 정책을 Swing에서 재판단하지 않는다.
- JavaFX 프로젝트 관리 화면은 수정하지 않는다.

## diff map
- 핵심 변경: `ProjectManagementPanel`, `ProjectManagementPresenter`, `ProjectDialogs`, `ProjectCreateRequest`, `ProjectManagementView` 추가
- 연결 변경: `SwingAppPanel`의 Admin dashboard에서 project management 화면으로 이동, `SwingAppFrame`에서 `ProjectController` 주입
- 테스트: panel action/selection, presenter controller 호출/오류 처리, app route, UI snapshot 검증 추가

## verification evidence
- `./gradlew test --tests 'com.github.marcellokim.issuetracker.ui.swing.*' --console=plain`
- `./gradlew test --tests 'com.github.marcellokim.issuetracker.ui.swing.ProjectManagementPanelTest.rendersProjectManagementSnapshot' --rerun-tasks --console=plain`
- `./gradlew check --console=plain`
- `./scripts/open-pr.sh` 내부 `./gradlew check` 및 pre-push 검증 통과

## reviewer focus areas
- Swing 화면이 repository를 직접 호출하지 않고 controller 경계만 사용하는지
- create/rename/description/delete 후 목록 refresh와 오류 메시지 처리가 자연스러운지
- project detail 이동이 #206 범위를 침범하지 않는 placeholder route인지
- 선택 행/버튼 활성 상태가 Admin 프로젝트 관리 흐름에 맞는지

## risk / rollback
- 프로젝트 상세 화면은 아직 placeholder라 #206 병합 전까지 상세 동작은 제한된다.
- 롤백은 Swing project management 화면 연결과 신규 panel/presenter/test 제거로 한정된다.

## 관련 이슈
Closes #205

## SonarQubeCloud follow-up
- Quality Gate: OK
- New Code duplication: 8.8% -> 1.0%
- unresolved PR issues: 0