### PR TITLE
feat: Swing 프로젝트 목록 화면 구현

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectListPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectListPanel.java
@@ -1,0 +1,195 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+
+final class ProjectListPanel extends JPanel implements ProjectListView {
+
+    private static final long serialVersionUID = 1L;
+    private static final String[] PROJECT_COLUMNS = {"ID", "Project", "Description", "Members", "Issues"};
+    private static final int[] PROJECT_COLUMN_WIDTHS = {72, 180, 300, 88, 88};
+    private static final Color SELECTION_BACKGROUND = new Color(219, 234, 254);
+    private static final String DEFAULT_ERROR_MESSAGE = "Project list failed. Please try again.";
+
+    private final transient ProjectListActions actions;
+    private final DefaultTableModel projectTableModel = SwingPanelSections.readOnlyTableModel(PROJECT_COLUMNS);
+    private final ProjectTableRows projectRows = new ProjectTableRows(projectTableModel);
+    private final JTable projectTable = table();
+    private final JLabel messageLabel = new JLabel(" ");
+    private final JButton openButton = new JButton("Open issues");
+
+    ProjectListPanel(UserResult user, ProjectListActions actions) {
+        Objects.requireNonNull(user, "user");
+        this.actions = Objects.requireNonNull(actions, "actions");
+
+        setName("projectListPanel");
+        setLayout(new BorderLayout(SwingStyles.SECTION_GAP, SwingStyles.SECTION_GAP));
+        setBackground(SwingStyles.BACKGROUND);
+        setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING));
+
+        add(header(user), BorderLayout.NORTH);
+        add(tableSection(), BorderLayout.CENTER);
+        add(actionBar(), BorderLayout.SOUTH);
+        updateActionState();
+    }
+
+    @Override
+    public void showProjects(List<DashboardProjectSummary> projects) {
+        Objects.requireNonNull(projects, "projects");
+        List<DashboardProjectSummary> snapshot = List.copyOf(projects);
+        SwingPanelSections.runOnEdt(() -> {
+            projectRows.replaceKeepingSelection(projectTable, snapshot);
+            updateActionState();
+        });
+    }
+
+    @Override
+    public void showMessage(String message, boolean error) {
+        SwingPanelSections.runOnEdt(() -> SwingPanelSections.updateMessage(
+                messageLabel,
+                message,
+                error,
+                DEFAULT_ERROR_MESSAGE));
+    }
+
+    void setBusy(boolean busy) {
+        SwingPanelSections.runOnEdt(() -> {
+            projectTable.setEnabled(!busy);
+            updateActionState(!busy);
+        });
+    }
+
+    private JPanel header(UserResult user) {
+        JPanel header = new JPanel(new BorderLayout(SwingStyles.SECTION_GAP, 0));
+        header.setBackground(SwingStyles.SURFACE);
+        header.setBorder(SwingStyles.surfaceBorder());
+
+        JPanel titles = new JPanel();
+        titles.setOpaque(false);
+        titles.setLayout(new BoxLayout(titles, BoxLayout.Y_AXIS));
+
+        JLabel title = new JLabel("Project list");
+        title.setName("projectListTitle");
+        title.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyTitle(title);
+        titles.add(title);
+
+        JLabel userLabel = new JLabel(user.name() + " (" + user.role() + ")");
+        userLabel.setName("projectListUser");
+        userLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyMuted(userLabel);
+        titles.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+        titles.add(userLabel);
+        titles.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+
+        messageLabel.setName("projectListMessage");
+        messageLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyMuted(messageLabel);
+        titles.add(messageLabel);
+
+        JButton logoutButton = new JButton("Logout");
+        logoutButton.setName("projectListLogoutButton");
+        logoutButton.addActionListener(event -> actions.onLogout().run());
+
+        header.add(titles, BorderLayout.CENTER);
+        header.add(logoutButton, BorderLayout.EAST);
+        return header;
+    }
+
+    private JPanel tableSection() {
+        return SwingPanelSections.tableSection("Projects", projectTable);
+    }
+
+    private JPanel actionBar() {
+        JPanel panel = new JPanel();
+        panel.setBackground(SwingStyles.SURFACE);
+        panel.setBorder(SwingStyles.surfaceBorder());
+
+        openButton.setName("openProjectIssuesButton");
+        openButton.addActionListener(event -> selectedProject()
+                .ifPresent(project -> actions.onOpenIssues().accept(project.projectId())));
+        panel.add(openButton);
+        return panel;
+    }
+
+    private JTable table() {
+        JTable table = new JTable(projectTableModel) {
+            @Override
+            public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
+                return SwingPanelSections.stripedTableCell(
+                        this,
+                        super.prepareRenderer(renderer, row, column),
+                        row,
+                        SELECTION_BACKGROUND);
+            }
+        };
+        SwingPanelSections.configureReadOnlyTable(table, "projectListTable", SELECTION_BACKGROUND);
+        table.getSelectionModel().addListSelectionListener(event -> {
+            if (!event.getValueIsAdjusting()) {
+                updateActionState();
+            }
+        });
+        table.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent event) {
+                if (event.getClickCount() == 2 && table.getSelectedRow() >= 0 && table.isEnabled()) {
+                    selectedProject().ifPresent(project ->
+                            actions.onOpenIssues().accept(project.projectId()));
+                }
+            }
+        });
+        applyColumnWidths(table);
+        return table;
+    }
+
+    private Optional<DashboardProjectSummary> selectedProject() {
+        return projectRows.selectedProject(projectTable);
+    }
+
+    private void updateActionState() {
+        updateActionState(projectTable.isEnabled());
+    }
+
+    private void updateActionState(boolean enabled) {
+        openButton.setEnabled(enabled && selectedProject().isPresent());
+    }
+
+    private void applyColumnWidths(JTable table) {
+        SwingPanelSections.applyColumnWidths(table, PROJECT_COLUMN_WIDTHS);
+    }
+
+    @FunctionalInterface
+    interface ProjectOpenConsumer {
+
+        void accept(long projectId);
+    }
+
+    record ProjectListActions(ProjectOpenConsumer onOpenIssues, Runnable onLogout) {
+
+        ProjectListActions {
+            Objects.requireNonNull(onOpenIssues, "onOpenIssues");
+            Objects.requireNonNull(onLogout, "onLogout");
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectListPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectListPresenter.java
@@ -1,0 +1,24 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.controller.DashboardController;
+import java.util.Objects;
+
+final class ProjectListPresenter {
+
+    private final DashboardController dashboardController;
+    private final ProjectListView view;
+
+    ProjectListPresenter(DashboardController dashboardController, ProjectListView view) {
+        this.dashboardController = Objects.requireNonNull(dashboardController, "dashboardController");
+        this.view = Objects.requireNonNull(view, "view");
+    }
+
+    void loadProjects() {
+        try {
+            view.showProjects(dashboardController.viewProjects());
+            view.showMessage(" ", false);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectListView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectListView.java
@@ -1,0 +1,4 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+interface ProjectListView extends ProjectSummaryView {
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanel.java
@@ -6,7 +6,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -15,7 +14,6 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
@@ -40,7 +38,8 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
 
     private final transient ProjectDialogs dialogs;
     private final transient ProjectManagementActions actions;
-    private final DefaultTableModel projectTableModel = readOnlyTableModel();
+    private final DefaultTableModel projectTableModel = SwingPanelSections.readOnlyTableModel(PROJECT_COLUMNS);
+    private final ProjectTableRows projectRows = new ProjectTableRows(projectTableModel);
     private final JTable projectTable = table();
     private final JLabel messageLabel = new JLabel(" ");
     private final JButton createButton = new JButton("Create project");
@@ -48,7 +47,6 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
     private final JButton renameButton = new JButton("Rename");
     private final JButton descriptionButton = new JButton("Change description");
     private final JButton deleteButton = new JButton("Delete");
-    private final List<DashboardProjectSummary> projects = new ArrayList<>();
 
     ProjectManagementPanel(
             UserResult user,
@@ -78,13 +76,7 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
         Objects.requireNonNull(projects, "projects");
         List<DashboardProjectSummary> snapshot = List.copyOf(projects);
         runOnEdt(() -> {
-            Long selectedProjectId = selectedProject()
-                    .map(DashboardProjectSummary::projectId)
-                    .orElse(null);
-            this.projects.clear();
-            this.projects.addAll(snapshot);
-            replaceRows(snapshot);
-            restoreSelection(selectedProjectId);
+            projectRows.replaceKeepingSelection(projectTable, snapshot);
             updateSelectionActions();
         });
     }
@@ -116,17 +108,7 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
     }
 
     private JPanel tableSection() {
-        JPanel section = new JPanel(new BorderLayout(0, SwingStyles.ROW_GAP));
-        section.setBackground(SwingStyles.SURFACE);
-        section.setBorder(SwingStyles.surfaceBorder());
-
-        JLabel title = new JLabel("Projects");
-        SwingStyles.applySectionTitle(title);
-        section.add(title, BorderLayout.NORTH);
-        JScrollPane scrollPane = new JScrollPane(projectTable);
-        scrollPane.setColumnHeaderView(projectTable.getTableHeader());
-        section.add(scrollPane, BorderLayout.CENTER);
-        return section;
+        return SwingPanelSections.tableSection("Projects", projectTable);
     }
 
     private JPanel actions() {
@@ -203,43 +185,7 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
     }
 
     private Optional<DashboardProjectSummary> selectedProject() {
-        int selectedRow = projectTable.getSelectedRow();
-        if (selectedRow < 0) {
-            return Optional.empty();
-        }
-        int modelRow = projectTable.convertRowIndexToModel(selectedRow);
-        if (modelRow < 0 || modelRow >= projects.size()) {
-            return Optional.empty();
-        }
-        return Optional.of(projects.get(modelRow));
-    }
-
-    private void replaceRows(List<DashboardProjectSummary> projects) {
-        projectTableModel.setRowCount(0);
-        for (DashboardProjectSummary project : projects) {
-            projectTableModel.addRow(new Object[]{
-                    project.projectId(),
-                    project.projectName(),
-                    project.projectDescription(),
-                    project.memberCount(),
-                    project.visibleIssueCount()
-            });
-        }
-    }
-
-    private void restoreSelection(Long selectedProjectId) {
-        if (selectedProjectId == null) {
-            return;
-        }
-        for (int row = 0; row < projects.size(); row++) {
-            if (selectedProjectId == projects.get(row).projectId()) {
-                int viewRow = projectTable.convertRowIndexToView(row);
-                if (viewRow >= 0) {
-                    projectTable.setRowSelectionInterval(viewRow, viewRow);
-                }
-                return;
-            }
-        }
+        return projectRows.selectedProject(projectTable);
     }
 
     private void updateSelectionActions() {
@@ -255,21 +201,7 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
     }
 
     private void applyColumnWidths(JTable table) {
-        if (table.getColumnCount() != PROJECT_COLUMN_WIDTHS.length) {
-            return;
-        }
-        for (int index = 0; index < PROJECT_COLUMN_WIDTHS.length; index++) {
-            table.getColumnModel().getColumn(index).setPreferredWidth(PROJECT_COLUMN_WIDTHS[index]);
-        }
-    }
-
-    private static DefaultTableModel readOnlyTableModel() {
-        return new DefaultTableModel(PROJECT_COLUMNS, 0) {
-            @Override
-            public boolean isCellEditable(int row, int column) {
-                return false;
-            }
-        };
+        SwingPanelSections.applyColumnWidths(table, PROJECT_COLUMN_WIDTHS);
     }
 
     private static void runOnEdt(Runnable action) {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementView.java
@@ -1,11 +1,4 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
-import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
-import java.util.List;
-
-interface ProjectManagementView {
-
-    void showProjects(List<DashboardProjectSummary> projects);
-
-    void showMessage(String message, boolean error);
+interface ProjectManagementView extends ProjectSummaryView {
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectSummaryView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectSummaryView.java
@@ -1,0 +1,11 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import java.util.List;
+
+interface ProjectSummaryView {
+
+    void showProjects(List<DashboardProjectSummary> projects);
+
+    void showMessage(String message, boolean error);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectTableRows.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectTableRows.java
@@ -1,0 +1,58 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableModel;
+
+final class ProjectTableRows {
+
+    private final DefaultTableModel model;
+    private final List<DashboardProjectSummary> projects = new ArrayList<>();
+
+    ProjectTableRows(DefaultTableModel model) {
+        this.model = model;
+    }
+
+    void replaceKeepingSelection(JTable table, List<DashboardProjectSummary> newProjects) {
+        Optional<Long> selectedProjectId = selectedProject(table).map(DashboardProjectSummary::projectId);
+        projects.clear();
+        projects.addAll(newProjects);
+        model.setRowCount(0);
+        newProjects.forEach(project -> model.addRow(new Object[]{
+                project.projectId(),
+                project.projectName(),
+                project.projectDescription(),
+                project.memberCount(),
+                project.visibleIssueCount()
+        }));
+        selectedProjectId.ifPresent(projectId -> restoreSelection(table, projectId));
+    }
+
+    Optional<DashboardProjectSummary> selectedProject(JTable table) {
+        int selectedRow = table.getSelectedRow();
+        if (selectedRow < 0) {
+            return Optional.empty();
+        }
+
+        int modelRow = table.convertRowIndexToModel(selectedRow);
+        if (modelRow < 0 || modelRow >= projects.size()) {
+            return Optional.empty();
+        }
+        return Optional.of(projects.get(modelRow));
+    }
+
+    private void restoreSelection(JTable table, long selectedProjectId) {
+        for (int row = 0; row < projects.size(); row++) {
+            if (projects.get(row).projectId() == selectedProjectId) {
+                int viewRow = table.convertRowIndexToView(row);
+                if (viewRow >= 0) {
+                    table.setRowSelectionInterval(viewRow, viewRow);
+                }
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -44,6 +44,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private final transient AtomicReference<AccountManagementWorker> accountWorker = new AtomicReference<>();
     private final transient AtomicReference<ProjectManagementWorker> projectWorker = new AtomicReference<>();
     private final transient AtomicReference<ProjectDetailWorker> projectDetailWorker = new AtomicReference<>();
+    private final transient AtomicReference<ProjectListWorker> projectListWorker = new AtomicReference<>();
 
     SwingAppPanel(
             AuthenticationController authenticationController,
@@ -75,6 +76,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelAccountWorker();
             cancelProjectWorker();
             cancelProjectDetailWorker();
+            cancelProjectListWorker();
             titleUpdater.accept("Issue Tracker");
             loginPanel.showMessage(" ", false);
             loginPanel.clearPassword();
@@ -91,6 +93,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelAccountWorker();
             cancelProjectWorker();
             cancelProjectDetailWorker();
+            cancelProjectListWorker();
             titleUpdater.accept("Admin dashboard");
             AdminDashboardPanel panel = new AdminDashboardPanel(
                     user,
@@ -114,9 +117,19 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelAccountWorker();
             cancelProjectWorker();
             cancelProjectDetailWorker();
+            cancelProjectListWorker();
             titleUpdater.accept("Project list");
-            showPlaceholder(projectListCard, "Project list", user);
+            ProjectListPanel panel = new ProjectListPanel(
+                    user,
+                    new ProjectListPanel.ProjectListActions(
+                            projectId -> showIssueList(user, projectId),
+                            this::logout));
+            projectListCard.removeAll();
+            projectListCard.add(panel, BorderLayout.CENTER);
+            projectListCard.revalidate();
+            projectListCard.repaint();
             cardLayout.show(this, PROJECT_LIST_CARD);
+            startProjectListTask(panel, ProjectListPresenter::loadProjects);
         });
     }
 
@@ -125,6 +138,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         cancelAccountWorker();
         cancelProjectWorker();
         cancelProjectDetailWorker();
+        cancelProjectListWorker();
         authenticationController.logout();
         showLogin();
     }
@@ -174,10 +188,6 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         });
     }
 
-    private void showPlaceholder(JPanel card, String destination, UserResult user) {
-        showPlaceholder(card, destination, user, null);
-    }
-
     private void showPlaceholder(JPanel card, String destination, UserResult user, Runnable onBack) {
         card.removeAll();
         card.add(new PlaceholderPanel(destination, user, onBack, this::logout), BorderLayout.CENTER);
@@ -191,6 +201,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelAccountWorker();
             cancelProjectWorker();
             cancelProjectDetailWorker();
+            cancelProjectListWorker();
             titleUpdater.accept("Account management");
             AccountManagementPanel panel = new AccountManagementPanel(
                     user,
@@ -219,6 +230,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelAccountWorker();
             cancelProjectWorker();
             cancelProjectDetailWorker();
+            cancelProjectListWorker();
             titleUpdater.accept("Project management");
             ProjectManagementPanel panel = new ProjectManagementPanel(
                     user,
@@ -254,6 +266,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelAccountWorker();
             cancelProjectWorker();
             cancelProjectDetailWorker();
+            cancelProjectListWorker();
             titleUpdater.accept("Project detail");
             ProjectDetailPanel panel = new ProjectDetailPanel(
                     user,
@@ -284,6 +297,19 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             adminDashboardCard.repaint();
             cardLayout.show(this, ADMIN_DASHBOARD_CARD);
             startProjectDetailTask(panel, presenter -> presenter.loadProject(projectId));
+        });
+    }
+
+    private void showIssueList(UserResult user, long projectId) {
+        SwingUtilities.invokeLater(() -> {
+            cancelDashboardWorker();
+            cancelAccountWorker();
+            cancelProjectWorker();
+            cancelProjectDetailWorker();
+            cancelProjectListWorker();
+            titleUpdater.accept("Issue list");
+            showPlaceholder(projectListCard, "Issue list #" + projectId, user, () -> showProjectList(user));
+            cardLayout.show(this, PROJECT_LIST_CARD);
         });
     }
 
@@ -346,6 +372,23 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     private void cancelProjectDetailWorker() {
         ProjectDetailWorker worker = projectDetailWorker.getAndSet(null);
+        if (worker != null && !worker.isDone()) {
+            worker.cancel(true);
+        }
+    }
+
+    private void startProjectListTask(ProjectListPanel panel, ProjectListTask task) {
+        Objects.requireNonNull(panel, "panel");
+        Objects.requireNonNull(task, "task");
+        cancelProjectListWorker();
+        panel.setBusy(true);
+        ProjectListWorker worker = new ProjectListWorker(panel, task);
+        projectListWorker.set(worker);
+        worker.execute();
+    }
+
+    private void cancelProjectListWorker() {
+        ProjectListWorker worker = projectListWorker.getAndSet(null);
         if (worker != null && !worker.isDone()) {
             worker.cancel(true);
         }
@@ -492,6 +535,31 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         }
     }
 
+    private final class ProjectListWorker extends SwingWorker<Void, Void> {
+
+        private final ProjectListPanel panel;
+        private final ProjectListTask task;
+
+        private ProjectListWorker(ProjectListPanel panel, ProjectListTask task) {
+            this.panel = Objects.requireNonNull(panel, "panel");
+            this.task = Objects.requireNonNull(task, "task");
+        }
+
+        @Override
+        protected Void doInBackground() {
+            ProjectListPresenter presenter = new ProjectListPresenter(
+                    dashboardController,
+                    new CurrentProjectListView(panel, this));
+            task.run(presenter);
+            return null;
+        }
+
+        @Override
+        protected void done() {
+            finishWorker(projectListWorker, this, () -> panel.setBusy(false), panel::showMessage, "Project list");
+        }
+    }
+
     private static <T extends SwingWorker<Void, Void>> void finishWorker(
             AtomicReference<T> workerRef,
             T worker,
@@ -544,32 +612,12 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         }
     }
 
-    private final class CurrentProjectManagementView implements ProjectManagementView {
-
-        private final ProjectManagementPanel delegate;
-        private final ProjectManagementWorker worker;
+    private final class CurrentProjectManagementView
+            extends CurrentProjectSummaryView<ProjectManagementWorker>
+            implements ProjectManagementView {
 
         private CurrentProjectManagementView(ProjectManagementPanel delegate, ProjectManagementWorker worker) {
-            this.delegate = Objects.requireNonNull(delegate, "delegate");
-            this.worker = Objects.requireNonNull(worker, WORKER_NAME);
-        }
-
-        @Override
-        public void showProjects(List<DashboardProjectSummary> projects) {
-            if (isCurrent()) {
-                delegate.showProjects(projects);
-            }
-        }
-
-        @Override
-        public void showMessage(String message, boolean error) {
-            if (isCurrent()) {
-                delegate.showMessage(message, error);
-            }
-        }
-
-        private boolean isCurrent() {
-            return projectWorker.get() == worker && !worker.isCancelled();
+            super(delegate, worker, projectWorker::get);
         }
     }
 
@@ -609,6 +657,46 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         }
     }
 
+    private final class CurrentProjectListView
+            extends CurrentProjectSummaryView<ProjectListWorker>
+            implements ProjectListView {
+
+        private CurrentProjectListView(ProjectListPanel delegate, ProjectListWorker worker) {
+            super(delegate, worker, projectListWorker::get);
+        }
+    }
+
+    private abstract class CurrentProjectSummaryView<T extends SwingWorker<Void, Void>> implements ProjectSummaryView {
+
+        private final ProjectSummaryView delegate;
+        private final T worker;
+        private final Supplier<T> currentWorker;
+
+        private CurrentProjectSummaryView(ProjectSummaryView delegate, T worker, Supplier<T> currentWorker) {
+            this.delegate = Objects.requireNonNull(delegate, "delegate");
+            this.worker = Objects.requireNonNull(worker, WORKER_NAME);
+            this.currentWorker = Objects.requireNonNull(currentWorker, "currentWorker");
+        }
+
+        @Override
+        public void showProjects(List<DashboardProjectSummary> projects) {
+            if (isCurrent()) {
+                delegate.showProjects(projects);
+            }
+        }
+
+        @Override
+        public void showMessage(String message, boolean error) {
+            if (isCurrent()) {
+                delegate.showMessage(message, error);
+            }
+        }
+
+        private boolean isCurrent() {
+            return currentWorker.get() == worker && !worker.isCancelled();
+        }
+    }
+
     @FunctionalInterface
     private interface AccountTask {
 
@@ -625,6 +713,12 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private interface ProjectDetailTask {
 
         void run(ProjectDetailPresenter presenter);
+    }
+
+    @FunctionalInterface
+    private interface ProjectListTask {
+
+        void run(ProjectListPresenter presenter);
     }
 
     private final class CurrentDashboardView implements AdminDashboardView {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingPanelSections.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingPanelSections.java
@@ -14,8 +14,11 @@ import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
+import javax.swing.SwingUtilities;
+import javax.swing.table.DefaultTableModel;
 
 final class SwingPanelSections {
 
@@ -141,6 +144,47 @@ final class SwingPanelSections {
         table.setSelectionBackground(selectionBackground);
         table.setSelectionForeground(SwingStyles.BODY_TEXT);
         table.getTableHeader().setReorderingAllowed(false);
+    }
+
+    static JPanel tableSection(String title, JTable table) {
+        JPanel section = new JPanel(new BorderLayout(0, SwingStyles.ROW_GAP));
+        section.setBackground(SwingStyles.SURFACE);
+        section.setBorder(SwingStyles.surfaceBorder());
+
+        JLabel label = new JLabel(title);
+        SwingStyles.applySectionTitle(label);
+        section.add(label, BorderLayout.NORTH);
+
+        JScrollPane scrollPane = new JScrollPane(table);
+        scrollPane.setColumnHeaderView(table.getTableHeader());
+        section.add(scrollPane, BorderLayout.CENTER);
+        return section;
+    }
+
+    static void applyColumnWidths(JTable table, int[] widths) {
+        if (table.getColumnCount() != widths.length) {
+            return;
+        }
+        for (int index = 0; index < widths.length; index++) {
+            table.getColumnModel().getColumn(index).setPreferredWidth(widths[index]);
+        }
+    }
+
+    static DefaultTableModel readOnlyTableModel(String[] columns) {
+        return new DefaultTableModel(columns, 0) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return false;
+            }
+        };
+    }
+
+    static void runOnEdt(Runnable action) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            action.run();
+        } else {
+            SwingUtilities.invokeLater(action);
+        }
     }
 
     record HeaderLabels(

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectListPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectListPanelTest.java
@@ -1,0 +1,218 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Graphics2D;
+import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.imageio.ImageIO;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JTable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing project list panel")
+class ProjectListPanelTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("renders projects and selection-sensitive open action")
+    void rendersProjectsAndSelectionSensitiveOpenAction() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            ProjectListPanel panel = panel();
+            panel.showProjects(List.of(
+                    projectSummary(1L, "Alpha", "Alpha project", 3, 7),
+                    projectSummary(2L, "Beta", "Beta project", 1, 0)));
+
+            JTable table = SwingComponentTestSupport.find(panel, "projectListTable", JTable.class);
+            JButton open = SwingComponentTestSupport.find(panel, "openProjectIssuesButton", JButton.class);
+
+            assertEquals(2, table.getRowCount());
+            assertEquals("Alpha", table.getValueAt(0, 1));
+            assertEquals("Alpha project", table.getValueAt(0, 2));
+            assertEquals(false, open.isEnabled());
+
+            table.setRowSelectionInterval(1, 1);
+
+            assertEquals(true, open.isEnabled());
+        });
+    }
+
+    @Test
+    @DisplayName("publishes selected project and logout actions")
+    void publishesSelectedProjectAndLogoutActions() throws Exception {
+        var openedProjectId = new AtomicLong();
+        var logoutClicks = new AtomicInteger();
+
+        SwingComponentTestSupport.onEdt(() -> {
+            ProjectListPanel panel = new ProjectListPanel(
+                    userResult("dev1", Role.DEV, true),
+                    new ProjectListPanel.ProjectListActions(
+                            openedProjectId::set,
+                            logoutClicks::incrementAndGet));
+            panel.showProjects(List.of(projectSummary(7L, "Alpha", "Alpha project", 3, 7)));
+            JTable table = SwingComponentTestSupport.find(panel, "projectListTable", JTable.class);
+            table.setRowSelectionInterval(0, 0);
+
+            SwingComponentTestSupport.find(panel, "openProjectIssuesButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "projectListLogoutButton", JButton.class).doClick();
+        });
+
+        assertEquals(7L, openedProjectId.get());
+        assertEquals(1, logoutClicks.get());
+    }
+
+    @Test
+    @DisplayName("opens selected project on double click")
+    void opensSelectedProjectOnDoubleClick() throws Exception {
+        var openedProjectId = new AtomicLong();
+
+        SwingComponentTestSupport.onEdt(() -> {
+            ProjectListPanel panel = new ProjectListPanel(
+                    userResult("tester1", Role.TESTER, true),
+                    new ProjectListPanel.ProjectListActions(
+                            openedProjectId::set,
+                            () -> {
+                            }));
+            panel.showProjects(List.of(projectSummary(9L, "Gamma", "Gamma project", 2, 4)));
+            JTable table = SwingComponentTestSupport.find(panel, "projectListTable", JTable.class);
+            table.setRowSelectionInterval(0, 0);
+
+            MouseEvent doubleClick = new MouseEvent(
+                    table,
+                    MouseEvent.MOUSE_CLICKED,
+                    System.currentTimeMillis(),
+                    0,
+                    8,
+                    8,
+                    2,
+                    false);
+            table.dispatchEvent(doubleClick);
+        });
+
+        assertEquals(9L, openedProjectId.get());
+    }
+
+    @Test
+    @DisplayName("shows fallback text for blank error messages")
+    void showsFallbackTextForBlankErrors() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            ProjectListPanel panel = panel();
+            panel.showMessage(" ", true);
+
+            JLabel message = SwingComponentTestSupport.find(panel, "projectListMessage", JLabel.class);
+
+            assertEquals("Project list failed. Please try again.", message.getText());
+        });
+    }
+
+    @Test
+    @DisplayName("renders project list screen snapshot")
+    void rendersProjectListSnapshot() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            ProjectListPanel panel = panel();
+            panel.showProjects(List.of(
+                    projectSummary(1L, "Alpha", "Alpha project", 3, 7),
+                    projectSummary(2L, "Beta", "Beta project", 1, 0)));
+            panel.setSize(SwingStyles.WINDOW_SIZE);
+            layoutRecursively(panel);
+
+            BufferedImage initial = render(panel, Path.of("build/reports/ui/project-list-panel.png"));
+            assertTrue(hasRenderedContent(initial));
+
+            JTable table = SwingComponentTestSupport.find(panel, "projectListTable", JTable.class);
+            table.setRowSelectionInterval(0, 0);
+            BufferedImage selected = render(panel, Path.of("build/reports/ui/project-list-panel-selected.png"));
+            assertTrue(hasRenderedContent(selected));
+        });
+    }
+
+    private static ProjectListPanel panel() {
+        return new ProjectListPanel(
+                userResult("dev1", Role.DEV, true),
+                new ProjectListPanel.ProjectListActions(
+                        projectId -> {
+                        },
+                        () -> {
+                        }));
+    }
+
+    private static DashboardProjectSummary projectSummary(
+            long projectId,
+            String name,
+            String description,
+            int memberCount,
+            int issueCount) {
+        return new DashboardProjectSummary(
+                projectId,
+                name,
+                description,
+                memberCount,
+                1,
+                1,
+                1,
+                issueCount,
+                Map.of(IssueStatus.NEW, issueCount));
+    }
+
+    private static UserResult userResult(String loginId, Role role, boolean active) {
+        return UserResult.from(User.fromPersistence(loginId, loginId, "stored-password", role, active, NOW, NOW));
+    }
+
+    private static void layoutRecursively(Container container) {
+        container.doLayout();
+        for (java.awt.Component child : container.getComponents()) {
+            if (child instanceof Container nested) {
+                layoutRecursively(nested);
+            }
+        }
+    }
+
+    private static BufferedImage render(ProjectListPanel panel, Path output) throws java.io.IOException {
+        BufferedImage image = new BufferedImage(
+                SwingStyles.WINDOW_SIZE.width,
+                SwingStyles.WINDOW_SIZE.height,
+                BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            panel.printAll(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        Files.createDirectories(output.getParent());
+        ImageIO.write(image, "png", output.toFile());
+        return image;
+    }
+
+    private static boolean hasRenderedContent(BufferedImage image) {
+        int background = SwingStyles.BACKGROUND.getRGB();
+        int white = Color.WHITE.getRGB();
+        int contentPixels = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                int pixel = image.getRGB(x, y);
+                if (pixel != background && pixel != white) {
+                    contentPixels++;
+                }
+            }
+        }
+        return contentPixels > 10_000;
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectListPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/ProjectListPresenterTest.java
@@ -1,0 +1,174 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository;
+import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository.DashboardProjectSnapshot;
+import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
+import com.github.marcellokim.issuetracker.service.PasswordHashing;
+import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.technical.SessionStore;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing project list presenter")
+class ProjectListPresenterTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("loads projects through dashboard controller")
+    void loadsProjectsThroughDashboardController() {
+        RecordingProjectListView view = new RecordingProjectListView();
+        ProjectListPresenter presenter = new ProjectListPresenter(
+                dashboardController(true, projectSnapshot(1L, "Alpha", 3, 7)),
+                view);
+
+        presenter.loadProjects();
+
+        assertEquals(List.of("Alpha"), view.projectNames());
+        assertEquals(" ", view.message());
+    }
+
+    @Test
+    @DisplayName("shows controller errors without replacing current project list")
+    void showsControllerErrorsWithoutReplacingCurrentProjectList() {
+        RecordingProjectListView view = new RecordingProjectListView();
+        view.showProjects(List.of(projectSummary(1L, "Alpha")));
+        ProjectListPresenter presenter = new ProjectListPresenter(
+                dashboardController(false, projectSnapshot(2L, "Beta", 1, 0)),
+                view);
+
+        presenter.loadProjects();
+
+        assertEquals(List.of("Alpha"), view.projectNames());
+        assertEquals("Login is required.", view.message());
+    }
+
+    private static DashboardController dashboardController(boolean loggedIn, DashboardProjectSnapshot... projects) {
+        var users = new InMemoryUserRepository(user("dev1", Role.DEV, true));
+        AuthenticationService authentication = new AuthenticationService(users, new AcceptingPasswordHashing(), new SessionStore());
+        if (loggedIn) {
+            authentication.login("dev1", "password");
+        }
+        return new DashboardController(
+                authentication,
+                new DashboardSummaryService(
+                        new FixedDashboardSummaryRepository(List.of(projects)),
+                        users,
+                        new PermissionPolicy()));
+    }
+
+    private static DashboardProjectSnapshot projectSnapshot(
+            long projectId,
+            String projectName,
+            int memberCount,
+            int visibleIssueCount) {
+        return new DashboardProjectSnapshot(
+                projectId,
+                projectName,
+                "Demo project",
+                memberCount,
+                1,
+                1,
+                1,
+                visibleIssueCount,
+                Map.of(IssueStatus.NEW, visibleIssueCount));
+    }
+
+    private static DashboardProjectSummary projectSummary(long projectId, String projectName) {
+        return new DashboardProjectSummary(
+                projectId,
+                projectName,
+                "Demo project",
+                1,
+                0,
+                1,
+                0,
+                0,
+                Map.of(IssueStatus.NEW, 0));
+    }
+
+    private static User user(String loginId, Role role, boolean active) {
+        return User.fromPersistence(loginId, loginId, "stored-password", role, active, NOW, NOW);
+    }
+
+    private record FixedDashboardSummaryRepository(
+            List<DashboardProjectSnapshot> projects) implements DashboardSummaryRepository {
+
+        @Override
+        public List<DashboardProjectSnapshot> findAllProjectSummaries() {
+            return projects;
+        }
+
+        @Override
+        public List<DashboardProjectSnapshot> findProjectSummariesByParticipant(String loginId) {
+            return projects;
+        }
+    }
+
+    private static final class RecordingProjectListView implements ProjectListView {
+
+        private List<DashboardProjectSummary> projects = List.of();
+        private String message = " ";
+
+        @Override
+        public void showProjects(List<DashboardProjectSummary> projects) {
+            this.projects = List.copyOf(projects);
+            this.message = " ";
+        }
+
+        @Override
+        public void showMessage(String message, boolean error) {
+            this.message = message;
+        }
+
+        private List<String> projectNames() {
+            return projects.stream()
+                    .map(DashboardProjectSummary::projectName)
+                    .toList();
+        }
+
+        private String message() {
+            return message;
+        }
+    }
+
+    private static final class AcceptingPasswordHashing implements PasswordHashing {
+
+        @Override
+        public String hash(String password) {
+            return "hashed-" + password;
+        }
+
+        @Override
+        public boolean matches(String password, String storedCredential) {
+            return true;
+        }
+
+        @Override
+        public boolean isHashed(String storedCredential) {
+            return true;
+        }
+
+        @Override
+        public String saltOf(String storedCredential) {
+            return "salt";
+        }
+
+        @Override
+        public String hashOf(String storedCredential) {
+            return storedCredential;
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -349,6 +349,119 @@ class SwingAppPanelTest {
         });
     }
 
+    @Test
+    @DisplayName("project user login shows project list data")
+    void projectUserLoginShowsProjectListData() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        SwingAppPanel panel = loginProjectUser(
+                passwordHashing,
+                titles,
+                List.of(projectSnapshot(1L, "Alpha", 3, 7)),
+                user("dev1", Role.DEV));
+
+        SwingComponentTestSupport.onEdt(() -> {
+            assertEquals(
+                    "Project list",
+                    SwingComponentTestSupport.find(panel, "projectListTitle", JLabel.class).getText());
+            JTable projects = SwingComponentTestSupport.find(panel, "projectListTable", JTable.class);
+            assertEquals("Alpha", projects.getValueAt(0, 1));
+        });
+    }
+
+    @Test
+    @DisplayName("project list opens issue list placeholder with selected project id")
+    void projectListOpensIssueListPlaceholderWithSelectedProjectId() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        SwingAppPanel panel = loginProjectUser(
+                passwordHashing,
+                titles,
+                List.of(projectSnapshot(7L, "Alpha", 3, 7)),
+                user("tester1", Role.TESTER));
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable projects = SwingComponentTestSupport.find(panel, "projectListTable", JTable.class);
+            projects.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openProjectIssuesButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openProjectIssuesButton", JButton.class).doClick());
+        awaitPlaceholderTitle(panel, "Issue list #7");
+
+        SwingComponentTestSupport.onEdt(() -> {
+            assertEquals(
+                    "Issue list #7",
+                    SwingComponentTestSupport.find(panel, "placeholderTitle", JLabel.class).getText());
+            SwingComponentTestSupport.find(panel, "backButton", JButton.class).doClick();
+        });
+        awaitProjectListRows(panel, 1);
+    }
+
+    @Test
+    @DisplayName("project list logout returns to login")
+    void projectListLogoutReturnsToLogin() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        SwingAppPanel panel = loginProjectUser(
+                passwordHashing,
+                titles,
+                List.of(projectSnapshot(1L, "Alpha", 3, 7)),
+                user("pl1", Role.PL));
+
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "projectListLogoutButton", JButton.class).doClick());
+
+        SwingComponentTestSupport.onEdt(() -> {
+            assertTrue(SwingComponentTestSupport.find(panel, "signInButton", JButton.class).isEnabled());
+            assertEquals("", new String(SwingComponentTestSupport.find(
+                    panel,
+                    "passwordField",
+                    JPasswordField.class).getPassword()));
+        });
+    }
+
+    private static SwingAppPanel loginProjectUser(
+            RecordingPasswordHashing passwordHashing,
+            RecordingTitleUpdater titles,
+            List<DashboardProjectSnapshot> projects,
+            User user) throws Exception {
+        var panelRef = new AtomicReference<SwingAppPanel>();
+        var workerDone = new CountDownLatch(1);
+        SwingControllerFixture controllers = controllers(passwordHashing, projects, user);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            SwingAppPanel panel = new SwingAppPanel(
+                    controllers.authenticationController(),
+                    controllers.dashboardController(),
+                    controllers.accountController(),
+                    controllers.projectController(),
+                    titles::update);
+            panelRef.set(panel);
+            SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText(user.getLoginId());
+            SwingComponentTestSupport.find(panel, "passwordField", JPasswordField.class).setText("submitted-password");
+            SwingComponentTestSupport.find(panel, "signInButton", JButton.class).doClick();
+            SwingWorker<?, ?> worker = loginWorker(panel);
+            worker.addPropertyChangeListener(event -> {
+                if ("state".equals(event.getPropertyName())
+                        && SwingWorker.StateValue.DONE == event.getNewValue()) {
+                    workerDone.countDown();
+                }
+            });
+            if (SwingWorker.StateValue.DONE == worker.getState()) {
+                workerDone.countDown();
+            }
+        });
+
+        assertTrue(passwordHashing.awaitMatch());
+        assertTrue(titles.awaitProjectList());
+        assertTrue(workerDone.await(5, TimeUnit.SECONDS));
+        SwingAppPanel panel = panelRef.get();
+        assertNotNull(panel);
+        awaitProjectListRows(panel, projects.size());
+        return panel;
+    }
+
     private static SwingWorker<?, ?> loginWorker(SwingAppPanel panel) throws ReflectiveOperationException {
         Field worker = SwingAppPanel.class.getDeclaredField("loginWorker");
         worker.setAccessible(true);
@@ -365,6 +478,10 @@ class SwingAppPanelTest {
 
     private static void awaitManagedProjectRows(SwingAppPanel panel, int expectedRows) throws Exception {
         awaitRows(panel, "projectManagementTable", expectedRows);
+    }
+
+    private static void awaitProjectListRows(SwingAppPanel panel, int expectedRows) throws Exception {
+        awaitRows(panel, "projectListTable", expectedRows);
     }
 
     private static void awaitProjectDetailName(SwingAppPanel panel, String expectedName) throws Exception {
@@ -398,6 +515,40 @@ class SwingAppPanelTest {
                 assertEquals(
                         expectedName,
                         SwingComponentTestSupport.find(panel, "projectDetailNameValue", JLabel.class).getText());
+            }
+        });
+    }
+
+    private static void awaitPlaceholderTitle(SwingAppPanel panel, String expectedTitle) throws Exception {
+        CountDownLatch placeholderReady = new CountDownLatch(1);
+        AtomicReference<Timer> timerRef = new AtomicReference<>();
+        SwingComponentTestSupport.onEdt(() -> {
+            Timer timer = new Timer(25, event -> {
+                try {
+                    String actual = SwingComponentTestSupport.find(panel, "placeholderTitle", JLabel.class).getText();
+                    if (expectedTitle.equals(actual)) {
+                        ((Timer) event.getSource()).stop();
+                        placeholderReady.countDown();
+                    }
+                } catch (AssertionError ignored) {
+                    // Placeholder is installed asynchronously after navigation.
+                }
+            });
+            timer.setRepeats(true);
+            timerRef.set(timer);
+            timer.start();
+        });
+
+        boolean ready = placeholderReady.await(5, TimeUnit.SECONDS);
+        SwingComponentTestSupport.onEdt(() -> {
+            Timer timer = timerRef.get();
+            if (timer != null) {
+                timer.stop();
+            }
+            if (!ready) {
+                assertEquals(
+                        expectedTitle,
+                        SwingComponentTestSupport.find(panel, "placeholderTitle", JLabel.class).getText());
             }
         });
     }
@@ -545,7 +696,7 @@ class SwingAppPanelTest {
 
         @Override
         public List<DashboardProjectSnapshot> findProjectSummariesByParticipant(String loginId) {
-            return List.of();
+            return projects;
         }
     }
 
@@ -599,15 +750,23 @@ class SwingAppPanelTest {
     private static final class RecordingTitleUpdater {
 
         private final CountDownLatch adminDashboardShown = new CountDownLatch(1);
+        private final CountDownLatch projectListShown = new CountDownLatch(1);
 
         private void update(String title) {
             if ("Admin dashboard".equals(title)) {
                 adminDashboardShown.countDown();
             }
+            if ("Project list".equals(title)) {
+                projectListShown.countDown();
+            }
         }
 
         private boolean awaitAdminDashboard() throws InterruptedException {
             return adminDashboardShown.await(5, TimeUnit.SECONDS);
+        }
+
+        private boolean awaitProjectList() throws InterruptedException {
+            return projectListShown.await(5, TimeUnit.SECONDS);
         }
     }
 }


### PR DESCRIPTION
## purpose
Closes #207

Swing 실사용자용 프로젝트 목록 화면을 추가함. 로그인 후 ADMIN이 아닌 사용자는 참여 프로젝트 목록을 보고, 선택한 프로젝트의 이슈 목록 자리로 이동할 수 있게 함.

## non-goals
- 실제 이슈 목록/상세/수정 화면 구현은 후속 이슈에서 처리함.
- JavaFX 화면 동작은 변경하지 않음.
- 백엔드 권한/조회 정책은 변경하지 않음.

## diff map
- 핵심 변경: `ProjectListPanel`, `ProjectListPresenter`, `ProjectListView` 추가
- 앱 연결: `SwingAppPanel`에서 non-admin 로그인 후 프로젝트 목록 카드로 라우팅하고 이슈 목록 placeholder 연결
- 공통화: Swing 프로젝트 테이블 행 상태, 읽기 전용 테이블 모델, 테이블 섹션/컬럼 설정을 공통 지원 코드로 정리
- 테스트: 프로젝트 목록 패널/프레젠터, Swing 앱 라우팅 및 스냅샷 검증 추가

## verification evidence
- `git diff --check`
- `./gradlew test --tests '*ProjectList*' --tests '*ProjectManagement*' --tests '*SwingAppPanelTest' --console=plain`
- `./gradlew check --console=plain`
- push 전 hook: test + repository setup 통과
- 렌더링 증빙: `build/reports/ui/project-list-panel.png`, `build/reports/ui/project-list-panel-selected.png`

## reviewer focus areas
- non-admin 로그인 후 프로젝트 목록으로 이동하는 흐름
- 프로젝트 선택/더블클릭/로그아웃 동작
- 프로젝트 관리 화면과 공유하는 테이블 상태 공통화가 기존 admin 화면 동작을 깨지 않는지
- 후속 이슈 목록 구현과 연결될 `showIssueList` placeholder 경계

## risk / rollback
- Swing UI 내부 변경이라 백엔드 데이터/정책 영향은 없음.
- 문제가 있으면 프로젝트 목록 카드 연결과 새 패널/프레젠터 추가분을 되돌리면 됨.