### PR TITLE
feat: Swing 이슈 목록/등록 화면 구현

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/controller/IssueController.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/controller/IssueController.java
@@ -87,6 +87,12 @@ public final class IssueController {
                 user.getLoginId());
     }
 
+    public List<IssueSummary> searchRelatedProjectIssues(long projectId, String keyword, IssueStatus status,
+            Priority priority) {
+        User user = requireCurrentUser();
+        return issueService.searchRelatedProjectIssues(projectId, keyword, status, priority, user.getLoginId());
+    }
+
     public List<IssueSummary> viewRelatedProjectIssues(long projectId) {
         User user = requireCurrentUser();
         return issueService.viewRelatedProjectIssues(projectId, user.getLoginId());

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
@@ -138,20 +138,15 @@ public final class IssueService {
             LocalDateTime reportedTo,
             String currentLoginId) {
 
-        long requiredProjectId = requirePositive(projectId, FIELD_PROJECT_ID);
-        String requiredLoginId = requireText(currentLoginId, FIELD_CURRENT_LOGIN_ID);
-        if (reportedFrom != null && reportedTo != null && reportedFrom.isAfter(reportedTo)) {
-            throw new IllegalArgumentException("reportedFrom must not be after reportedTo.");
-        }
-        findProject(requiredProjectId);
-        User actor = findUser(requiredLoginId);
-        permissionPolicy.assertCanViewIssue(actor);
-        if (status == IssueStatus.DELETED) {
-            throw new SecurityException("Deleted issues must be managed through deleted issue workflow.");
-        }
-        requireActiveProjectMember(actor, requiredProjectId, "Only project members can search issues.");
-        return issueRepository.findByCriteria(IssueSearchCriteria.create(
-                requiredProjectId,
+        SearchContext context = searchContext(
+                projectId,
+                status,
+                reportedFrom,
+                reportedTo,
+                currentLoginId,
+                "Only project members can search issues.");
+        return searchIssuesByCriteria(IssueSearchCriteria.create(
+                context.projectId(),
                 status,
                 priority,
                 optionalText(reporterId),
@@ -161,7 +156,36 @@ public final class IssueService {
                 reportedFrom,
                 reportedTo,
                 false)).stream()
-                .filter(issue -> issue.projectId() == requiredProjectId)
+                .map(IssueService::toIssueSummary)
+                .toList();
+    }
+
+    public List<IssueSummary> searchRelatedProjectIssues(
+            long projectId,
+            String keyword,
+            IssueStatus status,
+            Priority priority,
+            String currentLoginId) {
+
+        SearchContext context = searchContext(
+                projectId,
+                status,
+                null,
+                null,
+                currentLoginId,
+                "Only project members can search related project issues.");
+        return searchIssuesByCriteria(IssueSearchCriteria.create(
+                context.projectId(),
+                status,
+                priority,
+                null,
+                null,
+                null,
+                optionalText(keyword),
+                null,
+                null,
+                false)).stream()
+                .filter(issue -> canViewInRelatedList(context.actor(), issue))
                 .map(IssueService::toIssueSummary)
                 .toList();
     }
@@ -184,7 +208,7 @@ public final class IssueService {
                 null,
                 null,
                 false)).stream()
-                .filter(issue -> permissionPolicy.canViewAllProjectIssues(actor) || isRelatedParticipant(issue, actor.getLoginId()))
+                .filter(issue -> canViewInRelatedList(actor, issue))
                 .map(IssueService::toIssueSummary)
                 .toList();
     }
@@ -418,6 +442,38 @@ public final class IssueService {
         return userRepository.existsActiveProjectMember(projectId, actor.getLoginId());
     }
 
+    private SearchContext searchContext(
+            long projectId,
+            IssueStatus status,
+            LocalDateTime reportedFrom,
+            LocalDateTime reportedTo,
+            String currentLoginId,
+            String membershipMessage) {
+        long requiredProjectId = requirePositive(projectId, FIELD_PROJECT_ID);
+        String requiredLoginId = requireText(currentLoginId, FIELD_CURRENT_LOGIN_ID);
+        if (reportedFrom != null && reportedTo != null && reportedFrom.isAfter(reportedTo)) {
+            throw new IllegalArgumentException("reportedFrom must not be after reportedTo.");
+        }
+        findProject(requiredProjectId);
+        User actor = findUser(requiredLoginId);
+        permissionPolicy.assertCanViewIssue(actor);
+        if (status == IssueStatus.DELETED) {
+            throw new SecurityException("Deleted issues must be managed through deleted issue workflow.");
+        }
+        requireActiveProjectMember(actor, requiredProjectId, membershipMessage);
+        return new SearchContext(requiredProjectId, actor);
+    }
+
+    private List<Issue> searchIssuesByCriteria(IssueSearchCriteria criteria) {
+        return issueRepository.findByCriteria(criteria).stream()
+                .filter(issue -> issue.projectId() == criteria.projectId())
+                .toList();
+    }
+
+    private boolean canViewInRelatedList(User actor, Issue issue) {
+        return permissionPolicy.canViewAllProjectIssues(actor) || isRelatedParticipant(issue, actor.getLoginId());
+    }
+
     private static boolean isRelatedParticipant(Issue issue, String loginId) {
         return loginId.equals(issue.reporterId())
                 || loginId.equals(issue.assigneeId())
@@ -506,6 +562,9 @@ public final class IssueService {
 
     private LocalDateTime now() {
         return clock.now();
+    }
+
+    private record SearchContext(long projectId, User actor) {
     }
 
     private static IssueResult toIssueResult(Issue issue) {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentAccountManagementView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentAccountManagementView.java
@@ -1,0 +1,31 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.swing.SwingWorker;
+
+final class CurrentAccountManagementView implements AccountManagementView {
+
+    private final AccountManagementPanel delegate;
+    private final CurrentViewGate gate;
+
+    CurrentAccountManagementView(
+            AccountManagementPanel delegate,
+            SwingWorker<?, ?> worker,
+            Supplier<? extends SwingWorker<?, ?>> currentWorker) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.gate = new CurrentViewGate(worker, currentWorker);
+    }
+
+    @Override
+    public void showUsers(List<UserResult> users) {
+        gate.update(() -> delegate.showUsers(users));
+    }
+
+    @Override
+    public void showMessage(String message, boolean error) {
+        gate.update(() -> delegate.showMessage(message, error));
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentDashboardView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentDashboardView.java
@@ -1,0 +1,32 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.swing.SwingWorker;
+
+final class CurrentDashboardView implements AdminDashboardView {
+
+    private final AdminDashboardPanel delegate;
+    private final CurrentViewGate gate;
+
+    CurrentDashboardView(
+            AdminDashboardPanel delegate,
+            SwingWorker<?, ?> worker,
+            Supplier<? extends SwingWorker<?, ?>> currentWorker) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.gate = new CurrentViewGate(worker, currentWorker);
+    }
+
+    @Override
+    public void showDashboard(List<DashboardProjectSummary> projects, List<UserResult> users) {
+        gate.update(() -> delegate.showDashboard(projects, users));
+    }
+
+    @Override
+    public void showError(String message) {
+        gate.update(() -> delegate.showError(message));
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentIssueListView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentIssueListView.java
@@ -1,0 +1,42 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import com.github.marcellokim.issuetracker.service.ProjectResult;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.swing.SwingWorker;
+
+final class CurrentIssueListView implements IssueListView {
+
+    private final IssueListPanel delegate;
+    private final CurrentViewGate gate;
+
+    CurrentIssueListView(
+            IssueListPanel delegate,
+            SwingWorker<?, ?> worker,
+            Supplier<? extends SwingWorker<?, ?>> currentWorker) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.gate = new CurrentViewGate(worker, currentWorker);
+    }
+
+    @Override
+    public void showProject(ProjectResult project) {
+        gate.update(() -> delegate.showProject(project));
+    }
+
+    @Override
+    public void showIssues(List<IssueSummary> issues) {
+        gate.update(() -> delegate.showIssues(issues));
+    }
+
+    @Override
+    public void setRegisterEnabled(boolean enabled) {
+        gate.update(() -> delegate.setRegisterEnabled(enabled));
+    }
+
+    @Override
+    public void showMessage(String message, boolean error) {
+        gate.update(() -> delegate.showMessage(message, error));
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentProjectDetailView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentProjectDetailView.java
@@ -1,0 +1,37 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.ProjectAdminDetail;
+import com.github.marcellokim.issuetracker.service.ProjectMemberResult;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.swing.SwingWorker;
+
+final class CurrentProjectDetailView implements ProjectDetailView {
+
+    private final ProjectDetailPanel delegate;
+    private final CurrentViewGate gate;
+
+    CurrentProjectDetailView(
+            ProjectDetailPanel delegate,
+            SwingWorker<?, ?> worker,
+            Supplier<? extends SwingWorker<?, ?>> currentWorker) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.gate = new CurrentViewGate(worker, currentWorker);
+    }
+
+    @Override
+    public void showDetail(ProjectAdminDetail detail) {
+        gate.update(() -> delegate.showDetail(detail));
+    }
+
+    @Override
+    public void showParticipants(List<ProjectMemberResult> participants) {
+        gate.update(() -> delegate.showParticipants(participants));
+    }
+
+    @Override
+    public void showMessage(String message, boolean error) {
+        gate.update(() -> delegate.showMessage(message, error));
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentProjectSummaryView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentProjectSummaryView.java
@@ -1,0 +1,31 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.swing.SwingWorker;
+
+final class CurrentProjectSummaryView implements ProjectManagementView, ProjectListView {
+
+    private final ProjectSummaryView delegate;
+    private final CurrentViewGate gate;
+
+    CurrentProjectSummaryView(
+            ProjectSummaryView delegate,
+            SwingWorker<?, ?> worker,
+            Supplier<? extends SwingWorker<?, ?>> currentWorker) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.gate = new CurrentViewGate(worker, currentWorker);
+    }
+
+    @Override
+    public void showProjects(List<DashboardProjectSummary> projects) {
+        gate.update(() -> delegate.showProjects(projects));
+    }
+
+    @Override
+    public void showMessage(String message, boolean error) {
+        gate.update(() -> delegate.showMessage(message, error));
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentViewGate.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentViewGate.java
@@ -1,0 +1,29 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.swing.SwingWorker;
+
+final class CurrentViewGate {
+
+    private final SwingWorker<?, ?> worker;
+    private final Supplier<? extends SwingWorker<?, ?>> currentWorker;
+
+    CurrentViewGate(SwingWorker<?, ?> worker, Supplier<? extends SwingWorker<?, ?>> currentWorker) {
+        this.worker = Objects.requireNonNull(worker, "worker");
+        this.currentWorker = Objects.requireNonNull(currentWorker, "currentWorker");
+    }
+
+    void update(Runnable update) {
+        Objects.requireNonNull(update, "update");
+        SwingPanelSections.runOnEdt(() -> {
+            if (isCurrent()) {
+                update.run();
+            }
+        });
+    }
+
+    private boolean isCurrent() {
+        return currentWorker.get() == worker && !worker.isCancelled();
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDialogs.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDialogs.java
@@ -1,0 +1,8 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.util.Optional;
+
+interface IssueDialogs {
+
+    Optional<IssueRegisterRequest> requestRegister(IssueListPanel parent);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanel.java
@@ -1,0 +1,375 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import com.github.marcellokim.issuetracker.service.ProjectResult;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.LongConsumer;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+
+final class IssueListPanel extends JPanel implements IssueListView {
+
+    private static final long serialVersionUID = 1L;
+    private static final String[] ISSUE_COLUMNS = {
+            "ID", "Issue", "Status", "Priority", "Title", "Reporter", "Assignee", "Verifier", "Updated"
+    };
+    private static final int[] ISSUE_COLUMN_WIDTHS = {64, 96, 100, 92, 240, 112, 112, 112, 144};
+    private static final Color SELECTION_BACKGROUND = new Color(219, 234, 254);
+    private static final String DEFAULT_ERROR_MESSAGE = "Issue list failed. Please try again.";
+
+    private final transient IssueDialogs dialogs;
+    private final transient IssueListActions actions;
+    private final JLabel titleLabel = new JLabel("Project");
+    private final JLabel descriptionLabel = new JLabel(" ");
+    private final JLabel userLabel;
+    private final JLabel messageLabel = new JLabel(" ");
+    private final JTextField searchField = new JTextField();
+    private final JComboBox<IssueStatus> statusFilter = new JComboBox<>();
+    private final JComboBox<Priority> priorityFilter = new JComboBox<>();
+    private final DefaultTableModel issueTableModel = SwingPanelSections.readOnlyTableModel(ISSUE_COLUMNS);
+    private final transient IssueTableRows issueRows = new IssueTableRows(issueTableModel);
+    private final JTable issueTable = table();
+    private final JButton searchButton = new JButton("Search");
+    private final JButton registerButton = new JButton("Register issue");
+    private final JButton openButton = new JButton("Open detail");
+    private boolean busy;
+    private boolean registerAllowed;
+
+    IssueListPanel(
+            UserResult user,
+            IssueDialogs dialogs,
+            IssueListActions actions) {
+        Objects.requireNonNull(user, "user");
+        this.dialogs = Objects.requireNonNull(dialogs, "dialogs");
+        this.actions = Objects.requireNonNull(actions, "actions");
+        this.userLabel = new JLabel(user.name() + " (" + user.role() + ")");
+
+        setName("issueListPanel");
+        setLayout(new BorderLayout(SwingStyles.SECTION_GAP, SwingStyles.SECTION_GAP));
+        setBackground(SwingStyles.BACKGROUND);
+        setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING));
+
+        configureFilters();
+        add(header(), BorderLayout.NORTH);
+        add(tableSection(), BorderLayout.CENTER);
+        add(actionBar(), BorderLayout.SOUTH);
+        updateActionState();
+    }
+
+    @Override
+    public void showProject(ProjectResult project) {
+        Objects.requireNonNull(project, "project");
+        String projectName = project.name();
+        String description = project.description();
+        SwingPanelSections.runOnEdt(() -> {
+            titleLabel.setText(projectName);
+            descriptionLabel.setText(description == null || description.isBlank() ? " " : description);
+        });
+    }
+
+    @Override
+    public void showIssues(List<IssueSummary> issues) {
+        Objects.requireNonNull(issues, "issues");
+        List<IssueSummary> snapshot = List.copyOf(issues);
+        SwingPanelSections.runOnEdt(() -> {
+            issueRows.replaceKeepingSelection(issueTable, snapshot);
+            updateActionState();
+        });
+    }
+
+    @Override
+    public void setRegisterEnabled(boolean enabled) {
+        SwingPanelSections.runOnEdt(() -> {
+            registerAllowed = enabled;
+            updateActionState();
+        });
+    }
+
+    @Override
+    public void showMessage(String message, boolean error) {
+        SwingPanelSections.runOnEdt(() -> SwingPanelSections.updateMessage(
+                messageLabel,
+                message,
+                error,
+                DEFAULT_ERROR_MESSAGE));
+    }
+
+    void setBusy(boolean busy) {
+        SwingPanelSections.runOnEdt(() -> {
+            this.busy = busy;
+            boolean enabled = !busy;
+            issueTable.setEnabled(enabled);
+            searchField.setEnabled(enabled);
+            statusFilter.setEnabled(enabled);
+            priorityFilter.setEnabled(enabled);
+            searchButton.setEnabled(enabled);
+            updateActionState();
+        });
+    }
+
+    private JPanel header() {
+        JPanel header = new JPanel(new BorderLayout(SwingStyles.SECTION_GAP, 0));
+        header.setBackground(SwingStyles.SURFACE);
+        header.setBorder(SwingStyles.surfaceBorder());
+
+        JPanel titles = new JPanel();
+        titles.setOpaque(false);
+        titles.setLayout(new BoxLayout(titles, BoxLayout.Y_AXIS));
+
+        titleLabel.setName("issueListTitle");
+        titleLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyTitle(titleLabel);
+        titles.add(titleLabel);
+
+        descriptionLabel.setName("issueListProjectDescription");
+        descriptionLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyMuted(descriptionLabel);
+        titles.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+        titles.add(descriptionLabel);
+
+        userLabel.setName("issueListUser");
+        userLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyMuted(userLabel);
+        titles.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+        titles.add(userLabel);
+
+        messageLabel.setName("issueListMessage");
+        messageLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        SwingStyles.applyMuted(messageLabel);
+        titles.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+        titles.add(messageLabel);
+
+        JPanel nav = new JPanel();
+        nav.setOpaque(false);
+        JButton backButton = new JButton("Back");
+        backButton.setName("issueListBackButton");
+        backButton.addActionListener(event -> actions.onBack().run());
+        nav.add(backButton);
+
+        JButton logoutButton = new JButton("Logout");
+        logoutButton.setName("issueListLogoutButton");
+        logoutButton.addActionListener(event -> actions.onLogout().run());
+        nav.add(logoutButton);
+
+        header.add(titles, BorderLayout.CENTER);
+        header.add(nav, BorderLayout.EAST);
+        return header;
+    }
+
+    private JPanel tableSection() {
+        return SwingPanelSections.tableSection("Issues", issueTable);
+    }
+
+    private JPanel actionBar() {
+        JPanel panel = new JPanel();
+        panel.setBackground(SwingStyles.SURFACE);
+        panel.setBorder(SwingStyles.surfaceBorder());
+
+        searchField.setName("issueSearchField");
+        searchField.setColumns(18);
+        panel.add(searchField);
+
+        statusFilter.setName("issueStatusFilter");
+        panel.add(statusFilter);
+
+        priorityFilter.setName("issuePriorityFilter");
+        panel.add(priorityFilter);
+
+        searchButton.setName("searchIssuesButton");
+        searchButton.addActionListener(event -> actions.onSearch().accept(this, currentSearchRequest()));
+        panel.add(searchButton);
+
+        registerButton.setName("registerIssueButton");
+        registerButton.addActionListener(event -> dialogs.requestRegister(this)
+                .ifPresent(request -> actions.onRegister().accept(this, request)));
+        panel.add(registerButton);
+
+        openButton.setName("openIssueDetailButton");
+        openButton.addActionListener(event -> selectedIssue()
+                .ifPresent(issue -> actions.onOpenIssue().accept(issue.id())));
+        panel.add(openButton);
+        return panel;
+    }
+
+    private JTable table() {
+        JTable table = new JTable(issueTableModel) {
+            @Override
+            public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
+                return SwingPanelSections.stripedTableCell(
+                        this,
+                        super.prepareRenderer(renderer, row, column),
+                        row,
+                        SELECTION_BACKGROUND);
+            }
+        };
+        SwingPanelSections.configureReadOnlyTable(table, "issueListTable", SELECTION_BACKGROUND);
+        table.getSelectionModel().addListSelectionListener(event -> {
+            if (!event.getValueIsAdjusting()) {
+                updateActionState();
+            }
+        });
+        table.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent event) {
+                int clickedRow = table.rowAtPoint(event.getPoint());
+                if (event.getClickCount() == 2 && clickedRow >= 0 && table.isEnabled()) {
+                    selectedIssue().ifPresent(issue -> actions.onOpenIssue().accept(issue.id()));
+                }
+            }
+        });
+        applyColumnWidths(table);
+        return table;
+    }
+
+    private void configureFilters() {
+        statusFilter.addItem(null);
+        for (IssueStatus status : IssueStatus.values()) {
+            if (status != IssueStatus.DELETED) {
+                statusFilter.addItem(status);
+            }
+        }
+        priorityFilter.addItem(null);
+        for (Priority priority : Priority.values()) {
+            priorityFilter.addItem(priority);
+        }
+        statusFilter.setRenderer(new OptionalValueRenderer("All statuses"));
+        priorityFilter.setRenderer(new OptionalValueRenderer("All priorities"));
+    }
+
+    private IssueSearchRequest currentSearchRequest() {
+        return new IssueSearchRequest(
+                searchField.getText(),
+                selectedStatus(),
+                selectedPriority());
+    }
+
+    private IssueStatus selectedStatus() {
+        return (IssueStatus) statusFilter.getSelectedItem();
+    }
+
+    private Priority selectedPriority() {
+        return (Priority) priorityFilter.getSelectedItem();
+    }
+
+    private Optional<IssueSummary> selectedIssue() {
+        return issueRows.selectedIssue(issueTable);
+    }
+
+    private void updateActionState() {
+        boolean enabled = !busy;
+        registerButton.setEnabled(enabled && registerAllowed);
+        openButton.setEnabled(enabled && selectedIssue().isPresent());
+    }
+
+    private void applyColumnWidths(JTable table) {
+        SwingPanelSections.applyColumnWidths(table, ISSUE_COLUMN_WIDTHS);
+    }
+
+    @FunctionalInterface
+    interface PanelConsumer<T> {
+
+        void accept(IssueListPanel panel, T value);
+    }
+
+    record IssueListActions(
+            PanelConsumer<IssueSearchRequest> onSearch,
+            PanelConsumer<IssueRegisterRequest> onRegister,
+            LongConsumer onOpenIssue,
+            Runnable onBack,
+            Runnable onLogout) {
+
+        IssueListActions {
+            Objects.requireNonNull(onSearch, "onSearch");
+            Objects.requireNonNull(onRegister, "onRegister");
+            Objects.requireNonNull(onOpenIssue, "onOpenIssue");
+            Objects.requireNonNull(onBack, "onBack");
+            Objects.requireNonNull(onLogout, "onLogout");
+        }
+    }
+
+    static final class JOptionPaneIssueDialogs implements IssueDialogs {
+
+        @Override
+        public Optional<IssueRegisterRequest> requestRegister(IssueListPanel parent) {
+            JTextField title = new JTextField();
+            JTextArea description = new JTextArea(4, 28);
+            description.setLineWrap(true);
+            description.setWrapStyleWord(true);
+            JComboBox<Priority> priority = new JComboBox<>(Priority.values());
+            priority.setSelectedItem(Priority.MAJOR);
+            JPanel form = SwingPanelSections.formPanel(
+                    280,
+                    new JLabel("Title"), title,
+                    new JLabel("Description"), new JScrollPane(description),
+                    new JLabel("Priority"), priority);
+            int result = JOptionPane.showConfirmDialog(
+                    parent,
+                    form,
+                    "Register issue",
+                    JOptionPane.OK_CANCEL_OPTION,
+                    JOptionPane.PLAIN_MESSAGE);
+            if (result != JOptionPane.OK_OPTION) {
+                return Optional.empty();
+            }
+            return Optional.of(new IssueRegisterRequest(
+                    title.getText(),
+                    description.getText(),
+                    (Priority) priority.getSelectedItem()));
+        }
+    }
+
+    private static final class OptionalValueRenderer extends DefaultListCellRenderer {
+
+        private static final long serialVersionUID = 1L;
+        private final String emptyText;
+
+        private OptionalValueRenderer(String emptyText) {
+            this.emptyText = Objects.requireNonNull(emptyText, "emptyText");
+        }
+
+        @Override
+        public Component getListCellRendererComponent(
+                JList<?> list,
+                Object value,
+                int index,
+                boolean isSelected,
+                boolean cellHasFocus) {
+            JLabel label = (JLabel) super.getListCellRendererComponent(
+                    list,
+                    value == null ? emptyText : value,
+                    index,
+                    isSelected,
+                    cellHasFocus);
+            label.setText(value == null ? emptyText : value.toString());
+            return label;
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPresenter.java
@@ -1,0 +1,69 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.controller.IssueController;
+import com.github.marcellokim.issuetracker.controller.ProjectController;
+import com.github.marcellokim.issuetracker.service.IssueResult;
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import java.util.List;
+import java.util.Objects;
+
+final class IssueListPresenter {
+
+    private final ProjectController projectController;
+    private final IssueController issueController;
+    private final IssueListView view;
+
+    IssueListPresenter(
+            ProjectController projectController,
+            IssueController issueController,
+            IssueListView view) {
+        this.projectController = Objects.requireNonNull(projectController, "projectController");
+        this.issueController = Objects.requireNonNull(issueController, "issueController");
+        this.view = Objects.requireNonNull(view, "view");
+    }
+
+    void loadProjectAndIssues(long projectId) {
+        try {
+            view.showProject(projectController.viewProjectNonAdminDetail(projectId));
+            view.setRegisterEnabled(issueController.canRegisterIssue(projectId));
+            showIssues(issueController.viewRelatedProjectIssues(projectId));
+        } catch (RuntimeException exception) {
+            view.setRegisterEnabled(false);
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    void searchIssues(long projectId, IssueSearchRequest request) {
+        Objects.requireNonNull(request, "request");
+        try {
+            showIssues(issueController.searchRelatedProjectIssues(
+                    projectId,
+                    request.keyword(),
+                    request.status(),
+                    request.priority()));
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    void registerIssue(long projectId, IssueRegisterRequest request) {
+        Objects.requireNonNull(request, "request");
+        try {
+            IssueResult result = issueController.registerIssue(
+                    projectId,
+                    request.title(),
+                    request.description(),
+                    request.priority());
+            showIssues(issueController.viewRelatedProjectIssues(projectId));
+            view.setRegisterEnabled(issueController.canRegisterIssue(projectId));
+            view.showMessage("Issue registered: " + result.title(), false);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    private void showIssues(List<IssueSummary> issues) {
+        view.showIssues(issues);
+        view.showMessage(issues.size() + " issues", false);
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListView.java
@@ -1,0 +1,16 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import com.github.marcellokim.issuetracker.service.ProjectResult;
+import java.util.List;
+
+interface IssueListView {
+
+    void showProject(ProjectResult project);
+
+    void showIssues(List<IssueSummary> issues);
+
+    void setRegisterEnabled(boolean enabled);
+
+    void showMessage(String message, boolean error);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueRegisterRequest.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueRegisterRequest.java
@@ -1,0 +1,15 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.domain.Priority;
+
+record IssueRegisterRequest(String title, String description, Priority priority) {
+
+    IssueRegisterRequest {
+        title = normalize(title);
+        description = normalize(description);
+    }
+
+    private static String normalize(String value) {
+        return value == null ? null : value.trim();
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueSearchRequest.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueSearchRequest.java
@@ -1,0 +1,18 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+
+record IssueSearchRequest(String keyword, IssueStatus status, Priority priority) {
+
+    IssueSearchRequest {
+        keyword = normalize(keyword);
+    }
+
+    private static String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueTableRows.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueTableRows.java
@@ -1,0 +1,69 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableModel;
+
+final class IssueTableRows {
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    private final DefaultTableModel model;
+    private final List<IssueSummary> issues = new ArrayList<>();
+
+    IssueTableRows(DefaultTableModel model) {
+        this.model = model;
+    }
+
+    void replaceKeepingSelection(JTable table, List<IssueSummary> newIssues) {
+        Optional<Long> selectedIssueId = selectedIssue(table).map(IssueSummary::id);
+        issues.clear();
+        issues.addAll(newIssues);
+        model.setRowCount(0);
+        newIssues.forEach(issue -> model.addRow(new Object[]{
+                issue.id(),
+                issue.issueId(),
+                issue.status(),
+                issue.priority(),
+                issue.title(),
+                issue.reporterId(),
+                valueOrDash(issue.assigneeId()),
+                valueOrDash(issue.verifierId()),
+                DATE_TIME_FORMATTER.format(issue.updatedAt())
+        }));
+        selectedIssueId.ifPresent(issueId -> restoreSelection(table, issueId));
+    }
+
+    Optional<IssueSummary> selectedIssue(JTable table) {
+        int selectedRow = table.getSelectedRow();
+        if (selectedRow < 0) {
+            return Optional.empty();
+        }
+
+        int modelRow = table.convertRowIndexToModel(selectedRow);
+        if (modelRow < 0 || modelRow >= issues.size()) {
+            return Optional.empty();
+        }
+        return Optional.of(issues.get(modelRow));
+    }
+
+    private void restoreSelection(JTable table, long selectedIssueId) {
+        for (int row = 0; row < issues.size(); row++) {
+            if (issues.get(row).id() == selectedIssueId) {
+                int viewRow = table.convertRowIndexToView(row);
+                if (viewRow >= 0) {
+                    table.setRowSelectionInterval(viewRow, viewRow);
+                }
+                return;
+            }
+        }
+    }
+
+    private static String valueOrDash(String value) {
+        return value == null || value.isBlank() ? "-" : value;
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
@@ -4,6 +4,7 @@ import com.github.marcellokim.issuetracker.config.ApplicationContext;
 import com.github.marcellokim.issuetracker.controller.AccountController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.controller.IssueController;
 import com.github.marcellokim.issuetracker.controller.ProjectController;
 import java.util.Objects;
 import javax.swing.JFrame;
@@ -20,20 +21,23 @@ public final class SwingAppFrame extends JFrame {
                 Objects.requireNonNull(context, "context").authenticationController(),
                 context.dashboardController(),
                 context.accountController(),
-                context.projectController());
+                context.projectController(),
+                context.issueController());
     }
 
     SwingAppFrame(
             AuthenticationController authenticationController,
             DashboardController dashboardController,
             AccountController accountController,
-            ProjectController projectController) {
+            ProjectController projectController,
+            IssueController issueController) {
         super("Issue Tracker");
         this.appPanel = new SwingAppPanel(
                 authenticationController,
                 dashboardController,
                 accountController,
                 projectController,
+                issueController,
                 this::setTitle);
         setContentPane(appPanel);
         setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -3,59 +3,59 @@ package com.github.marcellokim.issuetracker.ui.swing;
 import com.github.marcellokim.issuetracker.controller.AccountController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.controller.IssueController;
 import com.github.marcellokim.issuetracker.controller.ProjectController;
-import com.github.marcellokim.issuetracker.service.DashboardProjectSummary;
-import com.github.marcellokim.issuetracker.service.ProjectAdminDetail;
-import com.github.marcellokim.issuetracker.service.ProjectMemberResult;
 import com.github.marcellokim.issuetracker.service.UserResult;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
 
+@SuppressWarnings("java:S6539")
 final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     private static final long serialVersionUID = 1L;
     private static final String LOGIN_CARD = "login";
     private static final String ADMIN_DASHBOARD_CARD = "adminDashboard";
     private static final String PROJECT_LIST_CARD = "projectList";
-    private static final String WORKER_NAME = "worker";
 
     private final transient AuthenticationController authenticationController;
     private final transient DashboardController dashboardController;
     private final transient AccountController accountController;
     private final transient ProjectController projectController;
+    private final transient IssueController issueController;
     private final transient Consumer<String> titleUpdater;
     private final CardLayout cardLayout = new CardLayout();
     private final LoginPanel loginPanel = new LoginPanel();
     private final JPanel adminDashboardCard = new JPanel(new BorderLayout());
     private final JPanel projectListCard = new JPanel(new BorderLayout());
     private transient SwingWorker<Void, Void> loginWorker;
-    private final transient AtomicReference<DashboardLoadWorker> dashboardWorker = new AtomicReference<>();
-    private final transient AtomicReference<AccountManagementWorker> accountWorker = new AtomicReference<>();
-    private final transient AtomicReference<ProjectManagementWorker> projectWorker = new AtomicReference<>();
-    private final transient AtomicReference<ProjectDetailWorker> projectDetailWorker = new AtomicReference<>();
-    private final transient AtomicReference<ProjectListWorker> projectListWorker = new AtomicReference<>();
+    private final transient AtomicReference<SwingWorker<Void, Void>> dashboardWorker = new AtomicReference<>();
+    private final transient AtomicReference<SwingWorker<Void, Void>> accountWorker = new AtomicReference<>();
+    private final transient AtomicReference<SwingWorker<Void, Void>> projectWorker = new AtomicReference<>();
+    private final transient AtomicReference<SwingWorker<Void, Void>> projectDetailWorker = new AtomicReference<>();
+    private final transient AtomicReference<SwingWorker<Void, Void>> projectListWorker = new AtomicReference<>();
+    private final transient AtomicReference<SwingWorker<Void, Void>> issueListWorker = new AtomicReference<>();
 
     SwingAppPanel(
             AuthenticationController authenticationController,
             DashboardController dashboardController,
             AccountController accountController,
             ProjectController projectController,
+            IssueController issueController,
             Consumer<String> titleUpdater) {
         this.authenticationController = Objects.requireNonNull(authenticationController, "authenticationController");
         this.dashboardController = Objects.requireNonNull(dashboardController, "dashboardController");
         this.accountController = Objects.requireNonNull(accountController, "accountController");
         this.projectController = Objects.requireNonNull(projectController, "projectController");
+        this.issueController = Objects.requireNonNull(issueController, "issueController");
         this.titleUpdater = Objects.requireNonNull(titleUpdater, "titleUpdater");
 
         setName("appCards");
@@ -77,6 +77,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectWorker();
             cancelProjectDetailWorker();
             cancelProjectListWorker();
+            cancelIssueListWorker();
             titleUpdater.accept("Issue Tracker");
             loginPanel.showMessage(" ", false);
             loginPanel.clearPassword();
@@ -94,6 +95,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectWorker();
             cancelProjectDetailWorker();
             cancelProjectListWorker();
+            cancelIssueListWorker();
             titleUpdater.accept("Admin dashboard");
             AdminDashboardPanel panel = new AdminDashboardPanel(
                     user,
@@ -118,6 +120,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectWorker();
             cancelProjectDetailWorker();
             cancelProjectListWorker();
+            cancelIssueListWorker();
             titleUpdater.accept("Project list");
             ProjectListPanel panel = new ProjectListPanel(
                     user,
@@ -139,6 +142,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         cancelProjectWorker();
         cancelProjectDetailWorker();
         cancelProjectListWorker();
+        cancelIssueListWorker();
         authenticationController.logout();
         showLogin();
     }
@@ -202,6 +206,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectWorker();
             cancelProjectDetailWorker();
             cancelProjectListWorker();
+            cancelIssueListWorker();
             titleUpdater.accept("Account management");
             AccountManagementPanel panel = new AccountManagementPanel(
                     user,
@@ -231,6 +236,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectWorker();
             cancelProjectDetailWorker();
             cancelProjectListWorker();
+            cancelIssueListWorker();
             titleUpdater.accept("Project management");
             ProjectManagementPanel panel = new ProjectManagementPanel(
                     user,
@@ -267,6 +273,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectWorker();
             cancelProjectDetailWorker();
             cancelProjectListWorker();
+            cancelIssueListWorker();
             titleUpdater.accept("Project detail");
             ProjectDetailPanel panel = new ProjectDetailPanel(
                     user,
@@ -307,8 +314,42 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectWorker();
             cancelProjectDetailWorker();
             cancelProjectListWorker();
+            cancelIssueListWorker();
             titleUpdater.accept("Issue list");
-            showPlaceholder(projectListCard, "Issue list #" + projectId, user, () -> showProjectList(user));
+            IssueListPanel panel = new IssueListPanel(
+                    user,
+                    new IssueListPanel.JOptionPaneIssueDialogs(),
+                    new IssueListPanel.IssueListActions(
+                            (panelRef, request) ->
+                                    startIssueListTask(
+                                            panelRef,
+                                            presenter -> presenter.searchIssues(projectId, request)),
+                            (panelRef, request) ->
+                                    startIssueListTask(
+                                            panelRef,
+                                            presenter -> presenter.registerIssue(projectId, request)),
+                            issueId -> showIssueDetail(user, projectId, issueId),
+                            () -> showProjectList(user),
+                            this::logout));
+            projectListCard.removeAll();
+            projectListCard.add(panel, BorderLayout.CENTER);
+            projectListCard.revalidate();
+            projectListCard.repaint();
+            cardLayout.show(this, PROJECT_LIST_CARD);
+            startIssueListTask(panel, presenter -> presenter.loadProjectAndIssues(projectId));
+        });
+    }
+
+    private void showIssueDetail(UserResult user, long projectId, long issueId) {
+        SwingUtilities.invokeLater(() -> {
+            cancelDashboardWorker();
+            cancelAccountWorker();
+            cancelProjectWorker();
+            cancelProjectDetailWorker();
+            cancelProjectListWorker();
+            cancelIssueListWorker();
+            titleUpdater.accept("Issue detail");
+            showPlaceholder(projectListCard, "Issue detail #" + issueId, user, () -> showIssueList(user, projectId));
             cardLayout.show(this, PROJECT_LIST_CARD);
         });
     }
@@ -320,7 +361,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     }
 
     private void cancelDashboardWorker() {
-        DashboardLoadWorker worker = dashboardWorker.getAndSet(null);
+        SwingWorker<Void, Void> worker = dashboardWorker.getAndSet(null);
         if (worker != null && !worker.isDone()) {
             worker.cancel(true);
         }
@@ -337,7 +378,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     }
 
     private void cancelAccountWorker() {
-        AccountManagementWorker worker = accountWorker.getAndSet(null);
+        SwingWorker<Void, Void> worker = accountWorker.getAndSet(null);
         if (worker != null && !worker.isDone()) {
             worker.cancel(true);
         }
@@ -354,7 +395,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     }
 
     private void cancelProjectWorker() {
-        ProjectManagementWorker worker = projectWorker.getAndSet(null);
+        SwingWorker<Void, Void> worker = projectWorker.getAndSet(null);
         if (worker != null && !worker.isDone()) {
             worker.cancel(true);
         }
@@ -371,7 +412,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     }
 
     private void cancelProjectDetailWorker() {
-        ProjectDetailWorker worker = projectDetailWorker.getAndSet(null);
+        SwingWorker<Void, Void> worker = projectDetailWorker.getAndSet(null);
         if (worker != null && !worker.isDone()) {
             worker.cancel(true);
         }
@@ -388,7 +429,24 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     }
 
     private void cancelProjectListWorker() {
-        ProjectListWorker worker = projectListWorker.getAndSet(null);
+        SwingWorker<Void, Void> worker = projectListWorker.getAndSet(null);
+        if (worker != null && !worker.isDone()) {
+            worker.cancel(true);
+        }
+    }
+
+    private void startIssueListTask(IssueListPanel panel, IssueListTask task) {
+        Objects.requireNonNull(panel, "panel");
+        Objects.requireNonNull(task, "task");
+        cancelIssueListWorker();
+        panel.setBusy(true);
+        IssueListWorker worker = new IssueListWorker(panel, task);
+        issueListWorker.set(worker);
+        worker.execute();
+    }
+
+    private void cancelIssueListWorker() {
+        SwingWorker<Void, Void> worker = issueListWorker.getAndSet(null);
         if (worker != null && !worker.isDone()) {
             worker.cancel(true);
         }
@@ -447,7 +505,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         protected Void doInBackground() {
             AdminDashboardPresenter presenter = new AdminDashboardPresenter(
                     dashboardController,
-                    new CurrentDashboardView(panel, this));
+                    new CurrentDashboardView(panel, this, dashboardWorker::get));
             presenter.load();
             return null;
         }
@@ -473,7 +531,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             AccountManagementPresenter presenter = new AccountManagementPresenter(
                     dashboardController,
                     accountController,
-                    new CurrentAccountManagementView(panel, this));
+                    new CurrentAccountManagementView(panel, this, accountWorker::get));
             task.run(presenter);
             return null;
         }
@@ -499,7 +557,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             ProjectManagementPresenter presenter = new ProjectManagementPresenter(
                     dashboardController,
                     projectController,
-                    new CurrentProjectManagementView(panel, this));
+                    new CurrentProjectSummaryView(panel, this, projectWorker::get));
             task.run(presenter);
             return null;
         }
@@ -524,7 +582,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         protected Void doInBackground() {
             ProjectDetailPresenter presenter = new ProjectDetailPresenter(
                     projectController,
-                    new CurrentProjectDetailView(panel, this));
+                    new CurrentProjectDetailView(panel, this, projectDetailWorker::get));
             task.run(presenter);
             return null;
         }
@@ -549,7 +607,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         protected Void doInBackground() {
             ProjectListPresenter presenter = new ProjectListPresenter(
                     dashboardController,
-                    new CurrentProjectListView(panel, this));
+                    new CurrentProjectSummaryView(panel, this, projectListWorker::get));
             task.run(presenter);
             return null;
         }
@@ -560,11 +618,37 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         }
     }
 
-    private static <T extends SwingWorker<Void, Void>> void finishWorker(
-            AtomicReference<T> workerRef,
-            T worker,
+    private final class IssueListWorker extends SwingWorker<Void, Void> {
+
+        private final IssueListPanel panel;
+        private final IssueListTask task;
+
+        private IssueListWorker(IssueListPanel panel, IssueListTask task) {
+            this.panel = Objects.requireNonNull(panel, "panel");
+            this.task = Objects.requireNonNull(task, "task");
+        }
+
+        @Override
+        protected Void doInBackground() {
+            IssueListPresenter presenter = new IssueListPresenter(
+                    projectController,
+                    issueController,
+                    new CurrentIssueListView(panel, this, issueListWorker::get));
+            task.run(presenter);
+            return null;
+        }
+
+        @Override
+        protected void done() {
+            finishWorker(issueListWorker, this, () -> panel.setBusy(false), panel::showMessage, "Issue list");
+        }
+    }
+
+    private static void finishWorker(
+            AtomicReference<SwingWorker<Void, Void>> workerRef,
+            SwingWorker<Void, Void> worker,
             Runnable clearBusy,
-            BiConsumer<String, Boolean> showMessage,
+            MessageSink showMessage,
             String screenName) {
         if (!workerRef.compareAndSet(worker, null)) {
             return;
@@ -577,123 +661,9 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             worker.get();
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
-            showMessage.accept(screenName + " was interrupted. Please try again.", true);
+            showMessage.showMessage(screenName + " was interrupted. Please try again.", true);
         } catch (ExecutionException exception) {
-            showMessage.accept(screenName + " failed. Please try again.", true);
-        }
-    }
-
-    private final class CurrentAccountManagementView implements AccountManagementView {
-
-        private final AccountManagementPanel delegate;
-        private final AccountManagementWorker worker;
-
-        private CurrentAccountManagementView(AccountManagementPanel delegate, AccountManagementWorker worker) {
-            this.delegate = Objects.requireNonNull(delegate, "delegate");
-            this.worker = Objects.requireNonNull(worker, WORKER_NAME);
-        }
-
-        @Override
-        public void showUsers(List<UserResult> users) {
-            if (isCurrent()) {
-                delegate.showUsers(users);
-            }
-        }
-
-        @Override
-        public void showMessage(String message, boolean error) {
-            if (isCurrent()) {
-                delegate.showMessage(message, error);
-            }
-        }
-
-        private boolean isCurrent() {
-            return accountWorker.get() == worker && !worker.isCancelled();
-        }
-    }
-
-    private final class CurrentProjectManagementView
-            extends CurrentProjectSummaryView<ProjectManagementWorker>
-            implements ProjectManagementView {
-
-        private CurrentProjectManagementView(ProjectManagementPanel delegate, ProjectManagementWorker worker) {
-            super(delegate, worker, projectWorker::get);
-        }
-    }
-
-    private final class CurrentProjectDetailView implements ProjectDetailView {
-
-        private final ProjectDetailPanel delegate;
-        private final ProjectDetailWorker worker;
-
-        private CurrentProjectDetailView(ProjectDetailPanel delegate, ProjectDetailWorker worker) {
-            this.delegate = Objects.requireNonNull(delegate, "delegate");
-            this.worker = Objects.requireNonNull(worker, WORKER_NAME);
-        }
-
-        @Override
-        public void showDetail(ProjectAdminDetail detail) {
-            if (isCurrent()) {
-                delegate.showDetail(detail);
-            }
-        }
-
-        @Override
-        public void showParticipants(List<ProjectMemberResult> participants) {
-            if (isCurrent()) {
-                delegate.showParticipants(participants);
-            }
-        }
-
-        @Override
-        public void showMessage(String message, boolean error) {
-            if (isCurrent()) {
-                delegate.showMessage(message, error);
-            }
-        }
-
-        private boolean isCurrent() {
-            return projectDetailWorker.get() == worker && !worker.isCancelled();
-        }
-    }
-
-    private final class CurrentProjectListView
-            extends CurrentProjectSummaryView<ProjectListWorker>
-            implements ProjectListView {
-
-        private CurrentProjectListView(ProjectListPanel delegate, ProjectListWorker worker) {
-            super(delegate, worker, projectListWorker::get);
-        }
-    }
-
-    private abstract class CurrentProjectSummaryView<T extends SwingWorker<Void, Void>> implements ProjectSummaryView {
-
-        private final ProjectSummaryView delegate;
-        private final T worker;
-        private final Supplier<T> currentWorker;
-
-        private CurrentProjectSummaryView(ProjectSummaryView delegate, T worker, Supplier<T> currentWorker) {
-            this.delegate = Objects.requireNonNull(delegate, "delegate");
-            this.worker = Objects.requireNonNull(worker, WORKER_NAME);
-            this.currentWorker = Objects.requireNonNull(currentWorker, "currentWorker");
-        }
-
-        @Override
-        public void showProjects(List<DashboardProjectSummary> projects) {
-            if (isCurrent()) {
-                delegate.showProjects(projects);
-            }
-        }
-
-        @Override
-        public void showMessage(String message, boolean error) {
-            if (isCurrent()) {
-                delegate.showMessage(message, error);
-            }
-        }
-
-        private boolean isCurrent() {
-            return currentWorker.get() == worker && !worker.isCancelled();
+            showMessage.showMessage(screenName + " failed. Please try again.", true);
         }
     }
 
@@ -721,33 +691,16 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         void run(ProjectListPresenter presenter);
     }
 
-    private final class CurrentDashboardView implements AdminDashboardView {
+    @FunctionalInterface
+    private interface IssueListTask {
 
-        private final AdminDashboardPanel delegate;
-        private final DashboardLoadWorker worker;
+        void run(IssueListPresenter presenter);
+    }
 
-        private CurrentDashboardView(AdminDashboardPanel delegate, DashboardLoadWorker worker) {
-            this.delegate = Objects.requireNonNull(delegate, "delegate");
-            this.worker = Objects.requireNonNull(worker, WORKER_NAME);
-        }
+    @FunctionalInterface
+    private interface MessageSink {
 
-        @Override
-        public void showDashboard(List<DashboardProjectSummary> projects, List<UserResult> users) {
-            if (isCurrent()) {
-                delegate.showDashboard(projects, users);
-            }
-        }
-
-        @Override
-        public void showError(String message) {
-            if (isCurrent()) {
-                delegate.showError(message);
-            }
-        }
-
-        private boolean isCurrent() {
-            return dashboardWorker.get() == worker && !worker.isCancelled();
-        }
+        void showMessage(String message, boolean error);
     }
 
     private static final class CapturedLoginView implements LoginView {

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanelTest.java
@@ -1,0 +1,280 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import com.github.marcellokim.issuetracker.service.ProjectResult;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Graphics2D;
+import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.imageio.ImageIO;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing issue list panel")
+class IssueListPanelTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("renders project, issues, filters, and selection-sensitive actions")
+    void rendersProjectIssuesAndActions() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            IssueListPanel panel = panel(new FixedIssueDialogs());
+            panel.showProject(project());
+            panel.showIssues(List.of(
+                    issueSummary(1L, "ISSUE-1", "Login bug", IssueStatus.NEW, Priority.CRITICAL),
+                    issueSummary(2L, "ISSUE-2", "Profile typo", IssueStatus.ASSIGNED, Priority.MINOR)));
+            panel.setRegisterEnabled(true);
+
+            JTable table = SwingComponentTestSupport.find(panel, "issueListTable", JTable.class);
+            JButton open = SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class);
+            JButton register = SwingComponentTestSupport.find(panel, "registerIssueButton", JButton.class);
+
+            assertEquals("Alpha", SwingComponentTestSupport.find(panel, "issueListTitle", JLabel.class).getText());
+            assertEquals(2, table.getRowCount());
+            assertEquals("ISSUE-1", table.getValueAt(0, 1));
+            assertEquals("Login bug", table.getValueAt(0, 4));
+            assertEquals(true, register.isEnabled());
+            assertEquals(false, open.isEnabled());
+
+            table.setRowSelectionInterval(1, 1);
+
+            assertEquals(true, open.isEnabled());
+        });
+    }
+
+    @Test
+    @DisplayName("publishes search, register, open, back, and logout actions")
+    void publishesActions() throws Exception {
+        var searchRef = new AtomicReference<IssueSearchRequest>();
+        var registerRef = new AtomicReference<IssueRegisterRequest>();
+        var openRef = new AtomicLong();
+        var backClicks = new AtomicInteger();
+        var logoutClicks = new AtomicInteger();
+        FixedIssueDialogs dialogs = new FixedIssueDialogs();
+
+        SwingComponentTestSupport.onEdt(() -> {
+            IssueListPanel panel = new IssueListPanel(
+                    userResult("dev1", Role.DEV),
+                    dialogs,
+                    new IssueListPanel.IssueListActions(
+                            (source, request) -> searchRef.set(request),
+                            (source, request) -> registerRef.set(request),
+                            openRef::set,
+                            backClicks::incrementAndGet,
+                            logoutClicks::incrementAndGet));
+            panel.showProject(project());
+            panel.showIssues(List.of(issueSummary(7L, "ISSUE-7", "Login bug", IssueStatus.NEW, Priority.CRITICAL)));
+            panel.setRegisterEnabled(true);
+
+            SwingComponentTestSupport.find(panel, "issueSearchField", JTextField.class).setText("login");
+            SwingComponentTestSupport.find(panel, "issueStatusFilter", JComboBox.class)
+                    .setSelectedItem(IssueStatus.NEW);
+            SwingComponentTestSupport.find(panel, "issuePriorityFilter", JComboBox.class)
+                    .setSelectedItem(Priority.CRITICAL);
+            SwingComponentTestSupport.find(panel, "searchIssuesButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "registerIssueButton", JButton.class).doClick();
+            JTable table = SwingComponentTestSupport.find(panel, "issueListTable", JTable.class);
+            table.setRowSelectionInterval(0, 0);
+            SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "issueListBackButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "issueListLogoutButton", JButton.class).doClick();
+        });
+
+        assertEquals(new IssueSearchRequest("login", IssueStatus.NEW, Priority.CRITICAL), searchRef.get());
+        assertEquals(new IssueRegisterRequest("New issue", "New issue description", Priority.MINOR), registerRef.get());
+        assertEquals(7L, openRef.get());
+        assertEquals(1, backClicks.get());
+        assertEquals(1, logoutClicks.get());
+    }
+
+    @Test
+    @DisplayName("opens selected issue on double click")
+    void opensSelectedIssueOnDoubleClick() throws Exception {
+        var openRef = new AtomicLong();
+
+        SwingComponentTestSupport.onEdt(() -> {
+            IssueListPanel panel = new IssueListPanel(
+                    userResult("tester1", Role.TESTER),
+                    new FixedIssueDialogs(),
+                    new IssueListPanel.IssueListActions(
+                            (source, request) -> {
+                            },
+                            (source, request) -> {
+                            },
+                            openRef::set,
+                            () -> {
+                            },
+                            () -> {
+                            }));
+            panel.showProject(project());
+            panel.showIssues(List.of(issueSummary(9L, "ISSUE-9", "Login bug", IssueStatus.NEW, Priority.CRITICAL)));
+            JTable table = SwingComponentTestSupport.find(panel, "issueListTable", JTable.class);
+            table.setRowSelectionInterval(0, 0);
+
+            MouseEvent doubleClick = new MouseEvent(
+                    table,
+                    MouseEvent.MOUSE_CLICKED,
+                    System.currentTimeMillis(),
+                    0,
+                    8,
+                    8,
+                    2,
+                    false);
+            table.dispatchEvent(doubleClick);
+        });
+
+        assertEquals(9L, openRef.get());
+    }
+
+    @Test
+    @DisplayName("shows fallback text for blank error messages")
+    void showsFallbackTextForBlankErrors() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            IssueListPanel panel = panel(new FixedIssueDialogs());
+            panel.showMessage(" ", true);
+
+            JLabel message = SwingComponentTestSupport.find(panel, "issueListMessage", JLabel.class);
+
+            assertEquals("Issue list failed. Please try again.", message.getText());
+        });
+    }
+
+    @Test
+    @DisplayName("renders issue list screen snapshot")
+    void rendersIssueListSnapshot() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            IssueListPanel panel = panel(new FixedIssueDialogs());
+            panel.showProject(project());
+            panel.showIssues(List.of(
+                    issueSummary(1L, "ISSUE-1", "Login bug", IssueStatus.NEW, Priority.CRITICAL),
+                    issueSummary(2L, "ISSUE-2", "Profile typo", IssueStatus.ASSIGNED, Priority.MINOR)));
+            panel.setRegisterEnabled(true);
+            panel.setSize(SwingStyles.WINDOW_SIZE);
+            layoutRecursively(panel);
+
+            BufferedImage initial = render(panel, Path.of("build/reports/ui/issue-list-panel.png"));
+            assertTrue(hasRenderedContent(initial));
+
+            JTable table = SwingComponentTestSupport.find(panel, "issueListTable", JTable.class);
+            table.setRowSelectionInterval(0, 0);
+            BufferedImage selected = render(panel, Path.of("build/reports/ui/issue-list-panel-selected.png"));
+            assertTrue(hasRenderedContent(selected));
+        });
+    }
+
+    private static IssueListPanel panel(FixedIssueDialogs dialogs) {
+        return new IssueListPanel(
+                userResult("dev1", Role.DEV),
+                dialogs,
+                new IssueListPanel.IssueListActions(
+                        (source, request) -> {
+                        },
+                        (source, request) -> {
+                        },
+                        issueId -> {
+                        },
+                        () -> {
+                        },
+                        () -> {
+                        }));
+    }
+
+    private static ProjectResult project() {
+        return new ProjectResult(1L, "Alpha", "Alpha project", "admin", NOW, NOW);
+    }
+
+    private static IssueSummary issueSummary(
+            long id,
+            String issueId,
+            String title,
+            IssueStatus status,
+            Priority priority) {
+        return new IssueSummary(
+                id,
+                issueId,
+                1L,
+                status,
+                priority,
+                title,
+                "dev1",
+                null,
+                null,
+                NOW,
+                NOW);
+    }
+
+    private static UserResult userResult(String loginId, Role role) {
+        return UserResult.from(User.fromPersistence(loginId, loginId, "stored-password", role, true, NOW, NOW));
+    }
+
+    private static void layoutRecursively(Container container) {
+        container.doLayout();
+        for (java.awt.Component child : container.getComponents()) {
+            if (child instanceof Container nested) {
+                layoutRecursively(nested);
+            }
+        }
+    }
+
+    private static BufferedImage render(IssueListPanel panel, Path output) throws java.io.IOException {
+        BufferedImage image = new BufferedImage(
+                SwingStyles.WINDOW_SIZE.width,
+                SwingStyles.WINDOW_SIZE.height,
+                BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            panel.printAll(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        Files.createDirectories(output.getParent());
+        ImageIO.write(image, "png", output.toFile());
+        return image;
+    }
+
+    private static boolean hasRenderedContent(BufferedImage image) {
+        int background = SwingStyles.BACKGROUND.getRGB();
+        int white = Color.WHITE.getRGB();
+        int contentPixels = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                int pixel = image.getRGB(x, y);
+                if (pixel != background && pixel != white) {
+                    contentPixels++;
+                }
+            }
+        }
+        return contentPixels > 10_000;
+    }
+
+    private static final class FixedIssueDialogs implements IssueDialogs {
+
+        @Override
+        public Optional<IssueRegisterRequest> requestRegister(IssueListPanel parent) {
+            return Optional.of(new IssueRegisterRequest("New issue", "New issue description", Priority.MINOR));
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPresenterTest.java
@@ -1,0 +1,295 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.marcellokim.issuetracker.controller.IssueController;
+import com.github.marcellokim.issuetracker.controller.ProjectController;
+import com.github.marcellokim.issuetracker.domain.Comment;
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueHistory;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Project;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.CommentRepository;
+import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.IssueService;
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import com.github.marcellokim.issuetracker.service.PasswordHashing;
+import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.service.ProjectResult;
+import com.github.marcellokim.issuetracker.service.ProjectService;
+import com.github.marcellokim.issuetracker.support.FakeIssueDependencyRepository;
+import com.github.marcellokim.issuetracker.support.FakeIssueHistoryRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.technical.SessionStore;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing issue list presenter")
+class IssueListPresenterTest {
+
+    private static final long PROJECT_ID = 1L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("loads project info, related issues, and register permission through controllers")
+    void loadsProjectAndRelatedIssues() {
+        User dev = user("dev1", Role.DEV);
+        ControllerFixture fixture = controllers(
+                dev,
+                issue(1L, "Login bug", "Cannot login", Priority.CRITICAL, dev),
+                issue(2L, "Tester-only issue", "Visible to tester", Priority.MINOR, user("tester1", Role.TESTER)));
+        RecordingIssueListView view = new RecordingIssueListView();
+        IssueListPresenter presenter = new IssueListPresenter(
+                fixture.projectController(),
+                fixture.issueController(),
+                view);
+
+        presenter.loadProjectAndIssues(PROJECT_ID);
+
+        assertEquals("Alpha", view.projectName());
+        assertEquals(List.of("Login bug"), view.issueTitles());
+        assertEquals(true, view.registerEnabled());
+        assertEquals("1 issues", view.message());
+    }
+
+    @Test
+    @DisplayName("searches issues with keyword, status, and priority filters")
+    void searchesIssuesWithFilters() {
+        User dev = user("dev1", Role.DEV);
+        ControllerFixture fixture = controllers(
+                dev,
+                issue(1L, "Login bug", "Cannot login", Priority.CRITICAL, dev),
+                issue(2L, "Profile typo", "Minor copy", Priority.MINOR, dev));
+        RecordingIssueListView view = new RecordingIssueListView();
+        IssueListPresenter presenter = new IssueListPresenter(
+                fixture.projectController(),
+                fixture.issueController(),
+                view);
+
+        presenter.searchIssues(PROJECT_ID, new IssueSearchRequest("login", IssueStatus.NEW, Priority.CRITICAL));
+
+        assertEquals(List.of("Login bug"), view.issueTitles());
+        assertEquals("1 issues", view.message());
+    }
+
+    @Test
+    @DisplayName("search stays inside related issue scope")
+    void searchStaysInsideRelatedIssueScope() {
+        User dev = user("dev1", Role.DEV);
+        ControllerFixture fixture = controllers(
+                dev,
+                issue(1L, "Login bug", "Cannot login", Priority.CRITICAL, dev),
+                issue(2L, "Login hidden", "Visible to tester", Priority.CRITICAL, user("tester1", Role.TESTER)));
+        RecordingIssueListView view = new RecordingIssueListView();
+        IssueListPresenter presenter = new IssueListPresenter(
+                fixture.projectController(),
+                fixture.issueController(),
+                view);
+
+        presenter.searchIssues(PROJECT_ID, new IssueSearchRequest("login", null, null));
+
+        assertEquals(List.of("Login bug"), view.issueTitles());
+        assertEquals("1 issues", view.message());
+    }
+
+    @Test
+    @DisplayName("registers issue and refreshes the issue list")
+    void registersIssueAndRefreshesList() {
+        User dev = user("dev1", Role.DEV);
+        ControllerFixture fixture = controllers(dev);
+        RecordingIssueListView view = new RecordingIssueListView();
+        IssueListPresenter presenter = new IssueListPresenter(
+                fixture.projectController(),
+                fixture.issueController(),
+                view);
+
+        presenter.registerIssue(PROJECT_ID, new IssueRegisterRequest("New issue", "New issue description", Priority.MINOR));
+
+        assertEquals(List.of("New issue"), view.issueTitles());
+        assertEquals("Issue registered: New issue", view.message());
+    }
+
+    @Test
+    @DisplayName("shows controller errors without replacing current issues")
+    void showsErrorsWithoutReplacingCurrentIssues() {
+        User dev = user("dev1", Role.DEV);
+        ControllerFixture fixture = controllers(dev, issue(1L, "Login bug", "Cannot login", Priority.CRITICAL, dev));
+        RecordingIssueListView view = new RecordingIssueListView();
+        IssueListPresenter presenter = new IssueListPresenter(
+                fixture.projectController(),
+                fixture.issueController(),
+                view);
+        presenter.loadProjectAndIssues(PROJECT_ID);
+
+        presenter.searchIssues(PROJECT_ID, new IssueSearchRequest(null, IssueStatus.DELETED, null));
+
+        assertEquals(List.of("Login bug"), view.issueTitles());
+        assertEquals("Deleted issues must be managed through deleted issue workflow.", view.message());
+    }
+
+    private static ControllerFixture controllers(User currentUser, Issue... issues) {
+        User tester = user("tester1", Role.TESTER);
+        User pl = user("pl1", Role.PL);
+        InMemoryUserRepository users = new InMemoryUserRepository(currentUser, tester, pl);
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project())
+                .withParticipant(PROJECT_ID, currentUser.getLoginId())
+                .withParticipant(PROJECT_ID, tester.getLoginId())
+                .withParticipant(PROJECT_ID, pl.getLoginId());
+        InMemoryIssueRepository issueRepository = new InMemoryIssueRepository(issues);
+        AuthenticationService authentication = new AuthenticationService(
+                users,
+                new AcceptingPasswordHashing(),
+                new SessionStore());
+        authentication.login(currentUser.getLoginId(), "password");
+        PermissionPolicy permissionPolicy = new PermissionPolicy();
+        ProjectController projectController = new ProjectController(
+                authentication,
+                new ProjectService(
+                        projects,
+                        issueRepository,
+                        users,
+                        permissionPolicy,
+                        () -> NOW));
+        IssueController issueController = new IssueController(
+                authentication,
+                new IssueService(
+                        projects,
+                        issueRepository,
+                        new FakeIssueDependencyRepository(),
+                        new FakeCommentRepository(),
+                        new FakeIssueHistoryRepository(),
+                        users,
+                        permissionPolicy,
+                        () -> NOW));
+        return new ControllerFixture(projectController, issueController);
+    }
+
+    private static Project project() {
+        return Project.fromPersistence(PROJECT_ID, "Alpha", "Alpha project", "admin", NOW, NOW);
+    }
+
+    private static Issue issue(long id, String title, String description, Priority priority, User reporter) {
+        return Issue.fromPersistence(Issue.persistedState(PROJECT_ID, title, description, reporter)
+                .id(id)
+                .issueId("ISSUE-" + id)
+                .priority(priority)
+                .reportedDate(NOW.plusMinutes(id))
+                .updatedAt(NOW.plusMinutes(id)));
+    }
+
+    private static User user(String loginId, Role role) {
+        return User.fromPersistence(loginId, loginId, "stored-password", role, true, NOW, NOW);
+    }
+
+    private record ControllerFixture(ProjectController projectController, IssueController issueController) {
+    }
+
+    private static final class RecordingIssueListView implements IssueListView {
+
+        private ProjectResult project;
+        private List<IssueSummary> issues = List.of();
+        private boolean registerEnabled;
+        private String message = " ";
+
+        @Override
+        public void showProject(ProjectResult project) {
+            this.project = project;
+        }
+
+        @Override
+        public void showIssues(List<IssueSummary> issues) {
+            this.issues = List.copyOf(issues);
+        }
+
+        @Override
+        public void setRegisterEnabled(boolean enabled) {
+            registerEnabled = enabled;
+        }
+
+        @Override
+        public void showMessage(String message, boolean error) {
+            this.message = message;
+        }
+
+        private String projectName() {
+            return project.name();
+        }
+
+        private List<String> issueTitles() {
+            return issues.stream()
+                    .map(IssueSummary::title)
+                    .toList();
+        }
+
+        private boolean registerEnabled() {
+            return registerEnabled;
+        }
+
+        private String message() {
+            return message;
+        }
+    }
+
+    private static final class FakeCommentRepository implements CommentRepository {
+
+        @Override
+        public Optional<Comment> findById(long commentId) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<Comment> findByIssueId(long issueId) {
+            return List.of();
+        }
+
+        @Override
+        public Comment saveCommentAndRecordHistory(Comment comment, IssueHistory history) {
+            return comment;
+        }
+
+        @Override
+        public void deleteGeneralByIdAndRecordIssueChange(
+                long issueId,
+                long commentId,
+                String writerLoginId,
+                IssueHistory history) {
+            // Comment deletion is outside the presenter scenarios covered by this fake.
+        }
+    }
+
+    private static final class AcceptingPasswordHashing implements PasswordHashing {
+
+        @Override
+        public String hash(String password) {
+            return "hashed-" + password;
+        }
+
+        @Override
+        public boolean matches(String password, String storedCredential) {
+            return true;
+        }
+
+        @Override
+        public boolean isHashed(String storedCredential) {
+            return true;
+        }
+
+        @Override
+        public String saltOf(String storedCredential) {
+            return "salt";
+        }
+
+        @Override
+        public String hashOf(String storedCredential) {
+            return storedCredential;
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -9,18 +9,28 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.github.marcellokim.issuetracker.controller.AccountController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.controller.IssueController;
 import com.github.marcellokim.issuetracker.controller.ProjectController;
+import com.github.marcellokim.issuetracker.domain.Comment;
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueHistory;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Project;
 import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.CommentRepository;
 import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository;
 import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository.DashboardProjectSnapshot;
 import com.github.marcellokim.issuetracker.service.AccountService;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
 import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
+import com.github.marcellokim.issuetracker.service.IssueService;
 import com.github.marcellokim.issuetracker.service.PasswordHashing;
 import com.github.marcellokim.issuetracker.service.PermissionPolicy;
 import com.github.marcellokim.issuetracker.service.ProjectService;
+import com.github.marcellokim.issuetracker.support.FakeIssueDependencyRepository;
+import com.github.marcellokim.issuetracker.support.FakeIssueHistoryRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
@@ -29,6 +39,7 @@ import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -65,6 +76,7 @@ class SwingAppPanelTest {
                     controllers.dashboardController(),
                     controllers.accountController(),
                     controllers.projectController(),
+                    controllers.issueController(),
                     titles::update);
             panelRef.set(panel);
             JTextField loginId = SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class);
@@ -139,6 +151,7 @@ class SwingAppPanelTest {
                     controllers.dashboardController(),
                     controllers.accountController(),
                     controllers.projectController(),
+                    controllers.issueController(),
                     titles::update);
             panelRef.set(panel);
             SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText("admin");
@@ -187,6 +200,7 @@ class SwingAppPanelTest {
                     controllers.dashboardController(),
                     controllers.accountController(),
                     controllers.projectController(),
+                    controllers.issueController(),
                     titles::update);
             panelRef.set(panel);
             SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText("admin");
@@ -246,6 +260,7 @@ class SwingAppPanelTest {
                     controllers.dashboardController(),
                     controllers.accountController(),
                     controllers.projectController(),
+                    controllers.issueController(),
                     titles::update);
             panelRef.set(panel);
             SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText("admin");
@@ -313,6 +328,7 @@ class SwingAppPanelTest {
                     controllers.dashboardController(),
                     controllers.accountController(),
                     controllers.projectController(),
+                    controllers.issueController(),
                     titles::update);
             panelRef.set(panel);
             SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText("admin");
@@ -370,15 +386,17 @@ class SwingAppPanelTest {
     }
 
     @Test
-    @DisplayName("project list opens issue list placeholder with selected project id")
-    void projectListOpensIssueListPlaceholderWithSelectedProjectId() throws Exception {
+    @DisplayName("project list opens issue list with selected project id")
+    void projectListOpensIssueListWithSelectedProjectId() throws Exception {
         var passwordHashing = new RecordingPasswordHashing();
         var titles = new RecordingTitleUpdater();
+        User tester = user("tester1", Role.TESTER);
         SwingAppPanel panel = loginProjectUser(
                 passwordHashing,
                 titles,
                 List.of(projectSnapshot(7L, "Alpha", 3, 7)),
-                user("tester1", Role.TESTER));
+                List.of(issue(7L, 7L, "Login bug", Priority.CRITICAL, tester)),
+                tester);
 
         SwingComponentTestSupport.onEdt(() -> {
             JTable projects = SwingComponentTestSupport.find(panel, "projectListTable", JTable.class);
@@ -387,15 +405,28 @@ class SwingAppPanelTest {
         awaitButtonEnabled(panel, "openProjectIssuesButton");
         SwingComponentTestSupport.onEdt(() ->
                 SwingComponentTestSupport.find(panel, "openProjectIssuesButton", JButton.class).doClick());
-        awaitPlaceholderTitle(panel, "Issue list #7");
+        awaitIssueRows(panel, 1);
 
         SwingComponentTestSupport.onEdt(() -> {
             assertEquals(
-                    "Issue list #7",
+                    "Alpha",
+                    SwingComponentTestSupport.find(panel, "issueListTitle", JLabel.class).getText());
+            JTable issues = SwingComponentTestSupport.find(panel, "issueListTable", JTable.class);
+            assertEquals("Login bug", issues.getValueAt(0, 4));
+            issues.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openIssueDetailButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick());
+        awaitPlaceholderTitle(panel, "Issue detail #7");
+
+        SwingComponentTestSupport.onEdt(() -> {
+            assertEquals(
+                    "Issue detail #7",
                     SwingComponentTestSupport.find(panel, "placeholderTitle", JLabel.class).getText());
             SwingComponentTestSupport.find(panel, "backButton", JButton.class).doClick();
         });
-        awaitProjectListRows(panel, 1);
+        awaitIssueRows(panel, 1);
     }
 
     @Test
@@ -426,9 +457,18 @@ class SwingAppPanelTest {
             RecordingTitleUpdater titles,
             List<DashboardProjectSnapshot> projects,
             User user) throws Exception {
+        return loginProjectUser(passwordHashing, titles, projects, List.of(), user);
+    }
+
+    private static SwingAppPanel loginProjectUser(
+            RecordingPasswordHashing passwordHashing,
+            RecordingTitleUpdater titles,
+            List<DashboardProjectSnapshot> projects,
+            List<Issue> issues,
+            User user) throws Exception {
         var panelRef = new AtomicReference<SwingAppPanel>();
         var workerDone = new CountDownLatch(1);
-        SwingControllerFixture controllers = controllers(passwordHashing, projects, user);
+        SwingControllerFixture controllers = controllers(passwordHashing, projects, issues, user);
 
         SwingComponentTestSupport.onEdt(() -> {
             SwingAppPanel panel = new SwingAppPanel(
@@ -436,6 +476,7 @@ class SwingAppPanelTest {
                     controllers.dashboardController(),
                     controllers.accountController(),
                     controllers.projectController(),
+                    controllers.issueController(),
                     titles::update);
             panelRef.set(panel);
             SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText(user.getLoginId());
@@ -482,6 +523,10 @@ class SwingAppPanelTest {
 
     private static void awaitProjectListRows(SwingAppPanel panel, int expectedRows) throws Exception {
         awaitRows(panel, "projectListTable", expectedRows);
+    }
+
+    private static void awaitIssueRows(SwingAppPanel panel, int expectedRows) throws Exception {
+        awaitRows(panel, "issueListTable", expectedRows);
     }
 
     private static void awaitProjectDetailName(SwingAppPanel panel, String expectedName) throws Exception {
@@ -619,16 +664,31 @@ class SwingAppPanelTest {
             PasswordHashing passwordHashing,
             List<DashboardProjectSnapshot> projects,
             User... users) {
+        return controllers(passwordHashing, projects, List.of(), users);
+    }
+
+    private static SwingControllerFixture controllers(
+            PasswordHashing passwordHashing,
+            List<DashboardProjectSnapshot> projects,
+            List<Issue> issues,
+            User... users) {
         var repository = new InMemoryUserRepository(users);
         var projectRepository = new InMemoryProjectRepository();
-        projects.forEach(project -> projectRepository.withProject(com.github.marcellokim.issuetracker.domain.Project
-                .fromPersistence(
+        projects.forEach(project -> {
+            projectRepository.withProject(Project.fromPersistence(
                         project.projectId(),
                         project.projectName(),
                         project.projectDescription(),
                         "admin",
                         NOW,
-                        NOW)));
+                        NOW));
+            for (User user : users) {
+                if (user.getRole() != Role.ADMIN) {
+                    projectRepository.withParticipant(project.projectId(), user.getLoginId());
+                }
+            }
+        });
+        var issueRepository = new InMemoryIssueRepository(issues.toArray(Issue[]::new));
         var service = new AuthenticationService(repository, passwordHashing, new SessionStore());
         PermissionPolicy permissionPolicy = new PermissionPolicy();
         return new SwingControllerFixture(
@@ -652,7 +712,18 @@ class SwingAppPanelTest {
                         service,
                         new ProjectService(
                                 projectRepository,
-                                new InMemoryIssueRepository(),
+                                issueRepository,
+                                repository,
+                                permissionPolicy,
+                                () -> NOW)),
+                new IssueController(
+                        service,
+                        new IssueService(
+                                projectRepository,
+                                issueRepository,
+                                new FakeIssueDependencyRepository(),
+                                new FakeCommentRepository(),
+                                new FakeIssueHistoryRepository(),
                                 repository,
                                 permissionPolicy,
                                 () -> NOW)));
@@ -679,11 +750,48 @@ class SwingAppPanelTest {
                 Map.of(IssueStatus.NEW, visibleIssueCount));
     }
 
+    private static Issue issue(long id, long projectId, String title, Priority priority, User reporter) {
+        return Issue.fromPersistence(Issue.persistedState(projectId, title, "Issue description", reporter)
+                .id(id)
+                .issueId("ISSUE-" + id)
+                .priority(priority)
+                .reportedDate(NOW)
+                .updatedAt(NOW));
+    }
+
     private record SwingControllerFixture(
             AuthenticationController authenticationController,
             DashboardController dashboardController,
             AccountController accountController,
-            ProjectController projectController) {
+            ProjectController projectController,
+            IssueController issueController) {
+    }
+
+    private static final class FakeCommentRepository implements CommentRepository {
+
+        @Override
+        public Optional<Comment> findById(long commentId) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<Comment> findByIssueId(long issueId) {
+            return List.of();
+        }
+
+        @Override
+        public Comment saveCommentAndRecordHistory(Comment comment, IssueHistory history) {
+            return comment;
+        }
+
+        @Override
+        public void deleteGeneralByIdAndRecordIssueChange(
+                long issueId,
+                long commentId,
+                String writerLoginId,
+                IssueHistory history) {
+            // Comment deletion is outside the app navigation scenarios covered by this fake.
+        }
     }
 
     private record FakeDashboardSummaryRepository(


### PR DESCRIPTION
## purpose
Closes #208

Swing 실사용자 흐름에서 프로젝트 선택 후 이슈 목록을 조회하고, 검색/필터/신규 이슈 등록/이슈 상세 진입까지 이어지는 화면을 구현함.

## non-goals
- 이슈 상세 화면의 실제 조회/수정/상태 변경 UI는 후속 Swing 이슈에서 처리함.
- JavaFX 화면과 백엔드 정책은 변경하지 않음.
- 삭제 이슈 관리, 통계, dependency action은 후속 화면 범위로 남김.

## diff map
- 핵심 변경: `IssueListPanel`, `IssueListPresenter`, `IssueListView` 추가
- 요청 모델: `IssueSearchRequest`, `IssueRegisterRequest`, `IssueDialogs` 추가
- 공통화: 이슈 테이블 행/선택 복원은 `IssueTableRows`로 분리하고 기존 Swing 테이블 섹션/EDT 헬퍼를 재사용
- 앱 연결: `SwingAppPanel`에서 프로젝트 목록 -> 이슈 목록 -> 이슈 상세 placeholder 흐름 연결
- stale worker 방지: 현재 worker만 view 갱신하도록 `Current*View` wrapper들을 분리하고 EDT 안에서 gate를 확인
- 검색 범위: Swing 검색은 초기 목록과 같은 관련 이슈 범위 안에서만 수행하도록 `searchRelatedProjectIssues` 경로 추가
- 테스트: 이슈 목록 패널/프레젠터, 관련 이슈 범위 검색, Swing 앱 라우팅, 렌더링 스냅샷 검증 추가

## verification evidence
- `git diff --check origin/dev...HEAD`
- `./gradlew test --tests '*IssueList*' --tests '*IssueServiceTest*' --tests '*IssueControllerTest*' --tests '*SwingAppPanelTest*' --console=plain`
- `./gradlew check --console=plain`
- push 전 hook: test + repository setup 통과
- 렌더링 증빙: `build/reports/ui/issue-list-panel.png`, `build/reports/ui/issue-list-panel-selected.png`

## reviewer focus areas
- 프로젝트 목록에서 선택한 projectId가 이슈 목록 조회/등록/검색에 유지되는지
- 검색 keyword/status/priority 전달과 DELETED 제외 필터 구성이 맞는지
- DEV/TESTER 검색 결과가 초기 관련 이슈 목록 범위를 벗어나지 않는지
- 신규 이슈 등록 후 목록 refresh 및 메시지 표시가 자연스러운지
- 이슈 테이블 선택/더블클릭/상세 placeholder 이동이 기존 Swing navigation과 충돌하지 않는지

## risk / rollback
- Swing UI 내부 변경과 관련 이슈 검색 경로 추가가 중심이며 저장소/스키마 변경은 없음.
- 문제가 있으면 이슈 목록 화면 연결과 새 패널/프레젠터/관련 검색 경로 추가분을 되돌리면 됨.