### PR TITLE
feat: Swing 이슈 상세/action 화면 구현

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/controller/IssueController.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/controller/IssueController.java
@@ -4,6 +4,7 @@ import com.github.marcellokim.issuetracker.domain.Priority;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.User;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.CommentActionResult;
 import com.github.marcellokim.issuetracker.service.CommentResult;
 import com.github.marcellokim.issuetracker.service.DependencyResult;
 import com.github.marcellokim.issuetracker.service.IssueDetailResult;
@@ -13,7 +14,6 @@ import com.github.marcellokim.issuetracker.service.IssueSummary;
 import com.github.marcellokim.issuetracker.service.IssueWorkflowActions;
 import com.github.marcellokim.issuetracker.service.IssueWorkflowService;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -55,7 +55,7 @@ public final class IssueController {
             return detail;
         }
         IssueWorkflowActions actions = issueWorkflowService.viewAvailableActions(issueId, user.getLoginId());
-        return detail.withAvailableActions(availableActionNames(actions));
+        return detail.withAvailableActions(actions.availableActionNames());
     }
 
     public List<IssueSummary> searchIssues(long projectId, String keyword, IssueStatus status,
@@ -148,6 +148,11 @@ public final class IssueController {
         return requireIssueWorkflowService().viewAvailableActions(issueId, user.getLoginId());
     }
 
+    public List<CommentActionResult> viewCommentActions(long issueId) {
+        User user = requireCurrentUser();
+        return requireIssueWorkflowService().viewCommentActions(issueId, user.getLoginId());
+    }
+
     public boolean canUpdateComment(long issueId, long commentId) {
         User user = requireCurrentUser();
         return requireIssueWorkflowService().canUpdateComment(issueId, commentId, user.getLoginId());
@@ -168,56 +173,6 @@ public final class IssueController {
             throw new IllegalStateException("Issue workflow service is not configured.");
         }
         return issueWorkflowService;
-    }
-
-    private static List<String> availableActionNames(IssueWorkflowActions actions) {
-        ArrayList<String> names = new ArrayList<>();
-        if (actions.canUpdateIssue()) {
-            names.add("UPDATE_ISSUE");
-        }
-        if (actions.canChangePriority()) {
-            names.add("CHANGE_PRIORITY");
-        }
-        if (actions.canStartAssignment()) {
-            names.add("START_ASSIGNMENT");
-        }
-        if (actions.canAssign()) {
-            names.add("ASSIGN");
-        }
-        if (actions.canReassign()) {
-            names.add("REASSIGN_DEV");
-        }
-        if (actions.canChangeVerifier()) {
-            names.add("CHANGE_TESTER");
-        }
-        if (actions.canMarkFixed()) {
-            names.add("MARK_FIXED");
-        }
-        if (actions.canRejectFix()) {
-            names.add("REJECT_FIX");
-        }
-        if (actions.canResolve()) {
-            names.add("RESOLVE");
-        }
-        if (actions.canClose()) {
-            names.add("CLOSE");
-        }
-        if (actions.canReopen()) {
-            names.add("REOPEN");
-        }
-        if (actions.canAddDependency()) {
-            names.add("ADD_DEPENDENCY");
-        }
-        if (actions.canRemoveDependency()) {
-            names.add("REMOVE_DEPENDENCY");
-        }
-        if (actions.canAddComment()) {
-            names.add("ADD_COMMENT");
-        }
-        if (actions.canSoftDelete()) {
-            names.add("SOFT_DELETE");
-        }
-        return List.copyOf(names);
     }
 
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/service/CommentActionResult.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/CommentActionResult.java
@@ -1,0 +1,4 @@
+package com.github.marcellokim.issuetracker.service;
+
+public record CommentActionResult(String commentId, boolean canUpdate, boolean canDelete) {
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueWorkflowActions.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueWorkflowActions.java
@@ -1,5 +1,8 @@
 package com.github.marcellokim.issuetracker.service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public record IssueWorkflowActions(
         boolean canUpdateIssue,
         boolean canChangePriority,
@@ -16,4 +19,54 @@ public record IssueWorkflowActions(
         boolean canRemoveDependency,
         boolean canAddComment,
         boolean canSoftDelete) {
+
+    public List<String> availableActionNames() {
+        ArrayList<String> names = new ArrayList<>();
+        if (canUpdateIssue) {
+            names.add("UPDATE_ISSUE");
+        }
+        if (canChangePriority) {
+            names.add("CHANGE_PRIORITY");
+        }
+        if (canStartAssignment) {
+            names.add("START_ASSIGNMENT");
+        }
+        if (canAssign) {
+            names.add("ASSIGN");
+        }
+        if (canReassign) {
+            names.add("REASSIGN_DEV");
+        }
+        if (canChangeVerifier) {
+            names.add("CHANGE_TESTER");
+        }
+        if (canMarkFixed) {
+            names.add("MARK_FIXED");
+        }
+        if (canRejectFix) {
+            names.add("REJECT_FIX");
+        }
+        if (canResolve) {
+            names.add("RESOLVE");
+        }
+        if (canClose) {
+            names.add("CLOSE");
+        }
+        if (canReopen) {
+            names.add("REOPEN");
+        }
+        if (canAddDependency) {
+            names.add("ADD_DEPENDENCY");
+        }
+        if (canRemoveDependency) {
+            names.add("REMOVE_DEPENDENCY");
+        }
+        if (canAddComment) {
+            names.add("ADD_COMMENT");
+        }
+        if (canSoftDelete) {
+            names.add("SOFT_DELETE");
+        }
+        return List.copyOf(names);
+    }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueWorkflowService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueWorkflowService.java
@@ -10,6 +10,7 @@ import com.github.marcellokim.issuetracker.repository.CommentRepository;
 import com.github.marcellokim.issuetracker.repository.IssueDependencyRepository;
 import com.github.marcellokim.issuetracker.repository.IssueRepository;
 import com.github.marcellokim.issuetracker.repository.UserRepository;
+import java.util.List;
 import java.util.Objects;
 
 public final class IssueWorkflowService {
@@ -34,10 +35,9 @@ public final class IssueWorkflowService {
     }
 
     public IssueWorkflowActions viewAvailableActions(long issueId, String currentLoginId) {
-        long requiredIssueId = requirePositive(issueId, "issueId");
-        String requiredLoginId = requireText(currentLoginId, "currentLoginId");
-        Issue issue = findIssue(requiredIssueId);
-        User actor = findUser(requiredLoginId);
+        WorkflowContext context = workflowContext(issueId, currentLoginId);
+        Issue issue = context.issue();
+        User actor = context.actor();
 
         if (issue.status() == IssueStatus.DELETED) {
             return noActions();
@@ -72,6 +72,21 @@ public final class IssueWorkflowService {
                 (actor, comment) -> permissionPolicy.assertCanDeleteComment(actor, comment));
     }
 
+    public List<CommentActionResult> viewCommentActions(long issueId, String currentLoginId) {
+        WorkflowContext context = workflowContext(issueId, currentLoginId);
+        Issue issue = context.issue();
+        User actor = context.actor();
+        if (issue.status() == IssueStatus.DELETED || !isActiveProjectMember(actor, issue.projectId())) {
+            return List.of();
+        }
+        return commentRepository.findByIssueId(issue.id()).stream()
+                .map(comment -> new CommentActionResult(
+                        comment.getCommentId(),
+                        allows(() -> permissionPolicy.assertCanUpdateComment(actor, comment)),
+                        allows(() -> permissionPolicy.assertCanDeleteComment(actor, comment))))
+                .toList();
+    }
+
     private boolean canManageComment(
             long issueId,
             long commentId,
@@ -89,10 +104,16 @@ public final class IssueWorkflowService {
             User actor = findUser(requiredLoginId);
             return comment.issueId() == issue.id()
                     && isActiveProjectMember(actor, issue.projectId())
-                    && allows(() -> permissionCheck.check(actor, comment));
+                && allows(() -> permissionCheck.check(actor, comment));
         } catch (RuntimeException exception) {
             return false;
         }
+    }
+
+    private WorkflowContext workflowContext(long issueId, String currentLoginId) {
+        long requiredIssueId = requirePositive(issueId, "issueId");
+        String requiredLoginId = requireText(currentLoginId, "currentLoginId");
+        return new WorkflowContext(findIssue(requiredIssueId), findUser(requiredLoginId));
     }
 
     private WorkflowAccess workflowAccess(User actor, Issue issue) {
@@ -282,6 +303,9 @@ public final class IssueWorkflowService {
             boolean canManageAssignment,
             boolean canManageDependency,
             boolean canManageDeleted) {
+    }
+
+    private record WorkflowContext(Issue issue, User actor) {
     }
 
     @FunctionalInterface

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentIssueDetailView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentIssueDetailView.java
@@ -1,0 +1,37 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.IssueDetailResult;
+import com.github.marcellokim.issuetracker.service.IssueWorkflowActions;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.swing.SwingWorker;
+
+final class CurrentIssueDetailView implements IssueDetailView {
+
+    private final IssueDetailPanel delegate;
+    private final CurrentViewGate gate;
+
+    CurrentIssueDetailView(
+            IssueDetailPanel delegate,
+            SwingWorker<?, ?> worker,
+            Supplier<? extends SwingWorker<?, ?>> currentWorker) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.gate = new CurrentViewGate(worker, currentWorker);
+    }
+
+    @Override
+    public void showDetail(IssueDetailResult detail, List<IssueCommentActionState> commentActions) {
+        gate.update(() -> delegate.showDetail(detail, commentActions));
+    }
+
+    @Override
+    public void showActions(IssueWorkflowActions actions) {
+        gate.update(() -> delegate.showActions(actions));
+    }
+
+    @Override
+    public void showMessage(String message, boolean error) {
+        gate.update(() -> delegate.showMessage(message, error));
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentActionState.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentActionState.java
@@ -1,0 +1,11 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+record IssueCommentActionState(String commentId, boolean canUpdate, boolean canDelete) {
+
+    IssueCommentActionState {
+        if (commentId == null || commentId.isBlank()) {
+            throw new IllegalArgumentException("commentId must not be blank");
+        }
+        commentId = commentId.trim();
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
@@ -1,0 +1,411 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.CommentResult;
+import com.github.marcellokim.issuetracker.service.DependencyResult;
+import com.github.marcellokim.issuetracker.service.HistoryResult;
+import com.github.marcellokim.issuetracker.service.IssueDetailResult;
+import com.github.marcellokim.issuetracker.service.IssueWorkflowActions;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Rectangle;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.Scrollable;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+
+final class IssueDetailPanel extends JPanel implements IssueDetailView {
+
+    private static final long serialVersionUID = 1L;
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    private static final String DEFAULT_ERROR_MESSAGE = "Issue detail failed. Please try again.";
+    private static final Color SELECTION_BACKGROUND = new Color(219, 234, 254);
+    private static final int SUMMARY_SECTION_HEIGHT = 168;
+    private static final int ACTION_SECTION_HEIGHT = 150;
+    private static final int COMMENT_SECTION_HEIGHT = 190;
+    private static final int HISTORY_SECTION_HEIGHT = 170;
+    private static final int DEPENDENCY_SECTION_HEIGHT = 150;
+    private static final String[] COMMENT_COLUMNS = {
+            "ID", "Purpose", "Writer", "Content", "Updated", "Edit", "Delete"
+    };
+    private static final String[] HISTORY_COLUMNS = {
+            "ID", "Action", "By", "Previous", "New", "Message", "Changed"
+    };
+    private static final String[] DEPENDENCY_COLUMNS = {
+            "ID", "Dependency", "Blocking", "Blocked", "Discovered"
+    };
+    private static final List<ActionSpec> ACTION_SPECS = List.of(
+            new ActionSpec("MARK_FIXED", "Mark fixed"),
+            new ActionSpec("RESOLVE", "Resolve"),
+            new ActionSpec("REJECT_FIX", "Reject fix"),
+            new ActionSpec("CLOSE", "Close"),
+            new ActionSpec("REOPEN", "Reopen"),
+            new ActionSpec("START_ASSIGNMENT", "Start assignment"),
+            new ActionSpec("ASSIGN", "Assign"),
+            new ActionSpec("REASSIGN_DEV", "Reassign dev"),
+            new ActionSpec("CHANGE_TESTER", "Change tester"),
+            new ActionSpec("UPDATE_ISSUE", "Edit issue"),
+            new ActionSpec("CHANGE_PRIORITY", "Change priority"),
+            new ActionSpec("ADD_DEPENDENCY", "Add dependency"),
+            new ActionSpec("REMOVE_DEPENDENCY", "Remove dependency"),
+            new ActionSpec("ADD_COMMENT", "Add comment"),
+            new ActionSpec("SOFT_DELETE", "Delete issue"));
+
+    private final transient IssueDetailActions actions;
+    private final JLabel titleLabel = new JLabel("Issue");
+    private final JLabel stateLabel = new JLabel(" ");
+    private final JLabel userLabel;
+    private final JLabel descriptionLabel = new JLabel(" ");
+    private final JLabel reporterLabel = new JLabel("Reporter: -");
+    private final JLabel assigneeLabel = new JLabel("Assignee: -");
+    private final JLabel verifierLabel = new JLabel("Verifier: -");
+    private final JLabel fixerLabel = new JLabel("Fixer: -");
+    private final JLabel resolverLabel = new JLabel("Resolver: -");
+    private final JLabel messageLabel = new JLabel(" ");
+    private final DefaultTableModel commentTableModel = SwingPanelSections.readOnlyTableModel(COMMENT_COLUMNS);
+    private final DefaultTableModel historyTableModel = SwingPanelSections.readOnlyTableModel(HISTORY_COLUMNS);
+    private final DefaultTableModel dependencyTableModel = SwingPanelSections.readOnlyTableModel(DEPENDENCY_COLUMNS);
+    private final JTable commentTable = table(commentTableModel, "issueCommentTable");
+    private final JTable historyTable = table(historyTableModel, "issueHistoryTable");
+    private final JTable dependencyTable = table(dependencyTableModel, "issueDependencyTable");
+    private final Map<String, JButton> actionButtons = new LinkedHashMap<>();
+    private boolean busy;
+    private Set<String> availableActions = Set.of();
+
+    IssueDetailPanel(UserResult user, IssueDetailActions actions) {
+        Objects.requireNonNull(user, "user");
+        this.actions = Objects.requireNonNull(actions, "actions");
+        this.userLabel = new JLabel(user.name() + " (" + user.role() + ")");
+
+        setName("issueDetailPanel");
+        setLayout(new BorderLayout(SwingStyles.SECTION_GAP, SwingStyles.SECTION_GAP));
+        setBackground(SwingStyles.BACKGROUND);
+        setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING));
+
+        add(header(), BorderLayout.NORTH);
+        add(content(), BorderLayout.CENTER);
+        updateActionButtons();
+    }
+
+    @Override
+    public void showDetail(IssueDetailResult detail, List<IssueCommentActionState> commentActions) {
+        Objects.requireNonNull(detail, "detail");
+        Objects.requireNonNull(commentActions, "commentActions");
+        Map<String, IssueCommentActionState> commentActionById = commentActionById(commentActions);
+        runOnEdt(() -> {
+            titleLabel.setText("[" + detail.issueId() + "] " + detail.title());
+            stateLabel.setText(detail.status() + " / " + detail.priority());
+            descriptionLabel.setText(detail.description());
+            reporterLabel.setText("Reporter: " + formatUser(detail.reporter()));
+            assigneeLabel.setText("Assignee: " + formatUser(detail.assignee()));
+            verifierLabel.setText("Verifier: " + formatUser(detail.verifier()));
+            fixerLabel.setText("Fixer: " + formatUser(detail.fixer()));
+            resolverLabel.setText("Resolver: " + formatUser(detail.resolver()));
+            availableActions = Set.copyOf(detail.availableActions());
+            replaceRows(commentTableModel, commentRows(detail.comments(), commentActionById));
+            replaceRows(historyTableModel, historyRows(detail.histories()));
+            replaceRows(dependencyTableModel, dependencyRows(detail.dependencies()));
+            updateActionButtons();
+        });
+    }
+
+    @Override
+    public void showActions(IssueWorkflowActions actions) {
+        Objects.requireNonNull(actions, "actions");
+        runOnEdt(() -> {
+            availableActions = Set.copyOf(actions.availableActionNames());
+            updateActionButtons();
+        });
+    }
+
+    @Override
+    public void showMessage(String message, boolean error) {
+        runOnEdt(() -> SwingPanelSections.updateMessage(
+                messageLabel,
+                message,
+                error,
+                DEFAULT_ERROR_MESSAGE));
+    }
+
+    void setBusy(boolean busy) {
+        runOnEdt(() -> {
+            this.busy = busy;
+            commentTable.setEnabled(!busy);
+            historyTable.setEnabled(!busy);
+            dependencyTable.setEnabled(!busy);
+            updateActionButtons();
+        });
+    }
+
+    private JPanel header() {
+        JButton backButton = new JButton("Back");
+        backButton.setName("issueDetailBackButton");
+        backButton.addActionListener(event -> actions.onBack().run());
+
+        JButton logoutButton = new JButton("Logout");
+        logoutButton.setName("issueDetailLogoutButton");
+        logoutButton.addActionListener(event -> actions.onLogout().run());
+        configureHeaderLabel(titleLabel, "issueDetailTitle", true);
+        configureHeaderLabel(stateLabel, "issueDetailState", false);
+        configureHeaderLabel(userLabel, "issueDetailUser", false);
+        configureHeaderLabel(messageLabel, "issueDetailMessage", false);
+        return SwingPanelSections.navigationHeader(
+                List.of(titleLabel, stateLabel, userLabel, messageLabel),
+                List.of(backButton, logoutButton));
+    }
+
+    private JPanel content() {
+        JPanel content = new VerticalScrollablePanel();
+        content.setBackground(SwingStyles.BACKGROUND);
+        content.setLayout(new BoxLayout(content, BoxLayout.Y_AXIS));
+
+        content.add(constrainedSection(summarySection(), SUMMARY_SECTION_HEIGHT));
+        content.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
+        content.add(constrainedSection(actionSection(), ACTION_SECTION_HEIGHT));
+        content.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
+        content.add(constrainedSection(SwingPanelSections.tableSection("Comments", commentTable), COMMENT_SECTION_HEIGHT));
+        content.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
+        content.add(constrainedSection(SwingPanelSections.tableSection("History", historyTable), HISTORY_SECTION_HEIGHT));
+        content.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
+        content.add(constrainedSection(
+                SwingPanelSections.tableSection("Dependencies", dependencyTable),
+                DEPENDENCY_SECTION_HEIGHT));
+
+        return SwingPanelSections.verticalScrollPanel(content);
+    }
+
+    private JPanel summarySection() {
+        JPanel section = new JPanel();
+        section.setBackground(SwingStyles.SURFACE);
+        section.setBorder(SwingStyles.surfaceBorder());
+        section.setLayout(new BoxLayout(section, BoxLayout.Y_AXIS));
+
+        descriptionLabel.setName("issueDetailDescription");
+        descriptionLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        descriptionLabel.setForeground(SwingStyles.BODY_TEXT);
+        section.add(descriptionLabel);
+        section.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+
+        for (JLabel label : List.of(reporterLabel, assigneeLabel, verifierLabel, fixerLabel, resolverLabel)) {
+            label.setAlignmentX(Component.LEFT_ALIGNMENT);
+            SwingStyles.applyMuted(label);
+            section.add(label);
+        }
+        return section;
+    }
+
+    private JPanel actionSection() {
+        JPanel section = new JPanel(new BorderLayout(0, SwingStyles.ROW_GAP));
+        section.setBackground(SwingStyles.SURFACE);
+        section.setBorder(SwingStyles.surfaceBorder());
+
+        JLabel title = new JLabel("Available actions");
+        SwingStyles.applySectionTitle(title);
+        section.add(title, BorderLayout.NORTH);
+
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.LEFT, SwingStyles.ROW_GAP, SwingStyles.ROW_GAP));
+        buttons.setOpaque(false);
+        for (ActionSpec spec : ACTION_SPECS) {
+            JButton button = new JButton(spec.label());
+            button.setName("issueActionButton_" + spec.action());
+            button.addActionListener(event -> actions.onAction().accept(this, spec.action()));
+            actionButtons.put(spec.action(), button);
+            buttons.add(button);
+        }
+        section.add(buttons, BorderLayout.CENTER);
+        return section;
+    }
+
+    private static JPanel constrainedSection(JPanel section, int height) {
+        Dimension size = new Dimension(SwingStyles.WINDOW_SIZE.width - SwingStyles.OUTER_PADDING * 2, height);
+        section.setAlignmentX(Component.LEFT_ALIGNMENT);
+        section.setMinimumSize(new Dimension(0, height));
+        section.setPreferredSize(size);
+        section.setMaximumSize(new Dimension(Integer.MAX_VALUE, height));
+        return section;
+    }
+
+    private JTable table(DefaultTableModel model, String name) {
+        JTable table = new JTable(model) {
+            @Override
+            public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
+                return SwingPanelSections.stripedTableCell(
+                        this,
+                        super.prepareRenderer(renderer, row, column),
+                        row,
+                        SELECTION_BACKGROUND);
+            }
+        };
+        SwingPanelSections.configureReadOnlyTable(table, name, SELECTION_BACKGROUND);
+        return table;
+    }
+
+    private void updateActionButtons() {
+        boolean enabled = !busy;
+        actionButtons.forEach((action, button) -> button.setEnabled(enabled && availableActions.contains(action)));
+    }
+
+    private static Map<String, IssueCommentActionState> commentActionById(
+            List<IssueCommentActionState> commentActions) {
+        Map<String, IssueCommentActionState> byId = new LinkedHashMap<>();
+        for (IssueCommentActionState action : commentActions) {
+            byId.put(action.commentId(), action);
+        }
+        return byId;
+    }
+
+    private static List<Object[]> commentRows(
+            List<CommentResult> comments,
+            Map<String, IssueCommentActionState> commentActionById) {
+        return comments.stream()
+                .map(comment -> {
+                    IssueCommentActionState state = commentActionById.get(comment.commentId());
+                    return new Object[]{
+                            comment.commentId(),
+                            comment.purpose(),
+                            comment.writerLoginId(),
+                            comment.content(),
+                            DATE_TIME_FORMATTER.format(comment.updatedDate()),
+                            yesNo(state != null && state.canUpdate()),
+                            yesNo(state != null && state.canDelete())
+                    };
+                })
+                .toList();
+    }
+
+    private static List<Object[]> historyRows(List<HistoryResult> histories) {
+        return histories.stream()
+                .map(history -> new Object[]{
+                        history.id(),
+                        history.actionType().toString(),
+                        history.changedById(),
+                        valueOrDash(history.previousValue()),
+                        valueOrDash(history.newValue()),
+                        valueOrDash(history.message()),
+                        DATE_TIME_FORMATTER.format(history.changedDate())
+                })
+                .toList();
+    }
+
+    private static List<Object[]> dependencyRows(List<DependencyResult> dependencies) {
+        return dependencies.stream()
+                .map(dependency -> new Object[]{
+                        dependency.id(),
+                        dependency.dependencyId(),
+                        dependency.blockingIssueKey(),
+                        dependency.blockedIssueKey(),
+                        DATE_TIME_FORMATTER.format(dependency.discoveredDate())
+                })
+                .toList();
+    }
+
+    private static void replaceRows(DefaultTableModel model, List<Object[]> rows) {
+        model.setRowCount(0);
+        for (Object[] row : rows) {
+            model.addRow(row);
+        }
+    }
+
+    private static String formatUser(UserResult user) {
+        return user == null ? "-" : user.loginId() + " (" + user.name() + ")";
+    }
+
+    private static String yesNo(boolean value) {
+        return value ? "Y" : "N";
+    }
+
+    private static String valueOrDash(String value) {
+        return value == null || value.isBlank() ? "-" : value;
+    }
+
+    private static void configureHeaderLabel(JLabel label, String name, boolean title) {
+        label.setName(name);
+        label.setAlignmentX(Component.LEFT_ALIGNMENT);
+        if (title) {
+            SwingStyles.applyTitle(label);
+            return;
+        }
+        SwingStyles.applyMuted(label);
+    }
+
+    private static void runOnEdt(Runnable action) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            action.run();
+            return;
+        }
+        SwingUtilities.invokeLater(action);
+    }
+
+    @FunctionalInterface
+    interface PanelStringConsumer {
+
+        void accept(IssueDetailPanel panel, String value);
+    }
+
+    record IssueDetailActions(PanelStringConsumer onAction, Runnable onBack, Runnable onLogout) {
+
+        IssueDetailActions {
+            Objects.requireNonNull(onAction, "onAction");
+            Objects.requireNonNull(onBack, "onBack");
+            Objects.requireNonNull(onLogout, "onLogout");
+        }
+    }
+
+    private record ActionSpec(String action, String label) {
+
+        private ActionSpec {
+            Objects.requireNonNull(action, "action");
+            Objects.requireNonNull(label, "label");
+        }
+    }
+
+    private static final class VerticalScrollablePanel extends JPanel implements Scrollable {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Dimension getPreferredScrollableViewportSize() {
+            return getPreferredSize();
+        }
+
+        @Override
+        public int getScrollableUnitIncrement(Rectangle visibleRect, int orientation, int direction) {
+            return 24;
+        }
+
+        @Override
+        public int getScrollableBlockIncrement(Rectangle visibleRect, int orientation, int direction) {
+            return Math.max(24, visibleRect.height - 24);
+        }
+
+        @Override
+        public boolean getScrollableTracksViewportWidth() {
+            return true;
+        }
+
+        @Override
+        public boolean getScrollableTracksViewportHeight() {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenter.java
@@ -1,0 +1,50 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.controller.IssueController;
+import com.github.marcellokim.issuetracker.service.CommentActionResult;
+import com.github.marcellokim.issuetracker.service.IssueDetailResult;
+import java.util.List;
+import java.util.Objects;
+
+final class IssueDetailPresenter {
+
+    private final IssueController issueController;
+    private final IssueDetailView view;
+
+    IssueDetailPresenter(IssueController issueController, IssueDetailView view) {
+        this.issueController = Objects.requireNonNull(issueController, "issueController");
+        this.view = Objects.requireNonNull(view, "view");
+    }
+
+    void loadIssue(long issueId) {
+        try {
+            IssueDetailResult detail = issueController.viewIssueDetail(issueId);
+            view.showDetail(detail, commentActions(issueId));
+            view.showMessage(" ", false);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    void refreshActions(long issueId) {
+        try {
+            view.showActions(issueController.viewAvailableActions(issueId));
+            view.showMessage(" ", false);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    private List<IssueCommentActionState> commentActions(long issueId) {
+        return issueController.viewCommentActions(issueId).stream()
+                .map(IssueDetailPresenter::toCommentActionState)
+                .toList();
+    }
+
+    private static IssueCommentActionState toCommentActionState(CommentActionResult result) {
+        return new IssueCommentActionState(
+                result.commentId(),
+                result.canUpdate(),
+                result.canDelete());
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailView.java
@@ -1,0 +1,14 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.IssueDetailResult;
+import com.github.marcellokim.issuetracker.service.IssueWorkflowActions;
+import java.util.List;
+
+interface IssueDetailView {
+
+    void showDetail(IssueDetailResult detail, List<IssueCommentActionState> commentActions);
+
+    void showActions(IssueWorkflowActions actions);
+
+    void showMessage(String message, boolean error);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -43,6 +43,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private final transient AtomicReference<SwingWorker<Void, Void>> projectDetailWorker = new AtomicReference<>();
     private final transient AtomicReference<SwingWorker<Void, Void>> projectListWorker = new AtomicReference<>();
     private final transient AtomicReference<SwingWorker<Void, Void>> issueListWorker = new AtomicReference<>();
+    private final transient AtomicReference<SwingWorker<Void, Void>> issueDetailWorker = new AtomicReference<>();
 
     SwingAppPanel(
             AuthenticationController authenticationController,
@@ -78,6 +79,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectDetailWorker();
             cancelProjectListWorker();
             cancelIssueListWorker();
+            cancelIssueDetailWorker();
             titleUpdater.accept("Issue Tracker");
             loginPanel.showMessage(" ", false);
             loginPanel.clearPassword();
@@ -96,6 +98,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectDetailWorker();
             cancelProjectListWorker();
             cancelIssueListWorker();
+            cancelIssueDetailWorker();
             titleUpdater.accept("Admin dashboard");
             AdminDashboardPanel panel = new AdminDashboardPanel(
                     user,
@@ -121,6 +124,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectDetailWorker();
             cancelProjectListWorker();
             cancelIssueListWorker();
+            cancelIssueDetailWorker();
             titleUpdater.accept("Project list");
             ProjectListPanel panel = new ProjectListPanel(
                     user,
@@ -143,6 +147,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         cancelProjectDetailWorker();
         cancelProjectListWorker();
         cancelIssueListWorker();
+        cancelIssueDetailWorker();
         authenticationController.logout();
         showLogin();
     }
@@ -207,6 +212,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectDetailWorker();
             cancelProjectListWorker();
             cancelIssueListWorker();
+            cancelIssueDetailWorker();
             titleUpdater.accept("Account management");
             AccountManagementPanel panel = new AccountManagementPanel(
                     user,
@@ -237,6 +243,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectDetailWorker();
             cancelProjectListWorker();
             cancelIssueListWorker();
+            cancelIssueDetailWorker();
             titleUpdater.accept("Project management");
             ProjectManagementPanel panel = new ProjectManagementPanel(
                     user,
@@ -274,6 +281,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectDetailWorker();
             cancelProjectListWorker();
             cancelIssueListWorker();
+            cancelIssueDetailWorker();
             titleUpdater.accept("Project detail");
             ProjectDetailPanel panel = new ProjectDetailPanel(
                     user,
@@ -315,6 +323,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectDetailWorker();
             cancelProjectListWorker();
             cancelIssueListWorker();
+            cancelIssueDetailWorker();
             titleUpdater.accept("Issue list");
             IssueListPanel panel = new IssueListPanel(
                     user,
@@ -348,8 +357,38 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectDetailWorker();
             cancelProjectListWorker();
             cancelIssueListWorker();
+            cancelIssueDetailWorker();
             titleUpdater.accept("Issue detail");
-            showPlaceholder(projectListCard, "Issue detail #" + issueId, user, () -> showIssueList(user, projectId));
+            IssueDetailPanel panel = new IssueDetailPanel(
+                    user,
+                    new IssueDetailPanel.IssueDetailActions(
+                            (panelRef, action) -> showIssueAction(user, projectId, issueId, action),
+                            () -> showIssueList(user, projectId),
+                            this::logout));
+            projectListCard.removeAll();
+            projectListCard.add(panel, BorderLayout.CENTER);
+            projectListCard.revalidate();
+            projectListCard.repaint();
+            cardLayout.show(this, PROJECT_LIST_CARD);
+            startIssueDetailTask(panel, presenter -> presenter.loadIssue(issueId));
+        });
+    }
+
+    private void showIssueAction(UserResult user, long projectId, long issueId, String action) {
+        SwingUtilities.invokeLater(() -> {
+            cancelDashboardWorker();
+            cancelAccountWorker();
+            cancelProjectWorker();
+            cancelProjectDetailWorker();
+            cancelProjectListWorker();
+            cancelIssueListWorker();
+            cancelIssueDetailWorker();
+            titleUpdater.accept("Issue action");
+            showPlaceholder(
+                    projectListCard,
+                    "Issue action " + action,
+                    user,
+                    () -> showIssueDetail(user, projectId, issueId));
             cardLayout.show(this, PROJECT_LIST_CARD);
         });
     }
@@ -447,6 +486,23 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     private void cancelIssueListWorker() {
         SwingWorker<Void, Void> worker = issueListWorker.getAndSet(null);
+        if (worker != null && !worker.isDone()) {
+            worker.cancel(true);
+        }
+    }
+
+    private void startIssueDetailTask(IssueDetailPanel panel, IssueDetailTask task) {
+        Objects.requireNonNull(panel, "panel");
+        Objects.requireNonNull(task, "task");
+        cancelIssueDetailWorker();
+        panel.setBusy(true);
+        IssueDetailWorker worker = new IssueDetailWorker(panel, task);
+        issueDetailWorker.set(worker);
+        worker.execute();
+    }
+
+    private void cancelIssueDetailWorker() {
+        SwingWorker<Void, Void> worker = issueDetailWorker.getAndSet(null);
         if (worker != null && !worker.isDone()) {
             worker.cancel(true);
         }
@@ -644,6 +700,31 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         }
     }
 
+    private final class IssueDetailWorker extends SwingWorker<Void, Void> {
+
+        private final IssueDetailPanel panel;
+        private final IssueDetailTask task;
+
+        private IssueDetailWorker(IssueDetailPanel panel, IssueDetailTask task) {
+            this.panel = Objects.requireNonNull(panel, "panel");
+            this.task = Objects.requireNonNull(task, "task");
+        }
+
+        @Override
+        protected Void doInBackground() {
+            IssueDetailPresenter presenter = new IssueDetailPresenter(
+                    issueController,
+                    new CurrentIssueDetailView(panel, this, issueDetailWorker::get));
+            task.run(presenter);
+            return null;
+        }
+
+        @Override
+        protected void done() {
+            finishWorker(issueDetailWorker, this, () -> panel.setBusy(false), panel::showMessage, "Issue detail");
+        }
+    }
+
     private static void finishWorker(
             AtomicReference<SwingWorker<Void, Void>> workerRef,
             SwingWorker<Void, Void> worker,
@@ -695,6 +776,12 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private interface IssueListTask {
 
         void run(IssueListPresenter presenter);
+    }
+
+    @FunctionalInterface
+    private interface IssueDetailTask {
+
+        void run(IssueDetailPresenter presenter);
     }
 
     @FunctionalInterface

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingPanelSections.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingPanelSections.java
@@ -8,13 +8,16 @@ import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.util.List;
 import java.util.Objects;
+import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.ScrollPaneConstants;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
@@ -159,6 +162,47 @@ final class SwingPanelSections {
         scrollPane.setColumnHeaderView(table.getTableHeader());
         section.add(scrollPane, BorderLayout.CENTER);
         return section;
+    }
+
+    static JPanel navigationHeader(List<JLabel> labels, List<JButton> buttons) {
+        JPanel header = new JPanel(new BorderLayout(SwingStyles.SECTION_GAP, 0));
+        header.setBackground(SwingStyles.SURFACE);
+        header.setBorder(SwingStyles.surfaceBorder());
+        header.add(stackedLabels(labels), BorderLayout.CENTER);
+        header.add(buttonRow(buttons), BorderLayout.EAST);
+        return header;
+    }
+
+    static JPanel verticalScrollPanel(Component content) {
+        JScrollPane scrollPane = new JScrollPane(
+                content,
+                ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
+                ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        scrollPane.setBorder(BorderFactory.createEmptyBorder());
+        JPanel wrapper = new JPanel(new BorderLayout());
+        wrapper.setOpaque(false);
+        wrapper.add(scrollPane, BorderLayout.CENTER);
+        return wrapper;
+    }
+
+    private static JPanel stackedLabels(List<JLabel> labels) {
+        JPanel panel = new JPanel();
+        panel.setOpaque(false);
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        for (int index = 0; index < labels.size(); index++) {
+            if (index > 0) {
+                panel.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+            }
+            panel.add(labels.get(index));
+        }
+        return panel;
+    }
+
+    private static JPanel buttonRow(List<JButton> buttons) {
+        JPanel panel = new JPanel();
+        panel.setOpaque(false);
+        buttons.forEach(panel::add);
+        return panel;
     }
 
     static void applyColumnWidths(JTable table, int[] widths) {

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueWorkflowServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueWorkflowServiceTest.java
@@ -1,5 +1,6 @@
 package com.github.marcellokim.issuetracker.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -148,6 +149,88 @@ class IssueWorkflowServiceTest {
         assertFalse(service.canUpdateComment(otherIssue.id(), 100L, reporter.getLoginId()));
         assertFalse(service.canDeleteComment(issue.id(), 100L, assignee.getLoginId()));
         assertFalse(service.canUpdateComment(issue.id(), 101L, reporter.getLoginId()));
+    }
+
+    @Test
+    @DisplayName("comment action list follows writer and issue access")
+    void commentActionListFollowsWriterAndIssueAccess() {
+        Issue issue = issue(1L, IssueStatus.NEW, reporter, null, null);
+        Issue deleted = issue(2L, IssueStatus.DELETED, reporter, null, null);
+        FakeCommentRepository comments = new FakeCommentRepository(
+                comment(100L, issue.id(), reporter, CommentPurpose.GENERAL),
+                comment(101L, issue.id(), reporter, CommentPurpose.STATUS_CHANGE));
+        InMemoryUserRepository users = new InMemoryUserRepository(reporter, assignee, tester, pl, outsider)
+                .withProjectMembers(
+                        PROJECT_ID,
+                        reporter.getLoginId(),
+                        assignee.getLoginId(),
+                        tester.getLoginId(),
+                        pl.getLoginId());
+        IssueWorkflowService service = service(new FakeIssueDependencyRepository(), comments, users, issue, deleted);
+
+        List<CommentActionResult> actions = service.viewCommentActions(issue.id(), reporter.getLoginId());
+
+        assertEquals(2, actions.size());
+        assertTrue(actions.get(0).canUpdate());
+        assertTrue(actions.get(0).canDelete());
+        assertFalse(actions.get(1).canUpdate());
+        assertFalse(actions.get(1).canDelete());
+        assertTrue(service.viewCommentActions(deleted.id(), reporter.getLoginId()).isEmpty());
+        assertTrue(service.viewCommentActions(issue.id(), outsider.getLoginId()).isEmpty());
+    }
+
+    @Test
+    @DisplayName("workflow action names follow enabled flags")
+    void workflowActionNamesFollowEnabledFlags() {
+        IssueWorkflowActions actions = new IssueWorkflowActions(
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true);
+
+        assertEquals(List.of(
+                "UPDATE_ISSUE",
+                "CHANGE_PRIORITY",
+                "START_ASSIGNMENT",
+                "ASSIGN",
+                "REASSIGN_DEV",
+                "CHANGE_TESTER",
+                "MARK_FIXED",
+                "REJECT_FIX",
+                "RESOLVE",
+                "CLOSE",
+                "REOPEN",
+                "ADD_DEPENDENCY",
+                "REMOVE_DEPENDENCY",
+                "ADD_COMMENT",
+                "SOFT_DELETE"), actions.availableActionNames());
+        assertTrue(new IssueWorkflowActions(
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false).availableActionNames().isEmpty());
     }
 
     @Test

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanelTest.java
@@ -1,0 +1,216 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.domain.ActionType;
+import com.github.marcellokim.issuetracker.domain.CommentPurpose;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.service.CommentResult;
+import com.github.marcellokim.issuetracker.service.DependencyResult;
+import com.github.marcellokim.issuetracker.service.HistoryResult;
+import com.github.marcellokim.issuetracker.service.IssueDetailResult;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.imageio.ImageIO;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JTable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing issue detail panel")
+class IssueDetailPanelTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("renders issue detail, summaries, comment permissions, and action button states")
+    void rendersIssueDetailAndActions() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            IssueDetailPanel panel = panel();
+            panel.showDetail(
+                    detail(List.of("UPDATE_ISSUE", "ADD_COMMENT")),
+                    List.of(new IssueCommentActionState("100", true, true)));
+
+            assertEquals(
+                    "[ISSUE-7] Login bug",
+                    SwingComponentTestSupport.find(panel, "issueDetailTitle", JLabel.class).getText());
+            assertEquals(
+                    "NEW / CRITICAL",
+                    SwingComponentTestSupport.find(panel, "issueDetailState", JLabel.class).getText());
+            assertTrue(SwingComponentTestSupport.find(panel, "issueActionButton_UPDATE_ISSUE", JButton.class)
+                    .isEnabled());
+            assertTrue(SwingComponentTestSupport.find(panel, "issueActionButton_ADD_COMMENT", JButton.class)
+                    .isEnabled());
+            assertFalse(SwingComponentTestSupport.find(panel, "issueActionButton_MARK_FIXED", JButton.class)
+                    .isEnabled());
+
+            JTable comments = SwingComponentTestSupport.find(panel, "issueCommentTable", JTable.class);
+            assertEquals(1, comments.getRowCount());
+            assertEquals("100", comments.getValueAt(0, 0));
+            assertEquals("Y", comments.getValueAt(0, 5));
+            assertEquals("Y", comments.getValueAt(0, 6));
+
+            JTable histories = SwingComponentTestSupport.find(panel, "issueHistoryTable", JTable.class);
+            assertEquals("CREATED", histories.getValueAt(0, 1));
+
+            JTable dependencies = SwingComponentTestSupport.find(panel, "issueDependencyTable", JTable.class);
+            assertEquals("ISSUE-3", dependencies.getValueAt(0, 2));
+        });
+    }
+
+    @Test
+    @DisplayName("publishes available action, back, and logout callbacks")
+    void publishesActions() throws Exception {
+        AtomicReference<String> actionRef = new AtomicReference<>();
+        AtomicInteger backClicks = new AtomicInteger();
+        AtomicInteger logoutClicks = new AtomicInteger();
+
+        SwingComponentTestSupport.onEdt(() -> {
+            IssueDetailPanel panel = new IssueDetailPanel(
+                    userResult("dev1", Role.DEV),
+                    new IssueDetailPanel.IssueDetailActions(
+                            (source, action) -> actionRef.set(action),
+                            backClicks::incrementAndGet,
+                            logoutClicks::incrementAndGet));
+            panel.showDetail(
+                    detail(List.of("ADD_COMMENT")),
+                    List.of(new IssueCommentActionState("100", true, true)));
+
+            SwingComponentTestSupport.find(panel, "issueActionButton_ADD_COMMENT", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "issueDetailBackButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "issueDetailLogoutButton", JButton.class).doClick();
+        });
+
+        assertEquals("ADD_COMMENT", actionRef.get());
+        assertEquals(1, backClicks.get());
+        assertEquals(1, logoutClicks.get());
+    }
+
+    @Test
+    @DisplayName("renders issue detail screen snapshot")
+    void rendersIssueDetailSnapshot() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            IssueDetailPanel panel = panel();
+            panel.showDetail(
+                    detail(List.of("UPDATE_ISSUE", "ADD_COMMENT")),
+                    List.of(new IssueCommentActionState("100", true, true)));
+            panel.setSize(SwingStyles.WINDOW_SIZE);
+            layoutRecursively(panel);
+
+            BufferedImage image = render(panel, Path.of("build/reports/ui/issue-detail-panel.png"));
+            assertTrue(hasRenderedContent(image));
+        });
+    }
+
+    private static IssueDetailPanel panel() {
+        return new IssueDetailPanel(
+                userResult("dev1", Role.DEV),
+                new IssueDetailPanel.IssueDetailActions(
+                        (source, action) -> {
+                        },
+                        () -> {
+                        },
+                        () -> {
+                        }));
+    }
+
+    private static IssueDetailResult detail(List<String> actions) {
+        return new IssueDetailResult(
+                7L,
+                1L,
+                "ISSUE-7",
+                IssueStatus.NEW,
+                Priority.CRITICAL,
+                "Login bug",
+                "Login fails with valid credentials.",
+                userResult("dev1", Role.DEV),
+                null,
+                null,
+                null,
+                null,
+                NOW,
+                NOW,
+                List.of(comment()),
+                List.of(history()),
+                List.of(dependency()),
+                actions);
+    }
+
+    private static CommentResult comment() {
+        return new CommentResult(
+                "100",
+                "Confirmed in local run.",
+                CommentPurpose.GENERAL,
+                "dev1",
+                userResult("dev1", Role.DEV),
+                NOW,
+                NOW);
+    }
+
+    private static HistoryResult history() {
+        return new HistoryResult(1L, 7L, "dev1", ActionType.CREATED, null, "NEW", "Created", NOW);
+    }
+
+    private static DependencyResult dependency() {
+        return new DependencyResult(1L, "dep-1", 3L, "ISSUE-3", 7L, "ISSUE-7", NOW);
+    }
+
+    private static UserResult userResult(String loginId, Role role) {
+        return UserResult.from(User.fromPersistence(loginId, loginId, "stored-password", role, true, NOW, NOW));
+    }
+
+    private static void layoutRecursively(Container container) {
+        container.doLayout();
+        for (java.awt.Component child : container.getComponents()) {
+            if (child instanceof Container nested) {
+                layoutRecursively(nested);
+            }
+        }
+    }
+
+    private static BufferedImage render(IssueDetailPanel panel, Path output) throws java.io.IOException {
+        BufferedImage image = new BufferedImage(
+                SwingStyles.WINDOW_SIZE.width,
+                SwingStyles.WINDOW_SIZE.height,
+                BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            panel.printAll(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        Files.createDirectories(output.getParent());
+        ImageIO.write(image, "png", output.toFile());
+        return image;
+    }
+
+    private static boolean hasRenderedContent(BufferedImage image) {
+        int background = SwingStyles.BACKGROUND.getRGB();
+        int white = Color.WHITE.getRGB();
+        int contentPixels = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                int pixel = image.getRGB(x, y);
+                if (pixel != background && pixel != white) {
+                    contentPixels++;
+                }
+            }
+        }
+        return contentPixels > 10_000;
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
@@ -1,0 +1,261 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.controller.IssueController;
+import com.github.marcellokim.issuetracker.domain.Comment;
+import com.github.marcellokim.issuetracker.domain.CommentPurpose;
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueHistory;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Project;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.CommentRepository;
+import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.IssueDetailResult;
+import com.github.marcellokim.issuetracker.service.IssueService;
+import com.github.marcellokim.issuetracker.service.IssueWorkflowActions;
+import com.github.marcellokim.issuetracker.service.IssueWorkflowService;
+import com.github.marcellokim.issuetracker.service.PasswordHashing;
+import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.support.FakeIssueDependencyRepository;
+import com.github.marcellokim.issuetracker.support.FakeIssueHistoryRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.technical.SessionStore;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing issue detail presenter")
+class IssueDetailPresenterTest {
+
+    private static final long PROJECT_ID = 1L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("loads issue detail with available actions and comment permissions through controllers")
+    void loadsIssueDetailWithActionsAndCommentPermissions() {
+        User reporter = user("dev1", Role.DEV);
+        Issue issue = issue(7L, "Login bug", reporter);
+        FakeCommentRepository comments = new FakeCommentRepository(
+                comment(100L, issue.id(), reporter, CommentPurpose.GENERAL),
+                comment(101L, issue.id(), reporter, CommentPurpose.STATUS_CHANGE));
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                controller(reporter, comments, issue),
+                view);
+
+        presenter.loadIssue(issue.id());
+
+        assertEquals("Login bug", view.detail().title());
+        assertTrue(view.detail().availableActions().contains("UPDATE_ISSUE"));
+        assertTrue(view.detail().availableActions().contains("ADD_COMMENT"));
+        assertEquals(true, view.commentAction("100").canUpdate());
+        assertEquals(true, view.commentAction("100").canDelete());
+        assertEquals(false, view.commentAction("101").canUpdate());
+        assertEquals(" ", view.message());
+    }
+
+    @Test
+    @DisplayName("refreshes action buttons without replacing the loaded detail")
+    void refreshesAvailableActionsOnly() {
+        User reporter = user("dev1", Role.DEV);
+        Issue issue = issue(7L, "Login bug", reporter);
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                controller(reporter, new FakeCommentRepository(), issue),
+                view);
+        presenter.loadIssue(issue.id());
+
+        presenter.refreshActions(issue.id());
+
+        assertEquals("Login bug", view.detail().title());
+        assertTrue(view.actions().canUpdateIssue());
+        assertTrue(view.actions().canAddComment());
+    }
+
+    @Test
+    @DisplayName("shows controller errors without replacing current detail")
+    void showsErrorsWithoutReplacingCurrentDetail() {
+        User reporter = user("dev1", Role.DEV);
+        Issue issue = issue(7L, "Login bug", reporter);
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                controller(reporter, new FakeCommentRepository(), issue),
+                view);
+        presenter.loadIssue(issue.id());
+
+        presenter.loadIssue(999L);
+
+        assertEquals("Login bug", view.detail().title());
+        assertEquals("Issue not found: 999", view.message());
+    }
+
+    private static IssueController controller(User currentUser, FakeCommentRepository comments, Issue... issues) {
+        InMemoryUserRepository users = new InMemoryUserRepository(currentUser)
+                .withProjectMembers(PROJECT_ID, currentUser.getLoginId());
+        InMemoryProjectRepository projects = new InMemoryProjectRepository(project())
+                .withParticipant(PROJECT_ID, currentUser.getLoginId());
+        InMemoryIssueRepository issueRepository = new InMemoryIssueRepository(issues);
+        FakeIssueDependencyRepository dependencies = new FakeIssueDependencyRepository();
+        PermissionPolicy permissionPolicy = new PermissionPolicy();
+        AuthenticationService authentication = new AuthenticationService(
+                users,
+                new AcceptingPasswordHashing(),
+                new SessionStore());
+        authentication.login(currentUser.getLoginId(), "password");
+        IssueService issueService = new IssueService(
+                projects,
+                issueRepository,
+                dependencies,
+                comments,
+                new FakeIssueHistoryRepository(),
+                users,
+                permissionPolicy,
+                () -> NOW);
+        IssueWorkflowService workflowService = new IssueWorkflowService(
+                issueRepository,
+                dependencies,
+                comments,
+                users,
+                permissionPolicy);
+        return new IssueController(authentication, issueService, workflowService);
+    }
+
+    private static Project project() {
+        return Project.fromPersistence(PROJECT_ID, "Alpha", "Alpha project", "admin", NOW, NOW);
+    }
+
+    private static Issue issue(long id, String title, User reporter) {
+        return Issue.fromPersistence(Issue.persistedState(PROJECT_ID, title, "Issue description", reporter)
+                .id(id)
+                .issueId("ISSUE-" + id)
+                .status(IssueStatus.NEW)
+                .priority(Priority.CRITICAL)
+                .reportedDate(NOW)
+                .updatedAt(NOW));
+    }
+
+    private static Comment comment(long id, long issueId, User writer, CommentPurpose purpose) {
+        return Comment.fromPersistence(id, issueId, writer.getLoginId(), "Comment " + id, purpose, NOW, NOW);
+    }
+
+    private static User user(String loginId, Role role) {
+        return User.fromPersistence(loginId, loginId, "stored-password", role, true, NOW, NOW);
+    }
+
+    private static final class RecordingIssueDetailView implements IssueDetailView {
+
+        private IssueDetailResult detail;
+        private IssueWorkflowActions actions;
+        private List<IssueCommentActionState> commentActions = List.of();
+        private String message = " ";
+
+        @Override
+        public void showDetail(IssueDetailResult detail, List<IssueCommentActionState> commentActions) {
+            this.detail = detail;
+            this.commentActions = List.copyOf(commentActions);
+        }
+
+        @Override
+        public void showActions(IssueWorkflowActions actions) {
+            this.actions = actions;
+        }
+
+        @Override
+        public void showMessage(String message, boolean error) {
+            this.message = message;
+        }
+
+        private IssueDetailResult detail() {
+            return detail;
+        }
+
+        private IssueWorkflowActions actions() {
+            return actions;
+        }
+
+        private IssueCommentActionState commentAction(String commentId) {
+            return commentActions.stream()
+                    .filter(action -> action.commentId().equals(commentId))
+                    .findFirst()
+                    .orElseThrow();
+        }
+
+        private String message() {
+            return message;
+        }
+    }
+
+    private static final class FakeCommentRepository implements CommentRepository {
+
+        private final List<Comment> comments;
+
+        private FakeCommentRepository(Comment... comments) {
+            this.comments = List.of(comments);
+        }
+
+        @Override
+        public Optional<Comment> findById(long commentId) {
+            return comments.stream()
+                    .filter(comment -> comment.id() == commentId)
+                    .findFirst();
+        }
+
+        @Override
+        public List<Comment> findByIssueId(long issueId) {
+            return comments.stream()
+                    .filter(comment -> comment.issueId() == issueId)
+                    .toList();
+        }
+
+        @Override
+        public Comment saveCommentAndRecordHistory(Comment comment, IssueHistory history) {
+            throw new UnsupportedOperationException("Comment writes are outside this presenter test.");
+        }
+
+        @Override
+        public void deleteGeneralByIdAndRecordIssueChange(
+                long issueId,
+                long commentId,
+                String writerLoginId,
+                IssueHistory history) {
+            throw new UnsupportedOperationException("Comment deletes are outside this presenter test.");
+        }
+    }
+
+    private static final class AcceptingPasswordHashing implements PasswordHashing {
+
+        @Override
+        public String hash(String password) {
+            return "hashed-" + password;
+        }
+
+        @Override
+        public boolean matches(String password, String storedCredential) {
+            return true;
+        }
+
+        @Override
+        public boolean isHashed(String storedCredential) {
+            return true;
+        }
+
+        @Override
+        public String saltOf(String storedCredential) {
+            return "salt";
+        }
+
+        @Override
+        public String hashOf(String storedCredential) {
+            return storedCredential;
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -26,6 +26,7 @@ import com.github.marcellokim.issuetracker.service.AccountService;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
 import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
 import com.github.marcellokim.issuetracker.service.IssueService;
+import com.github.marcellokim.issuetracker.service.IssueWorkflowService;
 import com.github.marcellokim.issuetracker.service.PasswordHashing;
 import com.github.marcellokim.issuetracker.service.PermissionPolicy;
 import com.github.marcellokim.issuetracker.service.ProjectService;
@@ -418,13 +419,13 @@ class SwingAppPanelTest {
         awaitButtonEnabled(panel, "openIssueDetailButton");
         SwingComponentTestSupport.onEdt(() ->
                 SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick());
-        awaitPlaceholderTitle(panel, "Issue detail #7");
+        awaitIssueDetailTitle(panel, "[ISSUE-7] Login bug");
 
         SwingComponentTestSupport.onEdt(() -> {
             assertEquals(
-                    "Issue detail #7",
-                    SwingComponentTestSupport.find(panel, "placeholderTitle", JLabel.class).getText());
-            SwingComponentTestSupport.find(panel, "backButton", JButton.class).doClick();
+                    "[ISSUE-7] Login bug",
+                    SwingComponentTestSupport.find(panel, "issueDetailTitle", JLabel.class).getText());
+            SwingComponentTestSupport.find(panel, "issueDetailBackButton", JButton.class).doClick();
         });
         awaitIssueRows(panel, 1);
     }
@@ -564,19 +565,19 @@ class SwingAppPanelTest {
         });
     }
 
-    private static void awaitPlaceholderTitle(SwingAppPanel panel, String expectedTitle) throws Exception {
-        CountDownLatch placeholderReady = new CountDownLatch(1);
+    private static void awaitIssueDetailTitle(SwingAppPanel panel, String expectedTitle) throws Exception {
+        CountDownLatch detailReady = new CountDownLatch(1);
         AtomicReference<Timer> timerRef = new AtomicReference<>();
         SwingComponentTestSupport.onEdt(() -> {
             Timer timer = new Timer(25, event -> {
                 try {
-                    String actual = SwingComponentTestSupport.find(panel, "placeholderTitle", JLabel.class).getText();
+                    String actual = SwingComponentTestSupport.find(panel, "issueDetailTitle", JLabel.class).getText();
                     if (expectedTitle.equals(actual)) {
                         ((Timer) event.getSource()).stop();
-                        placeholderReady.countDown();
+                        detailReady.countDown();
                     }
                 } catch (AssertionError ignored) {
-                    // Placeholder is installed asynchronously after navigation.
+                    // Detail panel is installed asynchronously after navigation.
                 }
             });
             timer.setRepeats(true);
@@ -584,7 +585,7 @@ class SwingAppPanelTest {
             timer.start();
         });
 
-        boolean ready = placeholderReady.await(5, TimeUnit.SECONDS);
+        boolean ready = detailReady.await(5, TimeUnit.SECONDS);
         SwingComponentTestSupport.onEdt(() -> {
             Timer timer = timerRef.get();
             if (timer != null) {
@@ -593,7 +594,7 @@ class SwingAppPanelTest {
             if (!ready) {
                 assertEquals(
                         expectedTitle,
-                        SwingComponentTestSupport.find(panel, "placeholderTitle", JLabel.class).getText());
+                        SwingComponentTestSupport.find(panel, "issueDetailTitle", JLabel.class).getText());
             }
         });
     }
@@ -689,6 +690,9 @@ class SwingAppPanelTest {
             }
         });
         var issueRepository = new InMemoryIssueRepository(issues.toArray(Issue[]::new));
+        var dependencyRepository = new FakeIssueDependencyRepository();
+        var commentRepository = new FakeCommentRepository();
+        var historyRepository = new FakeIssueHistoryRepository();
         var service = new AuthenticationService(repository, passwordHashing, new SessionStore());
         PermissionPolicy permissionPolicy = new PermissionPolicy();
         return new SwingControllerFixture(
@@ -721,12 +725,18 @@ class SwingAppPanelTest {
                         new IssueService(
                                 projectRepository,
                                 issueRepository,
-                                new FakeIssueDependencyRepository(),
-                                new FakeCommentRepository(),
-                                new FakeIssueHistoryRepository(),
+                                dependencyRepository,
+                                commentRepository,
+                                historyRepository,
                                 repository,
                                 permissionPolicy,
-                                () -> NOW)));
+                                () -> NOW),
+                        new IssueWorkflowService(
+                                issueRepository,
+                                dependencyRepository,
+                                commentRepository,
+                                repository,
+                                permissionPolicy)));
     }
 
     private static User user(String loginId, Role role) {


### PR DESCRIPTION
## purpose
Closes #209.

Swing 이슈 목록에서 선택한 이슈의 상세 정보, 댓글 권한, 이슈 workflow action 활성 상태를 실제 컨트롤러 결과로 표시한다. 최신 `dev`의 Swing 목록/등록 화면 흐름과 같은 worker/gate 패턴을 사용해 화면 전환 중 오래된 background update가 현재 화면을 덮지 않게 한다.

## non-goals
- 상태 변경, 배정, 댓글 작성/수정/삭제, 의존성, 삭제 action의 실제 입력 dialog 구현은 후속 Swing action PR에서 처리한다.
- JavaFX 화면, DB/schema, 문서 산출물은 변경하지 않는다.

## diff map
- 핵심 변경: `IssueDetailPanel`, `IssueDetailPresenter`, `IssueDetailView`, `CurrentIssueDetailView`, `IssueCommentActionState` 추가
- 권한 조회: 댓글 수정/삭제 가능 여부를 `IssueWorkflowService.viewCommentActions()`에서 일괄 계산하도록 연결
- 화면 연결: `SwingAppPanel.showIssueDetail()`에서 placeholder 대신 상세 화면을 렌더링하고 목록으로 되돌아가는 흐름 연결
- action 진입점: 사용 가능한 action 버튼 상태를 표시하고, 실제 dialog 구현 전까지 action placeholder로 진입
- 테스트: 상세 화면 렌더링/스냅샷, presenter 권한 조회, SwingAppPanel 목록→상세 이동 검증 추가

## verification evidence
- `git diff --check origin/dev...HEAD`
- `./gradlew test --tests '*IssueDetail*' --tests '*IssueWorkflowServiceTest*' --tests '*SwingAppPanelTest*' --console=plain`
- `./gradlew check --console=plain`
- push hook: `test + verifyRepositorySetup` 통과
- Swing screenshot: `build/reports/ui/issue-detail-panel.png`에서 주요 영역 겹침 없음 확인

## reviewer focus areas
- `IssueDetailPresenter`가 상세 조회, workflow action 조회, 댓글 action state 조회를 기존 controller/service 계약대로만 호출하는지
- `IssueWorkflowService.viewCommentActions()`가 댓글별 반복 조회 없이 현재 사용자/이슈 상태/댓글 작성자 정책을 같은 기준으로 계산하는지
- `SwingAppPanel`의 worker 취소/현재 화면 gate가 기존 Swing 화면들과 같은 방식으로 동작하는지
- action dialog는 후속 PR 범위이므로 현재 PR에서 placeholder 진입까지만 보는 것이 맞는지

## risk / rollback
- 후속 action dialog가 붙기 전까지 버튼 클릭 후 실제 업무 처리는 수행하지 않는다. 목록→상세 표시 기능만 분리되어 있어 문제가 생기면 `SwingAppPanel.showIssueDetail()`을 placeholder 흐름으로 되돌리면 된다.