### PR TITLE
feat: Swing 이슈 상태 변경 dialog 구현

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenter.java
@@ -1,6 +1,8 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
 import com.github.marcellokim.issuetracker.controller.IssueController;
+import com.github.marcellokim.issuetracker.controller.IssueStateController;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.service.CommentActionResult;
 import com.github.marcellokim.issuetracker.service.IssueDetailResult;
 import java.util.List;
@@ -9,10 +11,19 @@ import java.util.Objects;
 final class IssueDetailPresenter {
 
     private final IssueController issueController;
+    private final IssueStateController issueStateController;
     private final IssueDetailView view;
 
     IssueDetailPresenter(IssueController issueController, IssueDetailView view) {
+        this(issueController, null, view);
+    }
+
+    IssueDetailPresenter(
+            IssueController issueController,
+            IssueStateController issueStateController,
+            IssueDetailView view) {
         this.issueController = Objects.requireNonNull(issueController, "issueController");
+        this.issueStateController = issueStateController;
         this.view = Objects.requireNonNull(view, "view");
     }
 
@@ -35,6 +46,15 @@ final class IssueDetailPresenter {
         }
     }
 
+    void changeStatus(long issueId, IssueStatus targetStatus, String comment) {
+        try {
+            requireIssueStateController().changeStatus(issueId, targetStatus, comment);
+            loadIssue(issueId);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
     private List<IssueCommentActionState> commentActions(long issueId) {
         return issueController.viewCommentActions(issueId).stream()
                 .map(IssueDetailPresenter::toCommentActionState)
@@ -46,5 +66,12 @@ final class IssueDetailPresenter {
                 result.commentId(),
                 result.canUpdate(),
                 result.canDelete());
+    }
+
+    private IssueStateController requireIssueStateController() {
+        if (issueStateController == null) {
+            throw new IllegalStateException("Issue state controller is not configured.");
+        }
+        return issueStateController;
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangeActions.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangeActions.java
@@ -1,0 +1,32 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import java.util.Optional;
+
+final class IssueStatusChangeActions {
+
+    private IssueStatusChangeActions() {
+    }
+
+    static Optional<IssueStatus> targetStatus(String action) {
+        return switch (action) {
+            case "MARK_FIXED" -> Optional.of(IssueStatus.FIXED);
+            case "RESOLVE" -> Optional.of(IssueStatus.RESOLVED);
+            case "REJECT_FIX" -> Optional.of(IssueStatus.ASSIGNED);
+            case "CLOSE" -> Optional.of(IssueStatus.CLOSED);
+            case "REOPEN" -> Optional.of(IssueStatus.REOPENED);
+            default -> Optional.empty();
+        };
+    }
+
+    static String label(String action) {
+        return switch (action) {
+            case "MARK_FIXED" -> "Mark fixed";
+            case "RESOLVE" -> "Resolve";
+            case "REJECT_FIX" -> "Reject fix";
+            case "CLOSE" -> "Close";
+            case "REOPEN" -> "Reopen";
+            default -> action;
+        };
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangeDialogs.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangeDialogs.java
@@ -1,0 +1,67 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.util.Optional;
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+
+final class IssueStatusChangeDialogs {
+
+    private static final int COMMENT_ROWS = 5;
+    private static final int COMMENT_COLUMNS = 36;
+
+    private IssueStatusChangeDialogs() {
+    }
+
+    static Optional<IssueStatusChangeRequest> prompt(Component parent, String action, IssueStatus targetStatus) {
+        JTextArea commentArea = new JTextArea(COMMENT_ROWS, COMMENT_COLUMNS);
+        JPanel form = form(action, targetStatus, commentArea);
+        while (true) {
+            int result = JOptionPane.showConfirmDialog(
+                    parent,
+                    form,
+                    "Change issue status",
+                    JOptionPane.OK_CANCEL_OPTION,
+                    JOptionPane.PLAIN_MESSAGE);
+            if (result != JOptionPane.OK_OPTION) {
+                return Optional.empty();
+            }
+            String comment = commentArea.getText().trim();
+            if (!comment.isBlank()) {
+                return Optional.of(new IssueStatusChangeRequest(targetStatus, comment));
+            }
+            JOptionPane.showMessageDialog(
+                    parent,
+                    "Comment is required.",
+                    "Change issue status",
+                    JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    static JPanel form(String action, IssueStatus targetStatus) {
+        return form(action, targetStatus, new JTextArea(COMMENT_ROWS, COMMENT_COLUMNS));
+    }
+
+    private static JPanel form(String action, IssueStatus targetStatus, JTextArea commentArea) {
+        commentArea.setName("statusChangeCommentArea");
+        commentArea.setLineWrap(true);
+        commentArea.setWrapStyleWord(true);
+        JLabel title = new JLabel(IssueStatusChangeActions.label(action) + " -> " + targetStatus);
+        title.setName("statusChangeDialogTitle");
+        JPanel form = new JPanel(new BorderLayout(SwingStyles.ROW_GAP, SwingStyles.ROW_GAP));
+        form.setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP));
+        form.add(title, BorderLayout.NORTH);
+        form.add(new JScrollPane(commentArea), BorderLayout.CENTER);
+        return form;
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangePrompt.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangePrompt.java
@@ -1,0 +1,11 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import java.awt.Component;
+import java.util.Optional;
+
+@FunctionalInterface
+interface IssueStatusChangePrompt {
+
+    Optional<IssueStatusChangeRequest> prompt(Component parent, String action, IssueStatus targetStatus);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangeRequest.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangeRequest.java
@@ -1,0 +1,15 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import java.util.Objects;
+
+record IssueStatusChangeRequest(IssueStatus targetStatus, String comment) {
+
+    IssueStatusChangeRequest {
+        Objects.requireNonNull(targetStatus, "targetStatus");
+        if (comment == null || comment.isBlank()) {
+            throw new IllegalArgumentException("comment must not be blank");
+        }
+        comment = comment.trim();
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangeSupport.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangeSupport.java
@@ -1,0 +1,21 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.controller.IssueStateController;
+import java.util.Objects;
+
+record IssueStatusChangeSupport(
+        IssueStateController issueStateController,
+    IssueStatusChangePrompt prompt) {
+
+    IssueStatusChangeSupport {
+        Objects.requireNonNull(prompt, "prompt");
+    }
+
+    static IssueStatusChangeSupport disabled() {
+        return new IssueStatusChangeSupport(null, IssueStatusChangeDialogs::prompt);
+    }
+
+    static IssueStatusChangeSupport dialog(IssueStateController issueStateController) {
+        return new IssueStatusChangeSupport(issueStateController, IssueStatusChangeDialogs::prompt);
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
@@ -5,6 +5,7 @@ import com.github.marcellokim.issuetracker.controller.AccountController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
 import com.github.marcellokim.issuetracker.controller.IssueController;
+import com.github.marcellokim.issuetracker.controller.IssueStateController;
 import com.github.marcellokim.issuetracker.controller.ProjectController;
 import java.util.Objects;
 import javax.swing.JFrame;
@@ -22,7 +23,8 @@ public final class SwingAppFrame extends JFrame {
                 context.dashboardController(),
                 context.accountController(),
                 context.projectController(),
-                context.issueController());
+                context.issueController(),
+                context.issueStateController());
     }
 
     SwingAppFrame(
@@ -30,7 +32,8 @@ public final class SwingAppFrame extends JFrame {
             DashboardController dashboardController,
             AccountController accountController,
             ProjectController projectController,
-            IssueController issueController) {
+            IssueController issueController,
+            IssueStateController issueStateController) {
         super("Issue Tracker");
         this.appPanel = new SwingAppPanel(
                 authenticationController,
@@ -38,6 +41,7 @@ public final class SwingAppFrame extends JFrame {
                 accountController,
                 projectController,
                 issueController,
+                IssueStatusChangeSupport.dialog(issueStateController),
                 this::setTitle);
         setContentPane(appPanel);
         setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -5,11 +5,13 @@ import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
 import com.github.marcellokim.issuetracker.controller.IssueController;
 import com.github.marcellokim.issuetracker.controller.ProjectController;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.service.UserResult;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -31,6 +33,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private final transient AccountController accountController;
     private final transient ProjectController projectController;
     private final transient IssueController issueController;
+    private final transient IssueStatusChangeSupport statusChangeSupport;
     private final transient Consumer<String> titleUpdater;
     private final CardLayout cardLayout = new CardLayout();
     private final LoginPanel loginPanel = new LoginPanel();
@@ -52,11 +55,30 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             ProjectController projectController,
             IssueController issueController,
             Consumer<String> titleUpdater) {
+        this(
+                authenticationController,
+                dashboardController,
+                accountController,
+                projectController,
+                issueController,
+                IssueStatusChangeSupport.disabled(),
+                titleUpdater);
+    }
+
+    SwingAppPanel(
+            AuthenticationController authenticationController,
+            DashboardController dashboardController,
+            AccountController accountController,
+            ProjectController projectController,
+            IssueController issueController,
+            IssueStatusChangeSupport statusChangeSupport,
+            Consumer<String> titleUpdater) {
         this.authenticationController = Objects.requireNonNull(authenticationController, "authenticationController");
         this.dashboardController = Objects.requireNonNull(dashboardController, "dashboardController");
         this.accountController = Objects.requireNonNull(accountController, "accountController");
         this.projectController = Objects.requireNonNull(projectController, "projectController");
         this.issueController = Objects.requireNonNull(issueController, "issueController");
+        this.statusChangeSupport = Objects.requireNonNull(statusChangeSupport, "statusChangeSupport");
         this.titleUpdater = Objects.requireNonNull(titleUpdater, "titleUpdater");
 
         setName("appCards");
@@ -362,7 +384,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             IssueDetailPanel panel = new IssueDetailPanel(
                     user,
                     new IssueDetailPanel.IssueDetailActions(
-                            (panelRef, action) -> showIssueAction(user, projectId, issueId, action),
+                            (panelRef, action) -> showIssueAction(user, projectId, issueId, panelRef, action),
                             () -> showIssueList(user, projectId),
                             this::logout));
             projectListCard.removeAll();
@@ -374,7 +396,23 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         });
     }
 
-    private void showIssueAction(UserResult user, long projectId, long issueId, String action) {
+    private void showIssueAction(
+            UserResult user,
+            long projectId,
+            long issueId,
+            IssueDetailPanel panel,
+            String action) {
+        Optional<IssueStatus> targetStatus = IssueStatusChangeActions.targetStatus(action);
+        if (targetStatus.isPresent()) {
+            statusChangeSupport.prompt().prompt(panel, action, targetStatus.get())
+                    .ifPresent(request -> startIssueDetailTask(
+                            panel,
+                            presenter -> presenter.changeStatus(
+                                    issueId,
+                                    request.targetStatus(),
+                                    request.comment())));
+            return;
+        }
         SwingUtilities.invokeLater(() -> {
             cancelDashboardWorker();
             cancelAccountWorker();
@@ -714,6 +752,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         protected Void doInBackground() {
             IssueDetailPresenter presenter = new IssueDetailPresenter(
                     issueController,
+                    statusChangeSupport.issueStateController(),
                     new CurrentIssueDetailView(panel, this, issueDetailWorker::get));
             task.run(presenter);
             return null;

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.marcellokim.issuetracker.controller.IssueController;
+import com.github.marcellokim.issuetracker.controller.IssueStateController;
 import com.github.marcellokim.issuetracker.domain.Comment;
 import com.github.marcellokim.issuetracker.domain.CommentPurpose;
 import com.github.marcellokim.issuetracker.domain.Issue;
@@ -17,6 +18,7 @@ import com.github.marcellokim.issuetracker.repository.CommentRepository;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
 import com.github.marcellokim.issuetracker.service.IssueDetailResult;
 import com.github.marcellokim.issuetracker.service.IssueService;
+import com.github.marcellokim.issuetracker.service.IssueStateService;
 import com.github.marcellokim.issuetracker.service.IssueWorkflowActions;
 import com.github.marcellokim.issuetracker.service.IssueWorkflowService;
 import com.github.marcellokim.issuetracker.service.PasswordHashing;
@@ -82,6 +84,27 @@ class IssueDetailPresenterTest {
     }
 
     @Test
+    @DisplayName("changes status through state controller and reloads detail")
+    void changesStatusAndReloadsDetail() {
+        User assignee = user("dev1", Role.DEV);
+        User verifier = user("tester1", Role.TESTER);
+        Issue issue = assignedIssue(7L, "Login bug", assignee, verifier);
+        IssueDetailControllerFixture fixture = controllerFixture(assignee, new FakeCommentRepository(), issue);
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                fixture.issueController(),
+                fixture.issueStateController(),
+                view);
+        presenter.loadIssue(issue.id());
+
+        presenter.changeStatus(issue.id(), IssueStatus.FIXED, "fixed in swing");
+
+        assertEquals(IssueStatus.FIXED, view.detail().status());
+        assertEquals(assignee.getLoginId(), view.detail().fixer().loginId());
+        assertEquals(" ", view.message());
+    }
+
+    @Test
     @DisplayName("shows controller errors without replacing current detail")
     void showsErrorsWithoutReplacingCurrentDetail() {
         User reporter = user("dev1", Role.DEV);
@@ -99,10 +122,24 @@ class IssueDetailPresenterTest {
     }
 
     private static IssueController controller(User currentUser, FakeCommentRepository comments, Issue... issues) {
+        return controllerFixture(currentUser, comments, issues).issueController();
+    }
+
+    private static IssueDetailControllerFixture controllerFixture(
+            User currentUser,
+            FakeCommentRepository comments,
+            Issue... issues) {
         InMemoryUserRepository users = new InMemoryUserRepository(currentUser)
                 .withProjectMembers(PROJECT_ID, currentUser.getLoginId());
         InMemoryProjectRepository projects = new InMemoryProjectRepository(project())
                 .withParticipant(PROJECT_ID, currentUser.getLoginId());
+        for (Issue issue : issues) {
+            if (issue.getVerifier() != null) {
+                users.save(issue.getVerifier());
+                users.withProjectMembers(PROJECT_ID, issue.getVerifier().getLoginId());
+                projects.withParticipant(PROJECT_ID, issue.getVerifier().getLoginId());
+            }
+        }
         InMemoryIssueRepository issueRepository = new InMemoryIssueRepository(issues);
         FakeIssueDependencyRepository dependencies = new FakeIssueDependencyRepository();
         PermissionPolicy permissionPolicy = new PermissionPolicy();
@@ -126,7 +163,17 @@ class IssueDetailPresenterTest {
                 comments,
                 users,
                 permissionPolicy);
-        return new IssueController(authentication, issueService, workflowService);
+        IssueController issueController = new IssueController(authentication, issueService, workflowService);
+        IssueStateController issueStateController = new IssueStateController(
+                authentication,
+                new IssueStateService(
+                        issueRepository,
+                        dependencies,
+                        users,
+                        permissionPolicy,
+                        () -> NOW,
+                        () -> "status-change-comment"));
+        return new IssueDetailControllerFixture(issueController, issueStateController);
     }
 
     private static Project project() {
@@ -143,12 +190,29 @@ class IssueDetailPresenterTest {
                 .updatedAt(NOW));
     }
 
+    private static Issue assignedIssue(long id, String title, User assignee, User verifier) {
+        return Issue.fromPersistence(Issue.persistedState(PROJECT_ID, title, "Issue description", assignee)
+                .id(id)
+                .issueId("ISSUE-" + id)
+                .status(IssueStatus.ASSIGNED)
+                .priority(Priority.CRITICAL)
+                .assignee(assignee)
+                .verifier(verifier)
+                .reportedDate(NOW)
+                .updatedAt(NOW));
+    }
+
     private static Comment comment(long id, long issueId, User writer, CommentPurpose purpose) {
         return Comment.fromPersistence(id, issueId, writer.getLoginId(), "Comment " + id, purpose, NOW, NOW);
     }
 
     private static User user(String loginId, Role role) {
         return User.fromPersistence(loginId, loginId, "stored-password", role, true, NOW, NOW);
+    }
+
+    private record IssueDetailControllerFixture(
+            IssueController issueController,
+            IssueStateController issueStateController) {
     }
 
     private static final class RecordingIssueDetailView implements IssueDetailView {

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangeDialogsTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangeDialogsTest.java
@@ -1,0 +1,72 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.imageio.ImageIO;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing issue status change dialogs")
+class IssueStatusChangeDialogsTest {
+
+    @Test
+    @DisplayName("renders status change dialog form snapshot")
+    void rendersStatusChangeDialogFormSnapshot() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            JPanel form = IssueStatusChangeDialogs.form("MARK_FIXED", IssueStatus.FIXED);
+            assertEquals(
+                    "Mark fixed -> FIXED",
+                    SwingComponentTestSupport.find(form, "statusChangeDialogTitle", JLabel.class).getText());
+            form.setSize(520, 240);
+            layoutRecursively(form);
+
+            BufferedImage image = render(form, Path.of("build/reports/ui/issue-status-change-dialog.png"));
+            assertTrue(hasRenderedContent(image));
+        });
+    }
+
+    private static void layoutRecursively(Container container) {
+        container.doLayout();
+        for (java.awt.Component child : container.getComponents()) {
+            if (child instanceof Container nested) {
+                layoutRecursively(nested);
+            }
+        }
+    }
+
+    private static BufferedImage render(JPanel panel, Path output) throws java.io.IOException {
+        BufferedImage image = new BufferedImage(520, 240, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            panel.printAll(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        Files.createDirectories(output.getParent());
+        ImageIO.write(image, "png", output.toFile());
+        return image;
+    }
+
+    private static boolean hasRenderedContent(BufferedImage image) {
+        int white = Color.WHITE.getRGB();
+        int contentPixels = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                if (image.getRGB(x, y) != white) {
+                    contentPixels++;
+                }
+            }
+        }
+        return contentPixels > 1_000;
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangeRequestTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangeRequestTest.java
@@ -1,0 +1,50 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing issue status change request")
+class IssueStatusChangeRequestTest {
+
+    @Test
+    @DisplayName("trims status change comment")
+    void trimsStatusChangeComment() {
+        IssueStatusChangeRequest request = new IssueStatusChangeRequest(IssueStatus.FIXED, " fixed in swing ");
+
+        assertEquals(IssueStatus.FIXED, request.targetStatus());
+        assertEquals("fixed in swing", request.comment());
+    }
+
+    @Test
+    @DisplayName("rejects blank status change comment")
+    void rejectsBlankStatusChangeComment() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new IssueStatusChangeRequest(IssueStatus.FIXED, " "));
+    }
+
+    @Test
+    @DisplayName("maps detail action names to target status")
+    void mapsDetailActionNamesToTargetStatus() {
+        assertEquals(Optional.of(IssueStatus.FIXED), IssueStatusChangeActions.targetStatus("MARK_FIXED"));
+        assertEquals(Optional.of(IssueStatus.RESOLVED), IssueStatusChangeActions.targetStatus("RESOLVE"));
+        assertEquals(Optional.of(IssueStatus.ASSIGNED), IssueStatusChangeActions.targetStatus("REJECT_FIX"));
+        assertEquals(Optional.of(IssueStatus.CLOSED), IssueStatusChangeActions.targetStatus("CLOSE"));
+        assertEquals(Optional.of(IssueStatus.REOPENED), IssueStatusChangeActions.targetStatus("REOPEN"));
+        assertEquals(Optional.empty(), IssueStatusChangeActions.targetStatus("ADD_COMMENT"));
+    }
+
+    @Test
+    @DisplayName("maps detail action names to readable labels")
+    void mapsDetailActionNamesToReadableLabels() {
+        assertEquals("Mark fixed", IssueStatusChangeActions.label("MARK_FIXED"));
+        assertEquals("Resolve", IssueStatusChangeActions.label("RESOLVE"));
+        assertEquals("Reject fix", IssueStatusChangeActions.label("REJECT_FIX"));
+        assertEquals("ADD_COMMENT", IssueStatusChangeActions.label("ADD_COMMENT"));
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -10,6 +10,7 @@ import com.github.marcellokim.issuetracker.controller.AccountController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
 import com.github.marcellokim.issuetracker.controller.IssueController;
+import com.github.marcellokim.issuetracker.controller.IssueStateController;
 import com.github.marcellokim.issuetracker.controller.ProjectController;
 import com.github.marcellokim.issuetracker.domain.Comment;
 import com.github.marcellokim.issuetracker.domain.Issue;
@@ -26,6 +27,7 @@ import com.github.marcellokim.issuetracker.service.AccountService;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
 import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
 import com.github.marcellokim.issuetracker.service.IssueService;
+import com.github.marcellokim.issuetracker.service.IssueStateService;
 import com.github.marcellokim.issuetracker.service.IssueWorkflowService;
 import com.github.marcellokim.issuetracker.service.PasswordHashing;
 import com.github.marcellokim.issuetracker.service.PermissionPolicy;
@@ -431,6 +433,51 @@ class SwingAppPanelTest {
     }
 
     @Test
+    @DisplayName("issue detail status action changes status and reloads detail")
+    void issueDetailStatusActionChangesStatusAndReloadsDetail() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        User assignee = user("dev1", Role.DEV);
+        User verifier = user("tester1", Role.TESTER);
+        SwingAppPanel panel = loginProjectUser(
+                passwordHashing,
+                titles,
+                List.of(projectSnapshot(7L, "Alpha", 3, 7)),
+                List.of(assignedIssue(7L, 7L, "Login bug", Priority.CRITICAL, assignee, verifier)),
+                (parent, action, targetStatus) ->
+                        Optional.of(new IssueStatusChangeRequest(targetStatus, "fixed through swing")),
+                assignee,
+                verifier);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable projects = SwingComponentTestSupport.find(panel, "projectListTable", JTable.class);
+            projects.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openProjectIssuesButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openProjectIssuesButton", JButton.class).doClick());
+        awaitIssueRows(panel, 1);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable issues = SwingComponentTestSupport.find(panel, "issueListTable", JTable.class);
+            issues.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openIssueDetailButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick());
+        awaitIssueDetailTitle(panel, "[ISSUE-7] Login bug");
+        awaitButtonEnabled(panel, "issueActionButton_MARK_FIXED");
+
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "issueActionButton_MARK_FIXED", JButton.class).doClick());
+        awaitIssueDetailState(panel, "FIXED / CRITICAL");
+
+        SwingComponentTestSupport.onEdt(() -> assertEquals(
+                "FIXED / CRITICAL",
+                SwingComponentTestSupport.find(panel, "issueDetailState", JLabel.class).getText()));
+    }
+
+    @Test
     @DisplayName("project list logout returns to login")
     void projectListLogoutReturnsToLogin() throws Exception {
         var passwordHashing = new RecordingPasswordHashing();
@@ -467,9 +514,25 @@ class SwingAppPanelTest {
             List<DashboardProjectSnapshot> projects,
             List<Issue> issues,
             User user) throws Exception {
+        return loginProjectUser(
+                passwordHashing,
+                titles,
+                projects,
+                issues,
+                IssueStatusChangeDialogs::prompt,
+                user);
+    }
+
+    private static SwingAppPanel loginProjectUser(
+            RecordingPasswordHashing passwordHashing,
+            RecordingTitleUpdater titles,
+            List<DashboardProjectSnapshot> projects,
+            List<Issue> issues,
+            IssueStatusChangePrompt statusChangePrompt,
+            User... users) throws Exception {
         var panelRef = new AtomicReference<SwingAppPanel>();
         var workerDone = new CountDownLatch(1);
-        SwingControllerFixture controllers = controllers(passwordHashing, projects, issues, user);
+        SwingControllerFixture controllers = controllers(passwordHashing, projects, issues, users);
 
         SwingComponentTestSupport.onEdt(() -> {
             SwingAppPanel panel = new SwingAppPanel(
@@ -478,8 +541,10 @@ class SwingAppPanelTest {
                     controllers.accountController(),
                     controllers.projectController(),
                     controllers.issueController(),
+                    new IssueStatusChangeSupport(controllers.issueStateController(), statusChangePrompt),
                     titles::update);
             panelRef.set(panel);
+            User user = users[0];
             SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText(user.getLoginId());
             SwingComponentTestSupport.find(panel, "passwordField", JPasswordField.class).setText("submitted-password");
             SwingComponentTestSupport.find(panel, "signInButton", JButton.class).doClick();
@@ -599,6 +664,40 @@ class SwingAppPanelTest {
         });
     }
 
+    private static void awaitIssueDetailState(SwingAppPanel panel, String expectedState) throws Exception {
+        CountDownLatch detailReady = new CountDownLatch(1);
+        AtomicReference<Timer> timerRef = new AtomicReference<>();
+        SwingComponentTestSupport.onEdt(() -> {
+            Timer timer = new Timer(25, event -> {
+                try {
+                    String actual = SwingComponentTestSupport.find(panel, "issueDetailState", JLabel.class).getText();
+                    if (expectedState.equals(actual)) {
+                        ((Timer) event.getSource()).stop();
+                        detailReady.countDown();
+                    }
+                } catch (AssertionError ignored) {
+                    // Detail panel reloads asynchronously after status change.
+                }
+            });
+            timer.setRepeats(true);
+            timerRef.set(timer);
+            timer.start();
+        });
+
+        boolean ready = detailReady.await(5, TimeUnit.SECONDS);
+        SwingComponentTestSupport.onEdt(() -> {
+            Timer timer = timerRef.get();
+            if (timer != null) {
+                timer.stop();
+            }
+            if (!ready) {
+                assertEquals(
+                        expectedState,
+                        SwingComponentTestSupport.find(panel, "issueDetailState", JLabel.class).getText());
+            }
+        });
+    }
+
     private static void awaitButtonEnabled(SwingAppPanel panel, String buttonName) throws Exception {
         CountDownLatch enabled = new CountDownLatch(1);
         AtomicReference<Timer> timerRef = new AtomicReference<>();
@@ -695,6 +794,15 @@ class SwingAppPanelTest {
         var historyRepository = new FakeIssueHistoryRepository();
         var service = new AuthenticationService(repository, passwordHashing, new SessionStore());
         PermissionPolicy permissionPolicy = new PermissionPolicy();
+        IssueStateController issueStateController = new IssueStateController(
+                service,
+                new IssueStateService(
+                        issueRepository,
+                        dependencyRepository,
+                        repository,
+                        permissionPolicy,
+                        () -> NOW,
+                        () -> "status-change-comment"));
         return new SwingControllerFixture(
                 new AuthenticationController(service),
                 new DashboardController(
@@ -736,7 +844,8 @@ class SwingAppPanelTest {
                                 dependencyRepository,
                                 commentRepository,
                                 repository,
-                                permissionPolicy)));
+                                permissionPolicy)),
+                issueStateController);
     }
 
     private static User user(String loginId, Role role) {
@@ -769,12 +878,31 @@ class SwingAppPanelTest {
                 .updatedAt(NOW));
     }
 
+    private static Issue assignedIssue(
+            long id,
+            long projectId,
+            String title,
+            Priority priority,
+            User assignee,
+            User verifier) {
+        return Issue.fromPersistence(Issue.persistedState(projectId, title, "Issue description", assignee)
+                .id(id)
+                .issueId("ISSUE-" + id)
+                .priority(priority)
+                .status(IssueStatus.ASSIGNED)
+                .assignee(assignee)
+                .verifier(verifier)
+                .reportedDate(NOW)
+                .updatedAt(NOW));
+    }
+
     private record SwingControllerFixture(
             AuthenticationController authenticationController,
             DashboardController dashboardController,
             AccountController accountController,
             ProjectController projectController,
-            IssueController issueController) {
+            IssueController issueController,
+            IssueStateController issueStateController) {
     }
 
     private static final class FakeCommentRepository implements CommentRepository {


### PR DESCRIPTION
## purpose
Closes #210

Swing 이슈 상세 화면에서 상태 변경 action을 실제 status controller 흐름으로 연결한다. 사용자는 상태 변경 버튼을 누른 뒤 사유를 입력하고, 성공 시 이슈 상세 화면에서 변경된 상태를 바로 확인할 수 있다.

## non-goals
- assignment/reassignment, comment, dependency, issue edit/delete, deleted issue, statistics action은 후속 이슈에서 처리한다.
- 상태 전이 가능 여부, 권한, dependency guard는 Swing에서 계산하지 않는다.
- backend/domain/repository/JavaFX 계약은 변경하지 않는다.

## diff map
- 핵심 변경: `IssueStatusChangeActions`, `IssueStatusChangeDialogs`, `IssueStatusChangePrompt`, `IssueStatusChangeRequest` 추가
- 연결 변경: `IssueDetailPresenter`가 `IssueStateController.changeStatus(...)` 실행 후 상세를 reload
- 화면 연결: `SwingAppPanel`에서 `MARK_FIXED`, `RESOLVE`, `REJECT_FIX`, `CLOSE`, `REOPEN`만 status dialog 경로로 연결
- 테스트 변경: status action mapping, blank comment validation, dialog snapshot, presenter reload, app navigation/status change 테스트 추가

## verification evidence
- `git diff --check origin/dev...HEAD`
- `./gradlew test --tests '*IssueStatusChange*' --tests '*IssueDetailPresenterTest*' --tests '*SwingAppPanelTest*' --console=plain`
- `./gradlew check --console=plain`
- pre-push `test + verifyRepositorySetup`
- visual evidence inspected: `build/reports/ui/issue-status-change-dialog.png`, `build/reports/ui/issue-detail-panel.png`

## reviewer focus areas
- Swing이 상태 전이/권한/dependency 정책을 직접 판단하지 않고 controller/service 예외에 맡기는지
- action 이름에서 target status로 바꾸는 부분이 UI routing 수준에 머무르는지
- 성공 후 `loadIssue(issueId)`로 status, fixer/resolver, history/comment 영향까지 다시 읽는지

## risk / rollback
- 위험은 issue detail action routing과 dialog 입력 흐름에 집중된다.
- 문제가 생기면 이 PR만 revert하면 #209 상세 화면의 placeholder action 상태로 되돌릴 수 있다.