### PR TITLE
feat: Swing 이슈 배정 dialog 구현

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueActionSupport.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueActionSupport.java
@@ -1,0 +1,32 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.controller.AssignmentController;
+import com.github.marcellokim.issuetracker.controller.IssueStateController;
+import java.util.Objects;
+
+record IssueActionSupport(
+        IssueStatusChangeSupport statusChange,
+        AssignmentController assignmentController,
+        IssueAssignmentPrompt assignmentPrompt) {
+
+    IssueActionSupport {
+        Objects.requireNonNull(statusChange, "statusChange");
+        Objects.requireNonNull(assignmentPrompt, "assignmentPrompt");
+    }
+
+    static IssueActionSupport disabled() {
+        return new IssueActionSupport(
+                IssueStatusChangeSupport.disabled(),
+                null,
+                IssueAssignmentDialogs::prompt);
+    }
+
+    static IssueActionSupport dialogs(
+            IssueStateController issueStateController,
+            AssignmentController assignmentController) {
+        return new IssueActionSupport(
+                IssueStatusChangeSupport.dialog(issueStateController),
+                assignmentController,
+                IssueAssignmentDialogs::prompt);
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueAssignmentActions.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueAssignmentActions.java
@@ -1,0 +1,36 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+final class IssueAssignmentActions {
+
+    private static final String START_ASSIGNMENT = "START_ASSIGNMENT";
+    private static final List<String> CONCRETE_ACTIONS = List.of("ASSIGN", "REASSIGN_DEV", "CHANGE_TESTER");
+
+    private IssueAssignmentActions() {
+    }
+
+    static Optional<IssueAssignmentMode> mode(String action) {
+        return switch (action) {
+            case "ASSIGN" -> Optional.of(IssueAssignmentMode.ASSIGN);
+            case "REASSIGN_DEV" -> Optional.of(IssueAssignmentMode.REASSIGN_DEV);
+            case "CHANGE_TESTER" -> Optional.of(IssueAssignmentMode.CHANGE_TESTER);
+            default -> Optional.empty();
+        };
+    }
+
+    static String effectiveAction(String action, Set<String> availableActions) {
+        Objects.requireNonNull(action, "action");
+        Objects.requireNonNull(availableActions, "availableActions");
+        if (!START_ASSIGNMENT.equals(action)) {
+            return action;
+        }
+        return CONCRETE_ACTIONS.stream()
+                .filter(availableActions::contains)
+                .findFirst()
+                .orElse(action);
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueAssignmentDialogs.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueAssignmentDialogs.java
@@ -1,0 +1,214 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.AssignmentCandidateResult;
+import com.github.marcellokim.issuetracker.service.AssignmentOptionsResult;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.swing.BorderFactory;
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+
+final class IssueAssignmentDialogs {
+
+    private static final String DIALOG_TITLE = "Assign issue";
+
+    private IssueAssignmentDialogs() {
+    }
+
+    static Optional<IssueAssignmentRequest> prompt(
+            Component parent,
+            IssueAssignmentMode mode,
+            AssignmentOptionsResult options) {
+        AssignmentForm form = form(mode, options);
+        while (true) {
+            int result = JOptionPane.showConfirmDialog(
+                    parent,
+                    form.panel(),
+                    DIALOG_TITLE,
+                    JOptionPane.OK_CANCEL_OPTION,
+                    JOptionPane.PLAIN_MESSAGE);
+            if (result != JOptionPane.OK_OPTION) {
+                return Optional.empty();
+            }
+            try {
+                return Optional.of(new IssueAssignmentRequest(
+                        mode,
+                        selectedLoginId(form.assigneeBox()),
+                        selectedLoginId(form.verifierBox())));
+            } catch (IllegalArgumentException exception) {
+                JOptionPane.showMessageDialog(
+                        parent,
+                        exception.getMessage(),
+                        DIALOG_TITLE,
+                        JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    static AssignmentForm form(IssueAssignmentMode mode, AssignmentOptionsResult options) {
+        List<AssignmentCandidateResult> devCandidates = candidatesFor(
+                options.devAssigneeCandidates(),
+                options.allDevAssignees(),
+                mode == IssueAssignmentMode.REASSIGN_DEV ? "current assignee" : null);
+        List<AssignmentCandidateResult> testerCandidates = candidatesFor(
+                options.testerVerifierCandidates(),
+                options.allTesterVerifiers(),
+                mode == IssueAssignmentMode.CHANGE_TESTER ? "current verifier" : null);
+        Set<String> recommendedDevIds = candidateIds(options.devAssigneeCandidates());
+        Set<String> recommendedTesterIds = candidateIds(options.testerVerifierCandidates());
+
+        JPanel panel = new JPanel(new BorderLayout(SwingStyles.ROW_GAP, SwingStyles.ROW_GAP));
+        panel.setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP));
+        JLabel title = new JLabel(label(mode));
+        title.setName("assignmentDialogTitle");
+        panel.add(title, BorderLayout.NORTH);
+
+        JPanel fields = new JPanel(new java.awt.GridLayout(0, 1, SwingStyles.ROW_GAP, SwingStyles.ROW_GAP));
+        JComboBox<AssignmentCandidateResult> assigneeBox = candidateBox(
+                "assignmentAssigneeBox",
+                devCandidates,
+                recommendedDevIds);
+        JComboBox<AssignmentCandidateResult> verifierBox = candidateBox(
+                "assignmentVerifierBox",
+                testerCandidates,
+                recommendedTesterIds);
+        if (mode == IssueAssignmentMode.ASSIGN || mode == IssueAssignmentMode.REASSIGN_DEV) {
+            fields.add(new JLabel("Assignee (DEV)"));
+            fields.add(assigneeBox);
+        }
+        if (mode == IssueAssignmentMode.ASSIGN || mode == IssueAssignmentMode.CHANGE_TESTER) {
+            fields.add(new JLabel("Verifier (TESTER)"));
+            fields.add(verifierBox);
+        }
+        panel.add(fields, BorderLayout.CENTER);
+        return new AssignmentForm(panel, assigneeBox, verifierBox);
+    }
+
+    private static List<AssignmentCandidateResult> candidatesFor(
+            List<AssignmentCandidateResult> recommended,
+            List<AssignmentCandidateResult> all,
+            String excludedReason) {
+        List<AssignmentCandidateResult> merged = mergedCandidates(recommended, all);
+        if (excludedReason == null) {
+            return merged;
+        }
+        Set<String> excludedIds = candidateIdsByReason(recommended, excludedReason);
+        return merged.stream()
+                .filter(candidate -> !excludedIds.contains(candidate.loginId()))
+                .toList();
+    }
+
+    private static JComboBox<AssignmentCandidateResult> candidateBox(
+            String name,
+            List<AssignmentCandidateResult> candidates,
+            Set<String> recommendedIds) {
+        JComboBox<AssignmentCandidateResult> box =
+                new JComboBox<>(candidates.toArray(AssignmentCandidateResult[]::new));
+        box.setName(name);
+        box.setRenderer(new CandidateRenderer(recommendedIds));
+        return box;
+    }
+
+    private static String selectedLoginId(JComboBox<AssignmentCandidateResult> box) {
+        AssignmentCandidateResult candidate = (AssignmentCandidateResult) box.getSelectedItem();
+        return candidate == null ? null : candidate.loginId();
+    }
+
+    private static List<AssignmentCandidateResult> mergedCandidates(
+            List<AssignmentCandidateResult> recommended,
+            List<AssignmentCandidateResult> all) {
+        LinkedHashSet<String> seen = new LinkedHashSet<>();
+        List<AssignmentCandidateResult> merged = new ArrayList<>();
+        for (AssignmentCandidateResult candidate : recommended) {
+            if (seen.add(candidate.loginId())) {
+                merged.add(candidate);
+            }
+        }
+        for (AssignmentCandidateResult candidate : all) {
+            if (seen.add(candidate.loginId())) {
+                merged.add(candidate);
+            }
+        }
+        return merged;
+    }
+
+    private static Set<String> candidateIds(List<AssignmentCandidateResult> candidates) {
+        LinkedHashSet<String> ids = new LinkedHashSet<>();
+        for (AssignmentCandidateResult candidate : candidates) {
+            ids.add(candidate.loginId());
+        }
+        return ids;
+    }
+
+    private static Set<String> candidateIdsByReason(List<AssignmentCandidateResult> candidates, String reason) {
+        LinkedHashSet<String> ids = new LinkedHashSet<>();
+        for (AssignmentCandidateResult candidate : candidates) {
+            if (reason.equals(candidate.reason())) {
+                ids.add(candidate.loginId());
+            }
+        }
+        return ids;
+    }
+
+    private static String label(IssueAssignmentMode mode) {
+        return switch (mode) {
+            case ASSIGN -> DIALOG_TITLE;
+            case REASSIGN_DEV -> "Reassign assignee";
+            case CHANGE_TESTER -> "Change verifier";
+        };
+    }
+
+    record AssignmentForm(
+            JPanel panel,
+            JComboBox<AssignmentCandidateResult> assigneeBox,
+            JComboBox<AssignmentCandidateResult> verifierBox) {
+    }
+
+    private static final class CandidateRenderer extends DefaultListCellRenderer {
+
+        private static final long serialVersionUID = 1L;
+        private final Set<String> recommendedIds;
+
+        private CandidateRenderer(Set<String> recommendedIds) {
+            this.recommendedIds = Set.copyOf(recommendedIds);
+        }
+
+        @Override
+        public Component getListCellRendererComponent(
+                JList<?> list,
+                Object value,
+                int index,
+                boolean isSelected,
+                boolean cellHasFocus) {
+            JLabel label = (JLabel) super.getListCellRendererComponent(
+                    list,
+                    value,
+                    index,
+                    isSelected,
+                    cellHasFocus);
+            label.setText(candidateLabel((AssignmentCandidateResult) value));
+            return label;
+        }
+
+        private String candidateLabel(AssignmentCandidateResult candidate) {
+            if (candidate == null) {
+                return "";
+            }
+            String prefix = recommendedIds.contains(candidate.loginId()) ? "[Recommended] " : "";
+            return prefix + candidate.loginId() + " (" + candidate.name() + ") - " + candidate.reason();
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueAssignmentMode.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueAssignmentMode.java
@@ -1,0 +1,7 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+enum IssueAssignmentMode {
+    ASSIGN,
+    REASSIGN_DEV,
+    CHANGE_TESTER
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueAssignmentPrompt.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueAssignmentPrompt.java
@@ -1,0 +1,14 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.AssignmentOptionsResult;
+import java.awt.Component;
+import java.util.Optional;
+
+@FunctionalInterface
+interface IssueAssignmentPrompt {
+
+    Optional<IssueAssignmentRequest> prompt(
+            Component parent,
+            IssueAssignmentMode mode,
+            AssignmentOptionsResult options);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueAssignmentRequest.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueAssignmentRequest.java
@@ -1,0 +1,39 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.util.Objects;
+
+record IssueAssignmentRequest(IssueAssignmentMode mode, String assigneeId, String verifierId) {
+
+    IssueAssignmentRequest(IssueAssignmentMode mode, String assigneeId, String verifierId) {
+        this.mode = Objects.requireNonNull(mode, "mode");
+        String normalizedAssigneeId = normalize(assigneeId);
+        String normalizedVerifierId = normalize(verifierId);
+        this.assigneeId = requiredAssigneeId(this.mode, normalizedAssigneeId);
+        this.verifierId = requiredVerifierId(this.mode, normalizedVerifierId);
+    }
+
+    private static String requiredAssigneeId(IssueAssignmentMode mode, String value) {
+        return switch (mode) {
+            case ASSIGN, REASSIGN_DEV -> requireText(value, "assigneeId");
+            case CHANGE_TESTER -> value;
+        };
+    }
+
+    private static String requiredVerifierId(IssueAssignmentMode mode, String value) {
+        return switch (mode) {
+            case ASSIGN, CHANGE_TESTER -> requireText(value, "verifierId");
+            case REASSIGN_DEV -> value;
+        };
+    }
+
+    private static String normalize(String value) {
+        return value == null ? null : value.trim();
+    }
+
+    private static String requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
@@ -228,7 +228,10 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         for (ActionSpec spec : ACTION_SPECS) {
             JButton button = new JButton(spec.label());
             button.setName("issueActionButton_" + spec.action());
-            button.addActionListener(event -> actions.onAction().accept(this, spec.action()));
+            button.addActionListener(event ->
+                    actions.onAction().accept(this, IssueAssignmentActions.effectiveAction(
+                            spec.action(),
+                            availableActions)));
             actionButtons.put(spec.action(), button);
             buttons.add(button);
         }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenter.java
@@ -1,5 +1,6 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
+import com.github.marcellokim.issuetracker.controller.AssignmentController;
 import com.github.marcellokim.issuetracker.controller.IssueController;
 import com.github.marcellokim.issuetracker.controller.IssueStateController;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
@@ -12,18 +13,28 @@ final class IssueDetailPresenter {
 
     private final IssueController issueController;
     private final IssueStateController issueStateController;
+    private final AssignmentController assignmentController;
     private final IssueDetailView view;
 
     IssueDetailPresenter(IssueController issueController, IssueDetailView view) {
-        this(issueController, null, view);
+        this(issueController, null, null, view);
     }
 
     IssueDetailPresenter(
             IssueController issueController,
             IssueStateController issueStateController,
             IssueDetailView view) {
+        this(issueController, issueStateController, null, view);
+    }
+
+    IssueDetailPresenter(
+            IssueController issueController,
+            IssueStateController issueStateController,
+            AssignmentController assignmentController,
+            IssueDetailView view) {
         this.issueController = Objects.requireNonNull(issueController, "issueController");
         this.issueStateController = issueStateController;
+        this.assignmentController = assignmentController;
         this.view = Objects.requireNonNull(view, "view");
     }
 
@@ -55,6 +66,27 @@ final class IssueDetailPresenter {
         }
     }
 
+    void changeAssignment(long issueId, IssueAssignmentRequest request) {
+        try {
+            IssueAssignmentRequest requiredRequest = Objects.requireNonNull(request, "request");
+            switch (requiredRequest.mode()) {
+                case ASSIGN -> requireAssignmentController().assignIssue(
+                        issueId,
+                        requiredRequest.assigneeId(),
+                        requiredRequest.verifierId());
+                case REASSIGN_DEV -> requireAssignmentController().reassignIssue(
+                        issueId,
+                        requiredRequest.assigneeId());
+                case CHANGE_TESTER -> requireAssignmentController().changeVerifier(
+                        issueId,
+                        requiredRequest.verifierId());
+            }
+            loadIssue(issueId);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
     private List<IssueCommentActionState> commentActions(long issueId) {
         return issueController.viewCommentActions(issueId).stream()
                 .map(IssueDetailPresenter::toCommentActionState)
@@ -73,5 +105,12 @@ final class IssueDetailPresenter {
             throw new IllegalStateException("Issue state controller is not configured.");
         }
         return issueStateController;
+    }
+
+    private AssignmentController requireAssignmentController() {
+        if (assignmentController == null) {
+            throw new IllegalStateException("Assignment controller is not configured.");
+        }
+        return assignmentController;
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangeSupport.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueStatusChangeSupport.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 
 record IssueStatusChangeSupport(
         IssueStateController issueStateController,
-    IssueStatusChangePrompt prompt) {
+        IssueStatusChangePrompt prompt) {
 
     IssueStatusChangeSupport {
         Objects.requireNonNull(prompt, "prompt");

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
@@ -2,6 +2,7 @@ package com.github.marcellokim.issuetracker.ui.swing;
 
 import com.github.marcellokim.issuetracker.config.ApplicationContext;
 import com.github.marcellokim.issuetracker.controller.AccountController;
+import com.github.marcellokim.issuetracker.controller.AssignmentController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
 import com.github.marcellokim.issuetracker.controller.IssueController;
@@ -24,7 +25,8 @@ public final class SwingAppFrame extends JFrame {
                 context.accountController(),
                 context.projectController(),
                 context.issueController(),
-                context.issueStateController());
+                context.issueStateController(),
+                context.assignmentController());
     }
 
     SwingAppFrame(
@@ -33,7 +35,8 @@ public final class SwingAppFrame extends JFrame {
             AccountController accountController,
             ProjectController projectController,
             IssueController issueController,
-            IssueStateController issueStateController) {
+            IssueStateController issueStateController,
+            AssignmentController assignmentController) {
         super("Issue Tracker");
         this.appPanel = new SwingAppPanel(
                 authenticationController,
@@ -41,7 +44,7 @@ public final class SwingAppFrame extends JFrame {
                 accountController,
                 projectController,
                 issueController,
-                IssueStatusChangeSupport.dialog(issueStateController),
+                IssueActionSupport.dialogs(issueStateController, assignmentController),
                 this::setTitle);
         setContentPane(appPanel);
         setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -1,11 +1,13 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
 import com.github.marcellokim.issuetracker.controller.AccountController;
+import com.github.marcellokim.issuetracker.controller.AssignmentController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
 import com.github.marcellokim.issuetracker.controller.IssueController;
 import com.github.marcellokim.issuetracker.controller.ProjectController;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.service.AssignmentOptionsResult;
 import com.github.marcellokim.issuetracker.service.UserResult;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
@@ -33,7 +35,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private final transient AccountController accountController;
     private final transient ProjectController projectController;
     private final transient IssueController issueController;
-    private final transient IssueStatusChangeSupport statusChangeSupport;
+    private final transient IssueActionSupport issueActionSupport;
     private final transient Consumer<String> titleUpdater;
     private final CardLayout cardLayout = new CardLayout();
     private final LoginPanel loginPanel = new LoginPanel();
@@ -61,7 +63,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
                 accountController,
                 projectController,
                 issueController,
-                IssueStatusChangeSupport.disabled(),
+                IssueActionSupport.disabled(),
                 titleUpdater);
     }
 
@@ -71,14 +73,14 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             AccountController accountController,
             ProjectController projectController,
             IssueController issueController,
-            IssueStatusChangeSupport statusChangeSupport,
+            IssueActionSupport issueActionSupport,
             Consumer<String> titleUpdater) {
         this.authenticationController = Objects.requireNonNull(authenticationController, "authenticationController");
         this.dashboardController = Objects.requireNonNull(dashboardController, "dashboardController");
         this.accountController = Objects.requireNonNull(accountController, "accountController");
         this.projectController = Objects.requireNonNull(projectController, "projectController");
         this.issueController = Objects.requireNonNull(issueController, "issueController");
-        this.statusChangeSupport = Objects.requireNonNull(statusChangeSupport, "statusChangeSupport");
+        this.issueActionSupport = Objects.requireNonNull(issueActionSupport, "issueActionSupport");
         this.titleUpdater = Objects.requireNonNull(titleUpdater, "titleUpdater");
 
         setName("appCards");
@@ -404,13 +406,18 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             String action) {
         Optional<IssueStatus> targetStatus = IssueStatusChangeActions.targetStatus(action);
         if (targetStatus.isPresent()) {
-            statusChangeSupport.prompt().prompt(panel, action, targetStatus.get())
+            issueActionSupport.statusChange().prompt().prompt(panel, action, targetStatus.get())
                     .ifPresent(request -> startIssueDetailTask(
                             panel,
                             presenter -> presenter.changeStatus(
                                     issueId,
                                     request.targetStatus(),
                                     request.comment())));
+            return;
+        }
+        Optional<IssueAssignmentMode> assignmentMode = IssueAssignmentActions.mode(action);
+        if (assignmentMode.isPresent()) {
+            startIssueAssignmentTask(panel, issueId, assignmentMode.get());
             return;
         }
         SwingUtilities.invokeLater(() -> {
@@ -535,6 +542,16 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         cancelIssueDetailWorker();
         panel.setBusy(true);
         IssueDetailWorker worker = new IssueDetailWorker(panel, task);
+        issueDetailWorker.set(worker);
+        worker.execute();
+    }
+
+    private void startIssueAssignmentTask(IssueDetailPanel panel, long issueId, IssueAssignmentMode mode) {
+        Objects.requireNonNull(panel, "panel");
+        Objects.requireNonNull(mode, "mode");
+        cancelIssueDetailWorker();
+        panel.setBusy(true);
+        IssueAssignmentOptionsWorker worker = new IssueAssignmentOptionsWorker(panel, issueId, mode);
         issueDetailWorker.set(worker);
         worker.execute();
     }
@@ -752,7 +769,8 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         protected Void doInBackground() {
             IssueDetailPresenter presenter = new IssueDetailPresenter(
                     issueController,
-                    statusChangeSupport.issueStateController(),
+                    issueActionSupport.statusChange().issueStateController(),
+                    issueActionSupport.assignmentController(),
                     new CurrentIssueDetailView(panel, this, issueDetailWorker::get));
             task.run(presenter);
             return null;
@@ -761,6 +779,55 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         @Override
         protected void done() {
             finishWorker(issueDetailWorker, this, () -> panel.setBusy(false), panel::showMessage, "Issue detail");
+        }
+    }
+
+    private final class IssueAssignmentOptionsWorker extends SwingWorker<Void, Void> {
+
+        private final IssueDetailPanel panel;
+        private final long issueId;
+        private final IssueAssignmentMode mode;
+        private AssignmentOptionsResult options;
+
+        private IssueAssignmentOptionsWorker(IssueDetailPanel panel, long issueId, IssueAssignmentMode mode) {
+            this.panel = Objects.requireNonNull(panel, "panel");
+            this.issueId = issueId;
+            this.mode = Objects.requireNonNull(mode, "mode");
+        }
+
+        @Override
+        protected Void doInBackground() {
+            AssignmentController assignmentController = issueActionSupport.assignmentController();
+            if (assignmentController == null) {
+                throw new IllegalStateException("Assignment controller is not configured.");
+            }
+            options = assignmentController.startAssignment(issueId);
+            return null;
+        }
+
+        @Override
+        protected void done() {
+            if (!issueDetailWorker.compareAndSet(this, null)) {
+                return;
+            }
+            panel.setBusy(false);
+            if (isCancelled()) {
+                return;
+            }
+            try {
+                get();
+                issueActionSupport.assignmentPrompt().prompt(panel, mode, options)
+                        .ifPresent(request -> startIssueDetailTask(
+                                panel,
+                                presenter -> presenter.changeAssignment(issueId, request)));
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                panel.showMessage("Issue assignment was interrupted. Please try again.", true);
+            } catch (ExecutionException exception) {
+                panel.showMessage("Issue assignment failed. Please try again.", true);
+            } catch (RuntimeException exception) {
+                panel.showMessage(exception.getMessage(), true);
+            }
         }
     }
 

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueAssignmentDialogsTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueAssignmentDialogsTest.java
@@ -1,0 +1,161 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.service.AssignmentCandidateResult;
+import com.github.marcellokim.issuetracker.service.AssignmentOptionsResult;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import javax.imageio.ImageIO;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing issue assignment dialogs")
+class IssueAssignmentDialogsTest {
+
+    @Test
+    @DisplayName("renders assignment dialog form snapshot")
+    void rendersAssignmentDialogFormSnapshot() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            IssueAssignmentDialogs.AssignmentForm form = IssueAssignmentDialogs.form(
+                    IssueAssignmentMode.ASSIGN,
+                    options());
+            assertEquals(
+                    "Assign issue",
+                    SwingComponentTestSupport.find(form.panel(), "assignmentDialogTitle", JLabel.class).getText());
+            assertEquals(1, SwingComponentTestSupport.find(
+                    form.panel(),
+                    "assignmentAssigneeBox",
+                    JComboBox.class).getItemCount());
+            assertEquals(1, SwingComponentTestSupport.find(
+                    form.panel(),
+                    "assignmentVerifierBox",
+                    JComboBox.class).getItemCount());
+            form.panel().setSize(560, 220);
+            layoutRecursively(form.panel());
+
+            BufferedImage image = render(form.panel(), Path.of("build/reports/ui/issue-assignment-dialog.png"));
+            assertTrue(hasRenderedContent(image));
+        });
+    }
+
+    @Test
+    @DisplayName("change-only forms exclude current owners")
+    void changeOnlyFormsExcludeCurrentOwners() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            AssignmentOptionsResult options = optionsWithCurrentOwners();
+
+            IssueAssignmentDialogs.AssignmentForm reassignForm = IssueAssignmentDialogs.form(
+                    IssueAssignmentMode.REASSIGN_DEV,
+                    options);
+            JComboBox<?> assigneeBox = SwingComponentTestSupport.find(
+                    reassignForm.panel(),
+                    "assignmentAssigneeBox",
+                    JComboBox.class);
+            assertEquals(1, assigneeBox.getItemCount());
+            assertEquals("dev2", ((AssignmentCandidateResult) assigneeBox.getItemAt(0)).loginId());
+
+            IssueAssignmentDialogs.AssignmentForm verifierForm = IssueAssignmentDialogs.form(
+                    IssueAssignmentMode.CHANGE_TESTER,
+                    options);
+            JComboBox<?> verifierBox = SwingComponentTestSupport.find(
+                    verifierForm.panel(),
+                    "assignmentVerifierBox",
+                    JComboBox.class);
+            assertEquals(1, verifierBox.getItemCount());
+            assertEquals("tester2", ((AssignmentCandidateResult) verifierBox.getItemAt(0)).loginId());
+        });
+    }
+
+    private static AssignmentOptionsResult options() {
+        AssignmentCandidateResult dev = new AssignmentCandidateResult(
+                "dev1",
+                "Dev One",
+                Role.DEV,
+                3,
+                "recent resolver match");
+        AssignmentCandidateResult tester = new AssignmentCandidateResult(
+                "tester1",
+                "Tester One",
+                Role.TESTER,
+                2,
+                "recent verifier match");
+        return new AssignmentOptionsResult(List.of(dev), List.of(tester), List.of(dev), List.of(tester));
+    }
+
+    private static AssignmentOptionsResult optionsWithCurrentOwners() {
+        AssignmentCandidateResult currentDev = new AssignmentCandidateResult(
+                "dev1",
+                "Dev One",
+                Role.DEV,
+                0,
+                "current assignee");
+        AssignmentCandidateResult nextDev = new AssignmentCandidateResult(
+                "dev2",
+                "Dev Two",
+                Role.DEV,
+                2,
+                "recommended by similarity");
+        AssignmentCandidateResult currentTester = new AssignmentCandidateResult(
+                "tester1",
+                "Tester One",
+                Role.TESTER,
+                0,
+                "current verifier");
+        AssignmentCandidateResult nextTester = new AssignmentCandidateResult(
+                "tester2",
+                "Tester Two",
+                Role.TESTER,
+                2,
+                "recommended by similarity");
+        return new AssignmentOptionsResult(
+                List.of(currentDev, nextDev),
+                List.of(currentTester, nextTester),
+                List.of(currentDev, nextDev),
+                List.of(currentTester, nextTester));
+    }
+
+    private static void layoutRecursively(Container container) {
+        container.doLayout();
+        for (java.awt.Component child : container.getComponents()) {
+            if (child instanceof Container nested) {
+                layoutRecursively(nested);
+            }
+        }
+    }
+
+    private static BufferedImage render(Container panel, Path output) throws java.io.IOException {
+        BufferedImage image = new BufferedImage(560, 220, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            panel.printAll(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        Files.createDirectories(output.getParent());
+        ImageIO.write(image, "png", output.toFile());
+        return image;
+    }
+
+    private static boolean hasRenderedContent(BufferedImage image) {
+        int white = Color.WHITE.getRGB();
+        int contentPixels = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                if (image.getRGB(x, y) != white) {
+                    contentPixels++;
+                }
+            }
+        }
+        return contentPixels > 1_000;
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueAssignmentRequestTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueAssignmentRequestTest.java
@@ -1,0 +1,62 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing issue assignment request")
+class IssueAssignmentRequestTest {
+
+    @Test
+    @DisplayName("maps assignment detail actions to modes")
+    void mapsAssignmentDetailActionsToModes() {
+        assertEquals(Optional.of(IssueAssignmentMode.ASSIGN), IssueAssignmentActions.mode("ASSIGN"));
+        assertEquals(Optional.of(IssueAssignmentMode.REASSIGN_DEV), IssueAssignmentActions.mode("REASSIGN_DEV"));
+        assertEquals(Optional.of(IssueAssignmentMode.CHANGE_TESTER), IssueAssignmentActions.mode("CHANGE_TESTER"));
+        assertEquals(Optional.empty(), IssueAssignmentActions.mode("ADD_COMMENT"));
+    }
+
+    @Test
+    @DisplayName("delegates start assignment to the available concrete assignment action")
+    void delegatesStartAssignmentToAvailableConcreteAction() {
+        assertEquals(
+                "ASSIGN",
+                IssueAssignmentActions.effectiveAction("START_ASSIGNMENT", Set.of("START_ASSIGNMENT", "ASSIGN")));
+        assertEquals(
+                "REASSIGN_DEV",
+                IssueAssignmentActions.effectiveAction(
+                        "START_ASSIGNMENT",
+                        Set.of("START_ASSIGNMENT", "REASSIGN_DEV")));
+        assertEquals(
+                "CHANGE_TESTER",
+                IssueAssignmentActions.effectiveAction(
+                        "START_ASSIGNMENT",
+                        Set.of("START_ASSIGNMENT", "CHANGE_TESTER")));
+        assertEquals("START_ASSIGNMENT", IssueAssignmentActions.effectiveAction("START_ASSIGNMENT", Set.of()));
+    }
+
+    @Test
+    @DisplayName("validates assignment mode required fields")
+    void validatesAssignmentModeRequiredFields() {
+        IssueAssignmentRequest assign = new IssueAssignmentRequest(
+                IssueAssignmentMode.ASSIGN,
+                " dev1 ",
+                " tester1 ");
+        assertEquals("dev1", assign.assigneeId());
+        assertEquals("tester1", assign.verifierId());
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new IssueAssignmentRequest(IssueAssignmentMode.ASSIGN, "dev1", " "));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new IssueAssignmentRequest(IssueAssignmentMode.REASSIGN_DEV, " ", null));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new IssueAssignmentRequest(IssueAssignmentMode.CHANGE_TESTER, null, " "));
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
@@ -3,6 +3,7 @@ package com.github.marcellokim.issuetracker.ui.swing;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.marcellokim.issuetracker.controller.AssignmentController;
 import com.github.marcellokim.issuetracker.controller.IssueController;
 import com.github.marcellokim.issuetracker.controller.IssueStateController;
 import com.github.marcellokim.issuetracker.domain.Comment;
@@ -15,16 +16,20 @@ import com.github.marcellokim.issuetracker.domain.Project;
 import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.User;
 import com.github.marcellokim.issuetracker.repository.CommentRepository;
+import com.github.marcellokim.issuetracker.service.AssignmentRecommendationService;
+import com.github.marcellokim.issuetracker.service.AssignmentService;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
 import com.github.marcellokim.issuetracker.service.IssueDetailResult;
 import com.github.marcellokim.issuetracker.service.IssueService;
 import com.github.marcellokim.issuetracker.service.IssueStateService;
 import com.github.marcellokim.issuetracker.service.IssueWorkflowActions;
 import com.github.marcellokim.issuetracker.service.IssueWorkflowService;
+import com.github.marcellokim.issuetracker.service.KNNAssignmentRecommendation;
 import com.github.marcellokim.issuetracker.service.PasswordHashing;
 import com.github.marcellokim.issuetracker.service.PermissionPolicy;
 import com.github.marcellokim.issuetracker.support.FakeIssueDependencyRepository;
 import com.github.marcellokim.issuetracker.support.FakeIssueHistoryRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryAssignmentRecommendationRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
@@ -105,6 +110,107 @@ class IssueDetailPresenterTest {
     }
 
     @Test
+    @DisplayName("changes assignment through assignment controller and reloads detail")
+    void changesAssignmentAndReloadsDetail() {
+        User pl = user("pl1", Role.PL);
+        User assignee = user("dev1", Role.DEV);
+        User verifier = user("tester1", Role.TESTER);
+        Issue issue = issue(7L, "Login bug", pl);
+        IssueDetailControllerFixture fixture = controllerFixture(
+                pl,
+                new FakeCommentRepository(),
+                List.of(assignee, verifier),
+                issue);
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                fixture.issueController(),
+                fixture.issueStateController(),
+                fixture.assignmentController(),
+                view);
+        presenter.loadIssue(issue.id());
+
+        presenter.changeAssignment(
+                issue.id(),
+                new IssueAssignmentRequest(
+                        IssueAssignmentMode.ASSIGN,
+                        assignee.getLoginId(),
+                        verifier.getLoginId()));
+
+        assertEquals(IssueStatus.ASSIGNED, view.detail().status());
+        assertEquals(assignee.getLoginId(), view.detail().assignee().loginId());
+        assertEquals(verifier.getLoginId(), view.detail().verifier().loginId());
+        assertEquals(" ", view.message());
+    }
+
+    @Test
+    @DisplayName("reassigns assignee through assignment controller and reloads detail")
+    void reassignsAssigneeAndReloadsDetail() {
+        User pl = user("pl1", Role.PL);
+        User assignee = user("dev1", Role.DEV);
+        User nextAssignee = user("dev2", Role.DEV);
+        User verifier = user("tester1", Role.TESTER);
+        Issue issue = assignedIssue(7L, "Login bug", assignee, verifier);
+        IssueDetailControllerFixture fixture = controllerFixture(
+                pl,
+                new FakeCommentRepository(),
+                List.of(assignee, nextAssignee, verifier),
+                issue);
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                fixture.issueController(),
+                fixture.issueStateController(),
+                fixture.assignmentController(),
+                view);
+        presenter.loadIssue(issue.id());
+
+        presenter.changeAssignment(
+                issue.id(),
+                new IssueAssignmentRequest(
+                        IssueAssignmentMode.REASSIGN_DEV,
+                        nextAssignee.getLoginId(),
+                        null));
+
+        assertEquals(IssueStatus.ASSIGNED, view.detail().status());
+        assertEquals(nextAssignee.getLoginId(), view.detail().assignee().loginId());
+        assertEquals(verifier.getLoginId(), view.detail().verifier().loginId());
+        assertEquals(" ", view.message());
+    }
+
+    @Test
+    @DisplayName("changes verifier through assignment controller and reloads detail")
+    void changesVerifierAndReloadsDetail() {
+        User pl = user("pl1", Role.PL);
+        User assignee = user("dev1", Role.DEV);
+        User verifier = user("tester1", Role.TESTER);
+        User nextVerifier = user("tester2", Role.TESTER);
+        Issue issue = fixedIssue(7L, "Login bug", assignee, verifier);
+        IssueDetailControllerFixture fixture = controllerFixture(
+                pl,
+                new FakeCommentRepository(),
+                List.of(assignee, verifier, nextVerifier),
+                issue);
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                fixture.issueController(),
+                fixture.issueStateController(),
+                fixture.assignmentController(),
+                view);
+        presenter.loadIssue(issue.id());
+
+        presenter.changeAssignment(
+                issue.id(),
+                new IssueAssignmentRequest(
+                        IssueAssignmentMode.CHANGE_TESTER,
+                        null,
+                        nextVerifier.getLoginId()));
+
+        assertEquals(IssueStatus.FIXED, view.detail().status());
+        assertEquals(assignee.getLoginId(), view.detail().assignee().loginId());
+        assertEquals(nextVerifier.getLoginId(), view.detail().verifier().loginId());
+        assertEquals(" ", view.message());
+    }
+
+    @Test
     @DisplayName("shows controller errors without replacing current detail")
     void showsErrorsWithoutReplacingCurrentDetail() {
         User reporter = user("dev1", Role.DEV);
@@ -129,10 +235,23 @@ class IssueDetailPresenterTest {
             User currentUser,
             FakeCommentRepository comments,
             Issue... issues) {
+        return controllerFixture(currentUser, comments, List.of(), issues);
+    }
+
+    private static IssueDetailControllerFixture controllerFixture(
+            User currentUser,
+            FakeCommentRepository comments,
+            List<User> extraUsers,
+            Issue... issues) {
         InMemoryUserRepository users = new InMemoryUserRepository(currentUser)
                 .withProjectMembers(PROJECT_ID, currentUser.getLoginId());
         InMemoryProjectRepository projects = new InMemoryProjectRepository(project())
                 .withParticipant(PROJECT_ID, currentUser.getLoginId());
+        for (User user : extraUsers) {
+            users.save(user);
+            users.withProjectMembers(PROJECT_ID, user.getLoginId());
+            projects.withParticipant(PROJECT_ID, user.getLoginId());
+        }
         for (Issue issue : issues) {
             if (issue.getVerifier() != null) {
                 users.save(issue.getVerifier());
@@ -173,7 +292,17 @@ class IssueDetailPresenterTest {
                         permissionPolicy,
                         () -> NOW,
                         () -> "status-change-comment"));
-        return new IssueDetailControllerFixture(issueController, issueStateController);
+        AssignmentController assignmentController = new AssignmentController(
+                authentication,
+                new AssignmentService(
+                        issueRepository,
+                        users,
+                        permissionPolicy,
+                        new AssignmentRecommendationService(
+                                new InMemoryAssignmentRecommendationRepository(extraUsers.toArray(User[]::new)),
+                                new KNNAssignmentRecommendation()),
+                        () -> NOW));
+        return new IssueDetailControllerFixture(issueController, issueStateController, assignmentController);
     }
 
     private static Project project() {
@@ -202,6 +331,19 @@ class IssueDetailPresenterTest {
                 .updatedAt(NOW));
     }
 
+    private static Issue fixedIssue(long id, String title, User assignee, User verifier) {
+        return Issue.fromPersistence(Issue.persistedState(PROJECT_ID, title, "Issue description", assignee)
+                .id(id)
+                .issueId("ISSUE-" + id)
+                .status(IssueStatus.FIXED)
+                .priority(Priority.CRITICAL)
+                .assignee(assignee)
+                .verifier(verifier)
+                .fixer(assignee)
+                .reportedDate(NOW)
+                .updatedAt(NOW));
+    }
+
     private static Comment comment(long id, long issueId, User writer, CommentPurpose purpose) {
         return Comment.fromPersistence(id, issueId, writer.getLoginId(), "Comment " + id, purpose, NOW, NOW);
     }
@@ -212,7 +354,8 @@ class IssueDetailPresenterTest {
 
     private record IssueDetailControllerFixture(
             IssueController issueController,
-            IssueStateController issueStateController) {
+            IssueStateController issueStateController,
+            AssignmentController assignmentController) {
     }
 
     private static final class RecordingIssueDetailView implements IssueDetailView {

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.marcellokim.issuetracker.controller.AccountController;
+import com.github.marcellokim.issuetracker.controller.AssignmentController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
 import com.github.marcellokim.issuetracker.controller.IssueController;
@@ -20,20 +21,25 @@ import com.github.marcellokim.issuetracker.domain.Priority;
 import com.github.marcellokim.issuetracker.domain.Project;
 import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.AssignmentRecommendationRepository;
 import com.github.marcellokim.issuetracker.repository.CommentRepository;
 import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository;
 import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository.DashboardProjectSnapshot;
 import com.github.marcellokim.issuetracker.service.AccountService;
+import com.github.marcellokim.issuetracker.service.AssignmentRecommendationService;
+import com.github.marcellokim.issuetracker.service.AssignmentService;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
 import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
 import com.github.marcellokim.issuetracker.service.IssueService;
 import com.github.marcellokim.issuetracker.service.IssueStateService;
 import com.github.marcellokim.issuetracker.service.IssueWorkflowService;
+import com.github.marcellokim.issuetracker.service.KNNAssignmentRecommendation;
 import com.github.marcellokim.issuetracker.service.PasswordHashing;
 import com.github.marcellokim.issuetracker.service.PermissionPolicy;
 import com.github.marcellokim.issuetracker.service.ProjectService;
 import com.github.marcellokim.issuetracker.support.FakeIssueDependencyRepository;
 import com.github.marcellokim.issuetracker.support.FakeIssueHistoryRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryAssignmentRecommendationRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
@@ -478,6 +484,115 @@ class SwingAppPanelTest {
     }
 
     @Test
+    @DisplayName("issue detail start assignment action assigns issue and reloads detail")
+    void issueDetailStartAssignmentAssignsIssueAndReloadsDetail() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        User pl = user("pl1", Role.PL);
+        User assignee = user("dev1", Role.DEV);
+        User verifier = user("tester1", Role.TESTER);
+        AtomicReference<IssueAssignmentMode> promptedMode = new AtomicReference<>();
+        SwingAppPanel panel = loginProjectUser(
+                passwordHashing,
+                titles,
+                List.of(projectSnapshot(7L, "Alpha", 3, 7)),
+                List.of(issue(7L, 7L, "Login bug", Priority.CRITICAL, pl)),
+                IssueStatusChangeDialogs::prompt,
+                (parent, mode, options) -> {
+                    promptedMode.set(mode);
+                    assertEquals(1, options.allDevAssignees().size());
+                    assertEquals(1, options.allTesterVerifiers().size());
+                    return Optional.of(new IssueAssignmentRequest(
+                            mode,
+                            assignee.getLoginId(),
+                            verifier.getLoginId()));
+                },
+                pl,
+                assignee,
+                verifier);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable projects = SwingComponentTestSupport.find(panel, "projectListTable", JTable.class);
+            projects.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openProjectIssuesButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openProjectIssuesButton", JButton.class).doClick());
+        awaitIssueRows(panel, 1);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable issues = SwingComponentTestSupport.find(panel, "issueListTable", JTable.class);
+            issues.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openIssueDetailButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick());
+        awaitIssueDetailTitle(panel, "[ISSUE-7] Login bug");
+        awaitButtonEnabled(panel, "issueActionButton_START_ASSIGNMENT");
+
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "issueActionButton_START_ASSIGNMENT", JButton.class).doClick());
+        awaitIssueDetailState(panel, "ASSIGNED / CRITICAL");
+
+        assertEquals(IssueAssignmentMode.ASSIGN, promptedMode.get());
+        SwingComponentTestSupport.onEdt(() -> assertEquals(
+                "ASSIGNED / CRITICAL",
+                SwingComponentTestSupport.find(panel, "issueDetailState", JLabel.class).getText()));
+    }
+
+    @Test
+    @DisplayName("issue detail assignment loads options off the event dispatch thread")
+    void issueDetailAssignmentLoadsOptionsOffEdt() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        User pl = user("pl1", Role.PL);
+        User assignee = user("dev1", Role.DEV);
+        User verifier = user("tester1", Role.TESTER);
+        var recommendations = new RecordingAssignmentRecommendationRepository(pl, assignee, verifier);
+        SwingAppPanel panel = loginProjectUser(
+                passwordHashing,
+                titles,
+                List.of(projectSnapshot(7L, "Alpha", 3, 7)),
+                List.of(issue(7L, 7L, "Login bug", Priority.CRITICAL, pl)),
+                new SwingPromptSupport(
+                        IssueStatusChangeDialogs::prompt,
+                        (parent, mode, options) -> Optional.of(new IssueAssignmentRequest(
+                                mode,
+                                assignee.getLoginId(),
+                                verifier.getLoginId()))),
+                recommendations,
+                pl,
+                assignee,
+                verifier);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable projects = SwingComponentTestSupport.find(panel, "projectListTable", JTable.class);
+            projects.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openProjectIssuesButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openProjectIssuesButton", JButton.class).doClick());
+        awaitIssueRows(panel, 1);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable issues = SwingComponentTestSupport.find(panel, "issueListTable", JTable.class);
+            issues.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openIssueDetailButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick());
+        awaitIssueDetailTitle(panel, "[ISSUE-7] Login bug");
+        awaitButtonEnabled(panel, "issueActionButton_START_ASSIGNMENT");
+
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "issueActionButton_START_ASSIGNMENT", JButton.class).doClick());
+
+        assertTrue(recommendations.awaitCandidateLookup());
+        assertFalse(recommendations.candidateLookupOnEdt());
+        awaitIssueDetailState(panel, "ASSIGNED / CRITICAL");
+    }
+
+    @Test
     @DisplayName("project list logout returns to login")
     void projectListLogoutReturnsToLogin() throws Exception {
         var passwordHashing = new RecordingPasswordHashing();
@@ -520,6 +635,7 @@ class SwingAppPanelTest {
                 projects,
                 issues,
                 IssueStatusChangeDialogs::prompt,
+                IssueAssignmentDialogs::prompt,
                 user);
     }
 
@@ -528,11 +644,12 @@ class SwingAppPanelTest {
             RecordingTitleUpdater titles,
             List<DashboardProjectSnapshot> projects,
             List<Issue> issues,
-            IssueStatusChangePrompt statusChangePrompt,
+            SwingPromptSupport prompts,
+            AssignmentRecommendationRepository recommendationRepository,
             User... users) throws Exception {
         var panelRef = new AtomicReference<SwingAppPanel>();
         var workerDone = new CountDownLatch(1);
-        SwingControllerFixture controllers = controllers(passwordHashing, projects, issues, users);
+        SwingControllerFixture controllers = controllers(passwordHashing, projects, issues, recommendationRepository, users);
 
         SwingComponentTestSupport.onEdt(() -> {
             SwingAppPanel panel = new SwingAppPanel(
@@ -541,7 +658,10 @@ class SwingAppPanelTest {
                     controllers.accountController(),
                     controllers.projectController(),
                     controllers.issueController(),
-                    new IssueStatusChangeSupport(controllers.issueStateController(), statusChangePrompt),
+                    new IssueActionSupport(
+                            new IssueStatusChangeSupport(controllers.issueStateController(), prompts.statusChangePrompt()),
+                            controllers.assignmentController(),
+                            prompts.assignmentPrompt()),
                     titles::update);
             panelRef.set(panel);
             User user = users[0];
@@ -567,6 +687,41 @@ class SwingAppPanelTest {
         assertNotNull(panel);
         awaitProjectListRows(panel, projects.size());
         return panel;
+    }
+
+    private static SwingAppPanel loginProjectUser(
+            RecordingPasswordHashing passwordHashing,
+            RecordingTitleUpdater titles,
+            List<DashboardProjectSnapshot> projects,
+            List<Issue> issues,
+            IssueStatusChangePrompt statusChangePrompt,
+            User... users) throws Exception {
+        return loginProjectUser(
+                passwordHashing,
+                titles,
+                projects,
+                issues,
+                statusChangePrompt,
+                IssueAssignmentDialogs::prompt,
+                users);
+    }
+
+    private static SwingAppPanel loginProjectUser(
+            RecordingPasswordHashing passwordHashing,
+            RecordingTitleUpdater titles,
+            List<DashboardProjectSnapshot> projects,
+            List<Issue> issues,
+            IssueStatusChangePrompt statusChangePrompt,
+            IssueAssignmentPrompt assignmentPrompt,
+            User... users) throws Exception {
+        return loginProjectUser(
+                passwordHashing,
+                titles,
+                projects,
+                issues,
+                new SwingPromptSupport(statusChangePrompt, assignmentPrompt),
+                new InMemoryAssignmentRecommendationRepository(users),
+                users);
     }
 
     private static SwingWorker<?, ?> loginWorker(SwingAppPanel panel) throws ReflectiveOperationException {
@@ -772,6 +927,20 @@ class SwingAppPanelTest {
             List<DashboardProjectSnapshot> projects,
             List<Issue> issues,
             User... users) {
+        return controllers(
+                passwordHashing,
+                projects,
+                issues,
+                new InMemoryAssignmentRecommendationRepository(users),
+                users);
+    }
+
+    private static SwingControllerFixture controllers(
+            PasswordHashing passwordHashing,
+            List<DashboardProjectSnapshot> projects,
+            List<Issue> issues,
+            AssignmentRecommendationRepository recommendationRepository,
+            User... users) {
         var repository = new InMemoryUserRepository(users);
         var projectRepository = new InMemoryProjectRepository();
         projects.forEach(project -> {
@@ -803,6 +972,16 @@ class SwingAppPanelTest {
                         permissionPolicy,
                         () -> NOW,
                         () -> "status-change-comment"));
+        AssignmentController assignmentController = new AssignmentController(
+                service,
+                new AssignmentService(
+                        issueRepository,
+                        repository,
+                        permissionPolicy,
+                        new AssignmentRecommendationService(
+                                recommendationRepository,
+                                new KNNAssignmentRecommendation()),
+                        () -> NOW));
         return new SwingControllerFixture(
                 new AuthenticationController(service),
                 new DashboardController(
@@ -845,7 +1024,8 @@ class SwingAppPanelTest {
                                 commentRepository,
                                 repository,
                                 permissionPolicy)),
-                issueStateController);
+                issueStateController,
+                assignmentController);
     }
 
     private static User user(String loginId, Role role) {
@@ -902,7 +1082,13 @@ class SwingAppPanelTest {
             AccountController accountController,
             ProjectController projectController,
             IssueController issueController,
-            IssueStateController issueStateController) {
+            IssueStateController issueStateController,
+            AssignmentController assignmentController) {
+    }
+
+    private record SwingPromptSupport(
+            IssueStatusChangePrompt statusChangePrompt,
+            IssueAssignmentPrompt assignmentPrompt) {
     }
 
     private static final class FakeCommentRepository implements CommentRepository {
@@ -1013,6 +1199,43 @@ class SwingAppPanelTest {
 
         private boolean awaitProjectList() throws InterruptedException {
             return projectListShown.await(5, TimeUnit.SECONDS);
+        }
+    }
+
+    private static final class RecordingAssignmentRecommendationRepository
+            implements AssignmentRecommendationRepository {
+
+        private final InMemoryAssignmentRecommendationRepository delegate;
+        private final CountDownLatch candidateLookup = new CountDownLatch(1);
+        private final AtomicBoolean candidateLookupOnEdt = new AtomicBoolean(true);
+
+        private RecordingAssignmentRecommendationRepository(User... users) {
+            this.delegate = new InMemoryAssignmentRecommendationRepository(users);
+        }
+
+        @Override
+        public List<IssueRecommendationData> findResolvedIssuesForRecommendation(long projectId) {
+            return delegate.findResolvedIssuesForRecommendation(projectId);
+        }
+
+        @Override
+        public List<User> findActiveDevCandidates(long projectId) {
+            candidateLookupOnEdt.set(SwingUtilities.isEventDispatchThread());
+            candidateLookup.countDown();
+            return delegate.findActiveDevCandidates(projectId);
+        }
+
+        @Override
+        public List<User> findActiveTesterCandidates(long projectId) {
+            return delegate.findActiveTesterCandidates(projectId);
+        }
+
+        private boolean awaitCandidateLookup() throws InterruptedException {
+            return candidateLookup.await(5, TimeUnit.SECONDS);
+        }
+
+        private boolean candidateLookupOnEdt() {
+            return candidateLookupOnEdt.get();
         }
     }
 }


### PR DESCRIPTION
## purpose
Swing 전체 UI에서 이슈 배정, assignee 재배정, verifier 변경 흐름을 연결합니다.

Closes #211

## non-goals
- 추천 알고리즘, 권한 정책, controller/service 계약은 변경하지 않습니다.
- dependency, comment, edit/delete, deleted issue, statistics 화면은 후속 PR에서 다룹니다.

## diff map
- 핵심 변경: `IssueAssignmentActions`, `IssueAssignmentDialogs`, `IssueAssignmentPrompt`, `IssueAssignmentRequest` 추가
- 연결부: `IssueDetailPanel`의 `START_ASSIGNMENT`를 controller-derived available action 기준으로 구체 action에 위임
- 실행 흐름: `IssueDetailPresenter`가 `AssignmentController`의 assign/reassign/changeVerifier 후 상세를 새로고침
- 앱 wiring: `SwingAppFrame`, `SwingAppPanel`에 assignment action support와 prompt 주입
- 테스트 변경: request/action mapping, dialog snapshot, presenter 흐름, app 통합 흐름 추가

## verification evidence
- `git diff --check origin/dev...HEAD`
- `./gradlew test --tests '*IssueAssignment*' --tests '*IssueDetailPresenterTest*' --tests '*SwingAppPanelTest*' --console=plain`
- `./gradlew check --console=plain`
- pre-push `test + verifyRepositorySetup`
- visual evidence inspected: `build/reports/ui/issue-assignment-dialog.png`, `build/reports/ui/issue-detail-panel.png`

## reviewer focus areas
- `START_ASSIGNMENT`이 status/role 직접 판단 없이 `availableActions` 기반으로 `ASSIGN`, `REASSIGN_DEV`, `CHANGE_TESTER`에 위임되는지
- Swing이 후보 목록 병합과 선택 state만 담당하고 추천/권한 정책을 재구현하지 않는지
- action 후 이슈 상세 reload 흐름이 기존 status-change dialog 흐름과 일관적인지

## risk / rollback
- 이 PR은 Swing UI 계층 wiring과 테스트에 한정됩니다.
- 문제가 있으면 이 PR만 되돌려도 이전 이슈 상세/status-change 흐름은 유지됩니다.