### PR TITLE
feat: Swing 이슈 코멘트 action 구현

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueActionSupport.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueActionSupport.java
@@ -7,18 +7,21 @@ import java.util.Objects;
 record IssueActionSupport(
         IssueStatusChangeSupport statusChange,
         AssignmentController assignmentController,
-        IssueAssignmentPrompt assignmentPrompt) {
+        IssueAssignmentPrompt assignmentPrompt,
+        IssueCommentPrompt commentPrompt) {
 
     IssueActionSupport {
         Objects.requireNonNull(statusChange, "statusChange");
         Objects.requireNonNull(assignmentPrompt, "assignmentPrompt");
+        Objects.requireNonNull(commentPrompt, "commentPrompt");
     }
 
     static IssueActionSupport disabled() {
         return new IssueActionSupport(
                 IssueStatusChangeSupport.disabled(),
                 null,
-                IssueAssignmentDialogs::prompt);
+                IssueAssignmentDialogs::prompt,
+                IssueCommentDialogs::prompt);
     }
 
     static IssueActionSupport dialogs(
@@ -27,6 +30,7 @@ record IssueActionSupport(
         return new IssueActionSupport(
                 IssueStatusChangeSupport.dialog(issueStateController),
                 assignmentController,
-                IssueAssignmentDialogs::prompt);
+                IssueAssignmentDialogs::prompt,
+                IssueCommentDialogs::prompt);
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentActionState.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentActionState.java
@@ -1,11 +1,26 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
-record IssueCommentActionState(String commentId, boolean canUpdate, boolean canDelete) {
+import java.util.Objects;
+
+record IssueCommentActionState(
+        String displayCommentId,
+        Long numericCommentId,
+        String content,
+        boolean canUpdate,
+        boolean canDelete) {
 
     IssueCommentActionState {
-        if (commentId == null || commentId.isBlank()) {
+        if (displayCommentId == null || displayCommentId.isBlank()) {
             throw new IllegalArgumentException("commentId must not be blank");
         }
-        commentId = commentId.trim();
+        displayCommentId = displayCommentId.trim();
+        Objects.requireNonNull(content, "content");
+        if (numericCommentId != null && numericCommentId <= 0L) {
+            throw new IllegalArgumentException("numericCommentId must be positive");
+        }
+        if (numericCommentId == null) {
+            canUpdate = false;
+            canDelete = false;
+        }
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentDialogs.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentDialogs.java
@@ -1,0 +1,107 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.util.Optional;
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+
+final class IssueCommentDialogs {
+
+    private static final int TEXT_ROWS = 5;
+    private static final int TEXT_COLUMNS = 36;
+
+    private IssueCommentDialogs() {
+    }
+
+    static Optional<IssueCommentRequest> prompt(
+            Component parent,
+            IssueCommentMode mode,
+            IssueCommentSelection selection) {
+        return switch (mode) {
+            case ADD -> promptContent(parent, mode, null);
+            case UPDATE -> promptContent(parent, mode, requireSelection(selection));
+            case DELETE -> confirmDelete(parent, requireSelection(selection));
+        };
+    }
+
+    static CommentForm form(String title, String initialContent) {
+        JTextArea contentArea = new JTextArea(initialContent == null ? "" : initialContent, TEXT_ROWS, TEXT_COLUMNS);
+        contentArea.setName("commentContentArea");
+        contentArea.setLineWrap(true);
+        contentArea.setWrapStyleWord(true);
+
+        JPanel panel = new JPanel(new BorderLayout(SwingStyles.ROW_GAP, SwingStyles.ROW_GAP));
+        panel.setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP));
+        JLabel label = new JLabel(title);
+        label.setName("commentDialogTitle");
+        panel.add(label, BorderLayout.NORTH);
+        panel.add(new JScrollPane(contentArea), BorderLayout.CENTER);
+        return new CommentForm(panel, contentArea);
+    }
+
+    private static Optional<IssueCommentRequest> promptContent(
+            Component parent,
+            IssueCommentMode mode,
+            IssueCommentSelection selection) {
+        CommentForm form = form(label(mode), selection == null ? "" : selection.content());
+        while (true) {
+            int result = JOptionPane.showConfirmDialog(
+                    parent,
+                    form.panel(),
+                    label(mode),
+                    JOptionPane.OK_CANCEL_OPTION,
+                    JOptionPane.PLAIN_MESSAGE);
+            if (result != JOptionPane.OK_OPTION) {
+                return Optional.empty();
+            }
+            try {
+                if (mode == IssueCommentMode.ADD) {
+                    return Optional.of(IssueCommentRequest.add(form.contentArea().getText()));
+                }
+                return Optional.of(IssueCommentRequest.update(selection.commentId(), form.contentArea().getText()));
+            } catch (IllegalArgumentException exception) {
+                JOptionPane.showMessageDialog(parent, exception.getMessage(), label(mode), JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private static Optional<IssueCommentRequest> confirmDelete(Component parent, IssueCommentSelection selection) {
+        int result = JOptionPane.showConfirmDialog(
+                parent,
+                "Delete selected comment?",
+                label(IssueCommentMode.DELETE),
+                JOptionPane.OK_CANCEL_OPTION,
+                JOptionPane.WARNING_MESSAGE);
+        if (result != JOptionPane.OK_OPTION) {
+            return Optional.empty();
+        }
+        return Optional.of(IssueCommentRequest.delete(selection.commentId()));
+    }
+
+    private static IssueCommentSelection requireSelection(IssueCommentSelection selection) {
+        if (selection == null) {
+            throw new IllegalArgumentException("comment selection is required");
+        }
+        return selection;
+    }
+
+    private static String label(IssueCommentMode mode) {
+        return switch (mode) {
+            case ADD -> "Add comment";
+            case UPDATE -> "Edit comment";
+            case DELETE -> "Delete comment";
+        };
+    }
+
+    record CommentForm(JPanel panel, JTextArea contentArea) {
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentMode.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentMode.java
@@ -1,0 +1,7 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+enum IssueCommentMode {
+    ADD,
+    UPDATE,
+    DELETE
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentPrompt.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentPrompt.java
@@ -1,0 +1,13 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.awt.Component;
+import java.util.Optional;
+
+@FunctionalInterface
+interface IssueCommentPrompt {
+
+    Optional<IssueCommentRequest> prompt(
+            Component parent,
+            IssueCommentMode mode,
+            IssueCommentSelection selection);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentRequest.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentRequest.java
@@ -1,0 +1,41 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.util.Objects;
+
+    record IssueCommentRequest(IssueCommentMode mode, Long commentId, String content) {
+
+    IssueCommentRequest {
+        Objects.requireNonNull(mode, "mode");
+        if ((mode == IssueCommentMode.UPDATE || mode == IssueCommentMode.DELETE)
+                && (commentId == null || commentId <= 0L)) {
+            throw new IllegalArgumentException("commentId must be positive");
+        }
+        if (mode == IssueCommentMode.ADD) {
+            commentId = null;
+        }
+        if (mode == IssueCommentMode.ADD || mode == IssueCommentMode.UPDATE) {
+            content = requireText(content);
+        } else {
+            content = null;
+        }
+    }
+
+    static IssueCommentRequest add(String content) {
+        return new IssueCommentRequest(IssueCommentMode.ADD, null, content);
+    }
+
+    static IssueCommentRequest update(long commentId, String content) {
+        return new IssueCommentRequest(IssueCommentMode.UPDATE, commentId, content);
+    }
+
+    static IssueCommentRequest delete(long commentId) {
+        return new IssueCommentRequest(IssueCommentMode.DELETE, commentId, null);
+    }
+
+    private static String requireText(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("content must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentSelection.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentSelection.java
@@ -1,0 +1,13 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.util.Objects;
+
+record IssueCommentSelection(long commentId, String content) {
+
+    IssueCommentSelection {
+        if (commentId <= 0L) {
+            throw new IllegalArgumentException("commentId must be positive");
+        }
+        Objects.requireNonNull(content, "content");
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -24,6 +25,8 @@ import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ListSelectionModel;
 import javax.swing.Scrollable;
 import javax.swing.JTable;
 import javax.swing.SwingUtilities;
@@ -38,7 +41,7 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
     private static final Color SELECTION_BACKGROUND = new Color(219, 234, 254);
     private static final int SUMMARY_SECTION_HEIGHT = 168;
     private static final int ACTION_SECTION_HEIGHT = 150;
-    private static final int COMMENT_SECTION_HEIGHT = 190;
+    private static final int COMMENT_SECTION_HEIGHT = 220;
     private static final int HISTORY_SECTION_HEIGHT = 170;
     private static final int DEPENDENCY_SECTION_HEIGHT = 150;
     private static final String[] COMMENT_COLUMNS = {
@@ -84,9 +87,13 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
     private final JTable commentTable = table(commentTableModel, "issueCommentTable");
     private final JTable historyTable = table(historyTableModel, "issueHistoryTable");
     private final JTable dependencyTable = table(dependencyTableModel, "issueDependencyTable");
+    private final JButton addCommentButton = new JButton("Add comment");
+    private final JButton editCommentButton = new JButton("Edit selected");
+    private final JButton deleteCommentButton = new JButton("Delete selected");
     private final Map<String, JButton> actionButtons = new LinkedHashMap<>();
     private boolean busy;
     private Set<String> availableActions = Set.of();
+    private transient List<IssueCommentActionState> commentActionStates = List.of();
 
     IssueDetailPanel(UserResult user, IssueDetailActions actions) {
         Objects.requireNonNull(user, "user");
@@ -104,6 +111,7 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
 
         add(header(), BorderLayout.NORTH);
         add(content(), BorderLayout.CENTER);
+        configureCommentActions();
         updateActionButtons();
     }
 
@@ -122,10 +130,13 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
             fixerLabel.setText("Fixer: " + formatUser(detail.fixer()));
             resolverLabel.setText("Resolver: " + formatUser(detail.resolver()));
             availableActions = Set.copyOf(detail.availableActions());
+            commentActionStates = List.copyOf(commentActions);
             replaceRows(commentTableModel, commentRows(detail.comments(), commentActionById));
+            commentTable.clearSelection();
             replaceRows(historyTableModel, historyRows(detail.histories()));
             replaceRows(dependencyTableModel, dependencyRows(detail.dependencies()));
             updateActionButtons();
+            updateCommentButtons();
         });
     }
 
@@ -154,6 +165,7 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
             historyTable.setEnabled(!busy);
             dependencyTable.setEnabled(!busy);
             updateActionButtons();
+            updateCommentButtons();
         });
     }
 
@@ -183,7 +195,7 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         content.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
         content.add(constrainedSection(actionSection(), ACTION_SECTION_HEIGHT));
         content.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
-        content.add(constrainedSection(SwingPanelSections.tableSection("Comments", commentTable), COMMENT_SECTION_HEIGHT));
+        content.add(constrainedSection(commentSection(), COMMENT_SECTION_HEIGHT));
         content.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
         content.add(constrainedSection(SwingPanelSections.tableSection("History", historyTable), HISTORY_SECTION_HEIGHT));
         content.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
@@ -239,6 +251,34 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         return section;
     }
 
+    private JPanel commentSection() {
+        JPanel section = new JPanel(new BorderLayout(0, SwingStyles.ROW_GAP));
+        section.setBackground(SwingStyles.SURFACE);
+        section.setBorder(SwingStyles.surfaceBorder());
+
+        JPanel header = new JPanel(new BorderLayout(SwingStyles.ROW_GAP, 0));
+        header.setOpaque(false);
+        JLabel title = new JLabel("Comments");
+        SwingStyles.applySectionTitle(title);
+        header.add(title, BorderLayout.WEST);
+
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT, SwingStyles.ROW_GAP, 0));
+        buttons.setOpaque(false);
+        addCommentButton.setName("addCommentButton");
+        editCommentButton.setName("editCommentButton");
+        deleteCommentButton.setName("deleteCommentButton");
+        buttons.add(addCommentButton);
+        buttons.add(editCommentButton);
+        buttons.add(deleteCommentButton);
+        header.add(buttons, BorderLayout.EAST);
+
+        JScrollPane scrollPane = new JScrollPane(commentTable);
+        scrollPane.setColumnHeaderView(commentTable.getTableHeader());
+        section.add(header, BorderLayout.NORTH);
+        section.add(scrollPane, BorderLayout.CENTER);
+        return section;
+    }
+
     private static JPanel constrainedSection(JPanel section, int height) {
         Dimension size = new Dimension(SwingStyles.WINDOW_SIZE.width - SwingStyles.OUTER_PADDING * 2, height);
         section.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -266,13 +306,61 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
     private void updateActionButtons() {
         boolean enabled = !busy;
         actionButtons.forEach((action, button) -> button.setEnabled(enabled && availableActions.contains(action)));
+        addCommentButton.setEnabled(enabled && availableActions.contains("ADD_COMMENT"));
+    }
+
+    private void configureCommentActions() {
+        commentTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        setColumnWidths(commentTable, 64, 92, 96, 320, 132, 64, 64);
+        commentTable.getSelectionModel().addListSelectionListener(event -> {
+            if (!event.getValueIsAdjusting()) {
+                updateCommentButtons();
+            }
+        });
+        addCommentButton.addActionListener(event ->
+                actions.onCommentAction().accept(this, IssueCommentMode.ADD, null));
+        editCommentButton.addActionListener(event -> selectedComment()
+                .ifPresent(selection -> actions.onCommentAction().accept(this, IssueCommentMode.UPDATE, selection)));
+        deleteCommentButton.addActionListener(event -> selectedComment()
+                .ifPresent(selection -> actions.onCommentAction().accept(this, IssueCommentMode.DELETE, selection)));
+        updateCommentButtons();
+    }
+
+    private static void setColumnWidths(JTable table, int... widths) {
+        for (int index = 0; index < widths.length && index < table.getColumnCount(); index++) {
+            table.getColumnModel().getColumn(index).setPreferredWidth(widths[index]);
+        }
+    }
+
+    private void updateCommentButtons() {
+        Optional<IssueCommentActionState> selected = selectedCommentState();
+        editCommentButton.setEnabled(!busy && selected.map(IssueCommentActionState::canUpdate).orElse(false));
+        deleteCommentButton.setEnabled(!busy && selected.map(IssueCommentActionState::canDelete).orElse(false));
+    }
+
+    private Optional<IssueCommentSelection> selectedComment() {
+        return selectedCommentState()
+                .filter(state -> state.numericCommentId() != null)
+                .map(state -> new IssueCommentSelection(state.numericCommentId(), state.content()));
+    }
+
+    private Optional<IssueCommentActionState> selectedCommentState() {
+        int selectedRow = commentTable.getSelectedRow();
+        if (selectedRow < 0 || selectedRow >= commentTable.getRowCount()) {
+            return Optional.empty();
+        }
+        int modelRow = commentTable.convertRowIndexToModel(selectedRow);
+        if (modelRow < 0 || modelRow >= commentActionStates.size()) {
+            return Optional.empty();
+        }
+        return Optional.of(commentActionStates.get(modelRow));
     }
 
     private static Map<String, IssueCommentActionState> commentActionById(
             List<IssueCommentActionState> commentActions) {
         Map<String, IssueCommentActionState> byId = new LinkedHashMap<>();
         for (IssueCommentActionState action : commentActions) {
-            byId.put(action.commentId(), action);
+            byId.put(action.displayCommentId(), action);
         }
         return byId;
     }
@@ -365,10 +453,26 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         void accept(IssueDetailPanel panel, String value);
     }
 
-    record IssueDetailActions(PanelStringConsumer onAction, Runnable onBack, Runnable onLogout) {
+    @FunctionalInterface
+    interface PanelCommentConsumer {
+
+        void accept(IssueDetailPanel panel, IssueCommentMode mode, IssueCommentSelection selection);
+    }
+
+    record IssueDetailActions(
+            PanelStringConsumer onAction,
+            PanelCommentConsumer onCommentAction,
+            Runnable onBack,
+            Runnable onLogout) {
+
+        IssueDetailActions(PanelStringConsumer onAction, Runnable onBack, Runnable onLogout) {
+            this(onAction, (panel, mode, selection) -> {
+            }, onBack, onLogout);
+        }
 
         IssueDetailActions {
             Objects.requireNonNull(onAction, "onAction");
+            Objects.requireNonNull(onCommentAction, "onCommentAction");
             Objects.requireNonNull(onBack, "onBack");
             Objects.requireNonNull(onLogout, "onLogout");
         }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenter.java
@@ -5,8 +5,11 @@ import com.github.marcellokim.issuetracker.controller.IssueController;
 import com.github.marcellokim.issuetracker.controller.IssueStateController;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.service.CommentActionResult;
+import com.github.marcellokim.issuetracker.service.CommentResult;
 import com.github.marcellokim.issuetracker.service.IssueDetailResult;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 final class IssueDetailPresenter {
@@ -41,7 +44,7 @@ final class IssueDetailPresenter {
     void loadIssue(long issueId) {
         try {
             IssueDetailResult detail = issueController.viewIssueDetail(issueId);
-            view.showDetail(detail, commentActions(issueId));
+            view.showDetail(detail, commentActions(issueId, detail.comments()));
             view.showMessage(" ", false);
         } catch (RuntimeException exception) {
             view.showMessage(exception.getMessage(), true);
@@ -87,17 +90,73 @@ final class IssueDetailPresenter {
         }
     }
 
-    private List<IssueCommentActionState> commentActions(long issueId) {
-        return issueController.viewCommentActions(issueId).stream()
-                .map(IssueDetailPresenter::toCommentActionState)
+    void changeComment(long issueId, IssueCommentRequest request) {
+        IssueCommentRequest requiredRequest = Objects.requireNonNull(request, "request");
+        switch (requiredRequest.mode()) {
+            case ADD -> addComment(issueId, requiredRequest.content());
+            case UPDATE -> updateComment(issueId, requiredRequest.commentId(), requiredRequest.content());
+            case DELETE -> deleteComment(issueId, requiredRequest.commentId());
+        }
+    }
+
+    void addComment(long issueId, String content) {
+        try {
+            issueController.addComment(issueId, content);
+            loadIssue(issueId);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    void updateComment(long issueId, long commentId, String content) {
+        try {
+            issueController.updateComment(issueId, commentId, content);
+            loadIssue(issueId);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    void deleteComment(long issueId, long commentId) {
+        try {
+            issueController.deleteComment(issueId, commentId);
+            loadIssue(issueId);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    private List<IssueCommentActionState> commentActions(long issueId, List<CommentResult> comments) {
+        Map<String, CommentActionResult> actionsById = commentActionsById(issueId);
+        return comments.stream()
+                .map(comment -> commentAction(comment, actionsById.get(comment.commentId())))
                 .toList();
     }
 
-    private static IssueCommentActionState toCommentActionState(CommentActionResult result) {
+    private Map<String, CommentActionResult> commentActionsById(long issueId) {
+        Map<String, CommentActionResult> actionsById = new LinkedHashMap<>();
+        for (CommentActionResult action : issueController.viewCommentActions(issueId)) {
+            actionsById.put(action.commentId(), action);
+        }
+        return actionsById;
+    }
+
+    private static IssueCommentActionState commentAction(CommentResult comment, CommentActionResult action) {
+        Long commentId = numericCommentId(comment.commentId());
         return new IssueCommentActionState(
-                result.commentId(),
-                result.canUpdate(),
-                result.canDelete());
+                comment.commentId(),
+                commentId,
+                comment.content(),
+                action != null && action.canUpdate(),
+                action != null && action.canDelete());
+    }
+
+    private static Long numericCommentId(String commentId) {
+        try {
+            return Long.valueOf(commentId);
+        } catch (NumberFormatException exception) {
+            return null;
+        }
     }
 
     private IssueStateController requireIssueStateController() {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -387,6 +387,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
                     user,
                     new IssueDetailPanel.IssueDetailActions(
                             (panelRef, action) -> showIssueAction(user, projectId, issueId, panelRef, action),
+                            (panelRef, mode, selection) -> showIssueComment(issueId, panelRef, mode, selection),
                             () -> showIssueList(user, projectId),
                             this::logout));
             projectListCard.removeAll();
@@ -420,6 +421,10 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             startIssueAssignmentTask(panel, issueId, assignmentMode.get());
             return;
         }
+        if ("ADD_COMMENT".equals(action)) {
+            showIssueComment(issueId, panel, IssueCommentMode.ADD, null);
+            return;
+        }
         SwingUtilities.invokeLater(() -> {
             cancelDashboardWorker();
             cancelAccountWorker();
@@ -436,6 +441,21 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
                     () -> showIssueDetail(user, projectId, issueId));
             cardLayout.show(this, PROJECT_LIST_CARD);
         });
+    }
+
+    private void showIssueComment(
+            long issueId,
+            IssueDetailPanel panel,
+            IssueCommentMode mode,
+            IssueCommentSelection selection) {
+        try {
+            issueActionSupport.commentPrompt().prompt(panel, mode, selection)
+                    .ifPresent(request -> startIssueDetailTask(
+                            panel,
+                            presenter -> presenter.changeComment(issueId, request)));
+        } catch (RuntimeException exception) {
+            panel.showMessage(exception.getMessage(), true);
+        }
     }
 
     private void loadAdminDashboard(AdminDashboardPanel panel) {

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentDialogsTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentDialogsTest.java
@@ -1,0 +1,75 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.imageio.ImageIO;
+import javax.swing.JLabel;
+import javax.swing.JTextArea;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing issue comment dialogs")
+class IssueCommentDialogsTest {
+
+    @Test
+    @DisplayName("renders comment content dialog form snapshot")
+    void rendersCommentDialogFormSnapshot() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            IssueCommentDialogs.CommentForm form =
+                    IssueCommentDialogs.form("Edit comment", "Existing comment body");
+            assertEquals(
+                    "Edit comment",
+                    SwingComponentTestSupport.find(form.panel(), "commentDialogTitle", JLabel.class).getText());
+            assertEquals(
+                    "Existing comment body",
+                    SwingComponentTestSupport.find(form.panel(), "commentContentArea", JTextArea.class).getText());
+            form.panel().setSize(560, 260);
+            layoutRecursively(form.panel());
+
+            BufferedImage image = render(form.panel(), Path.of("build/reports/ui/issue-comment-dialog.png"));
+            assertTrue(hasRenderedContent(image));
+        });
+    }
+
+    private static void layoutRecursively(Container container) {
+        container.doLayout();
+        for (java.awt.Component child : container.getComponents()) {
+            if (child instanceof Container nested) {
+                layoutRecursively(nested);
+            }
+        }
+    }
+
+    private static BufferedImage render(Container panel, Path output) throws java.io.IOException {
+        BufferedImage image = new BufferedImage(560, 260, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            panel.printAll(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        Files.createDirectories(output.getParent());
+        ImageIO.write(image, "png", output.toFile());
+        return image;
+    }
+
+    private static boolean hasRenderedContent(BufferedImage image) {
+        int white = Color.WHITE.getRGB();
+        int contentPixels = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                if (image.getRGB(x, y) != white) {
+                    contentPixels++;
+                }
+            }
+        }
+        return contentPixels > 1_000;
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentRequestTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueCommentRequestTest.java
@@ -1,0 +1,41 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing issue comment request")
+class IssueCommentRequestTest {
+
+    @Test
+    @DisplayName("validates add and update comment content")
+    void validatesContentRequests() {
+        IssueCommentRequest add = IssueCommentRequest.add(" comment body ");
+        IssueCommentRequest update = IssueCommentRequest.update(100L, " edited body ");
+
+        assertEquals(IssueCommentMode.ADD, add.mode());
+        assertNull(add.commentId());
+        assertEquals("comment body", add.content());
+        assertEquals(IssueCommentMode.UPDATE, update.mode());
+        assertEquals(100L, update.commentId());
+        assertEquals("edited body", update.content());
+
+        assertThrows(IllegalArgumentException.class, () -> IssueCommentRequest.add(" "));
+        assertThrows(IllegalArgumentException.class, () -> IssueCommentRequest.update(100L, ""));
+    }
+
+    @Test
+    @DisplayName("validates delete comment id")
+    void validatesDeleteRequest() {
+        IssueCommentRequest request = IssueCommentRequest.delete(100L);
+
+        assertEquals(IssueCommentMode.DELETE, request.mode());
+        assertEquals(100L, request.commentId());
+        assertNull(request.content());
+
+        assertThrows(IllegalArgumentException.class, () -> IssueCommentRequest.delete(0L));
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanelTest.java
@@ -44,7 +44,7 @@ class IssueDetailPanelTest {
             IssueDetailPanel panel = panel();
             panel.showDetail(
                     detail(List.of("UPDATE_ISSUE", "ADD_COMMENT")),
-                    List.of(new IssueCommentActionState("100", true, true)));
+                    List.of(new IssueCommentActionState("100", 100L, "Confirmed in local run.", true, true)));
 
             assertEquals(
                     "[ISSUE-7] Login bug",
@@ -64,6 +64,13 @@ class IssueDetailPanelTest {
             assertEquals("100", comments.getValueAt(0, 0));
             assertEquals("Y", comments.getValueAt(0, 5));
             assertEquals("Y", comments.getValueAt(0, 6));
+            assertTrue(SwingComponentTestSupport.find(panel, "addCommentButton", JButton.class).isEnabled());
+            assertFalse(SwingComponentTestSupport.find(panel, "editCommentButton", JButton.class).isEnabled());
+            assertFalse(SwingComponentTestSupport.find(panel, "deleteCommentButton", JButton.class).isEnabled());
+
+            comments.setRowSelectionInterval(0, 0);
+            assertTrue(SwingComponentTestSupport.find(panel, "editCommentButton", JButton.class).isEnabled());
+            assertTrue(SwingComponentTestSupport.find(panel, "deleteCommentButton", JButton.class).isEnabled());
 
             JTable histories = SwingComponentTestSupport.find(panel, "issueHistoryTable", JTable.class);
             assertEquals("CREATED", histories.getValueAt(0, 1));
@@ -77,6 +84,8 @@ class IssueDetailPanelTest {
     @DisplayName("publishes available action, back, and logout callbacks")
     void publishesActions() throws Exception {
         AtomicReference<String> actionRef = new AtomicReference<>();
+        AtomicReference<IssueCommentMode> commentModeRef = new AtomicReference<>();
+        AtomicReference<IssueCommentSelection> commentSelectionRef = new AtomicReference<>();
         AtomicInteger backClicks = new AtomicInteger();
         AtomicInteger logoutClicks = new AtomicInteger();
 
@@ -85,20 +94,49 @@ class IssueDetailPanelTest {
                     userResult("dev1", Role.DEV),
                     new IssueDetailPanel.IssueDetailActions(
                             (source, action) -> actionRef.set(action),
+                            (source, mode, selection) -> {
+                                commentModeRef.set(mode);
+                                commentSelectionRef.set(selection);
+                            },
                             backClicks::incrementAndGet,
                             logoutClicks::incrementAndGet));
             panel.showDetail(
                     detail(List.of("ADD_COMMENT")),
-                    List.of(new IssueCommentActionState("100", true, true)));
+                    List.of(new IssueCommentActionState("100", 100L, "Confirmed in local run.", true, true)));
 
             SwingComponentTestSupport.find(panel, "issueActionButton_ADD_COMMENT", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "addCommentButton", JButton.class).doClick();
+            JTable comments = SwingComponentTestSupport.find(panel, "issueCommentTable", JTable.class);
+            comments.setRowSelectionInterval(0, 0);
+            SwingComponentTestSupport.find(panel, "editCommentButton", JButton.class).doClick();
             SwingComponentTestSupport.find(panel, "issueDetailBackButton", JButton.class).doClick();
             SwingComponentTestSupport.find(panel, "issueDetailLogoutButton", JButton.class).doClick();
         });
 
         assertEquals("ADD_COMMENT", actionRef.get());
+        assertEquals(IssueCommentMode.UPDATE, commentModeRef.get());
+        assertEquals(100L, commentSelectionRef.get().commentId());
+        assertEquals("Confirmed in local run.", commentSelectionRef.get().content());
         assertEquals(1, backClicks.get());
         assertEquals(1, logoutClicks.get());
+    }
+
+    @Test
+    @DisplayName("disables edit and delete for non numeric comments")
+    void disablesEditAndDeleteForNonNumericComments() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            IssueDetailPanel panel = panel();
+            panel.showDetail(
+                    detail(List.of("ADD_COMMENT")),
+                    List.of(new IssueCommentActionState("legacy-id", null, "Legacy comment", false, false)));
+
+            JTable comments = SwingComponentTestSupport.find(panel, "issueCommentTable", JTable.class);
+            comments.setRowSelectionInterval(0, 0);
+
+            assertTrue(SwingComponentTestSupport.find(panel, "addCommentButton", JButton.class).isEnabled());
+            assertFalse(SwingComponentTestSupport.find(panel, "editCommentButton", JButton.class).isEnabled());
+            assertFalse(SwingComponentTestSupport.find(panel, "deleteCommentButton", JButton.class).isEnabled());
+        });
     }
 
     @Test
@@ -108,7 +146,7 @@ class IssueDetailPanelTest {
             IssueDetailPanel panel = panel();
             panel.showDetail(
                     detail(List.of("UPDATE_ISSUE", "ADD_COMMENT")),
-                    List.of(new IssueCommentActionState("100", true, true)));
+                    List.of(new IssueCommentActionState("100", 100L, "Confirmed in local run.", true, true)));
             panel.setSize(SwingStyles.WINDOW_SIZE);
             layoutRecursively(panel);
 
@@ -122,6 +160,8 @@ class IssueDetailPanelTest {
                 userResult("dev1", Role.DEV),
                 new IssueDetailPanel.IssueDetailActions(
                         (source, action) -> {
+                        },
+                        (source, mode, selection) -> {
                         },
                         () -> {
                         },

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
@@ -35,7 +35,9 @@ import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
 import com.github.marcellokim.issuetracker.technical.SessionStore;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -64,9 +66,10 @@ class IssueDetailPresenterTest {
         assertEquals("Login bug", view.detail().title());
         assertTrue(view.detail().availableActions().contains("UPDATE_ISSUE"));
         assertTrue(view.detail().availableActions().contains("ADD_COMMENT"));
-        assertEquals(true, view.commentAction("100").canUpdate());
-        assertEquals(true, view.commentAction("100").canDelete());
-        assertEquals(false, view.commentAction("101").canUpdate());
+        assertEquals("100", view.commentAction(100L).displayCommentId());
+        assertEquals(true, view.commentAction(100L).canUpdate());
+        assertEquals(true, view.commentAction(100L).canDelete());
+        assertEquals(false, view.commentAction(101L).canUpdate());
         assertEquals(" ", view.message());
     }
 
@@ -208,6 +211,79 @@ class IssueDetailPresenterTest {
         assertEquals(assignee.getLoginId(), view.detail().assignee().loginId());
         assertEquals(nextVerifier.getLoginId(), view.detail().verifier().loginId());
         assertEquals(" ", view.message());
+    }
+
+    @Test
+    @DisplayName("adds a comment through issue controller and reloads detail")
+    void addsCommentAndReloadsDetail() {
+        User reporter = user("dev1", Role.DEV);
+        Issue issue = issue(7L, "Login bug", reporter);
+        FakeCommentRepository comments = new FakeCommentRepository();
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                controller(reporter, comments, issue),
+                view);
+
+        presenter.addComment(issue.id(), " added through swing ");
+
+        assertEquals(1, view.detail().comments().size());
+        assertEquals("added through swing", view.detail().comments().getFirst().content());
+        assertEquals(" ", view.message());
+    }
+
+    @Test
+    @DisplayName("updates a comment through issue controller and reloads detail")
+    void updatesCommentAndReloadsDetail() {
+        User reporter = user("dev1", Role.DEV);
+        Issue issue = issue(7L, "Login bug", reporter);
+        FakeCommentRepository comments = new FakeCommentRepository(
+                comment(100L, issue.id(), reporter, CommentPurpose.GENERAL));
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                controller(reporter, comments, issue),
+                view);
+
+        presenter.updateComment(issue.id(), 100L, "edited through swing");
+
+        assertEquals("edited through swing", view.detail().comments().getFirst().content());
+        assertEquals(" ", view.message());
+    }
+
+    @Test
+    @DisplayName("deletes a comment through issue controller and reloads detail")
+    void deletesCommentAndReloadsDetail() {
+        User reporter = user("dev1", Role.DEV);
+        Issue issue = issue(7L, "Login bug", reporter);
+        FakeCommentRepository comments = new FakeCommentRepository(
+                comment(100L, issue.id(), reporter, CommentPurpose.GENERAL));
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                controller(reporter, comments, issue),
+                view);
+
+        presenter.deleteComment(issue.id(), 100L);
+
+        assertTrue(view.detail().comments().isEmpty());
+        assertEquals(" ", view.message());
+    }
+
+    @Test
+    @DisplayName("shows comment action errors without replacing current detail")
+    void showsCommentActionErrorsWithoutReplacingCurrentDetail() {
+        User reporter = user("dev1", Role.DEV);
+        Issue issue = issue(7L, "Login bug", reporter);
+        FakeCommentRepository comments = new FakeCommentRepository(
+                comment(100L, issue.id(), reporter, CommentPurpose.GENERAL));
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                controller(reporter, comments, issue),
+                view);
+        presenter.loadIssue(issue.id());
+
+        presenter.deleteComment(issue.id(), 999L);
+
+        assertEquals("Comment 100", view.detail().comments().getFirst().content());
+        assertEquals("Comment not found: 999", view.message());
     }
 
     @Test
@@ -389,9 +465,9 @@ class IssueDetailPresenterTest {
             return actions;
         }
 
-        private IssueCommentActionState commentAction(String commentId) {
+        private IssueCommentActionState commentAction(long commentId) {
             return commentActions.stream()
-                    .filter(action -> action.commentId().equals(commentId))
+                    .filter(action -> action.numericCommentId() != null && action.numericCommentId() == commentId)
                     .findFirst()
                     .orElseThrow();
         }
@@ -403,29 +479,42 @@ class IssueDetailPresenterTest {
 
     private static final class FakeCommentRepository implements CommentRepository {
 
-        private final List<Comment> comments;
+        private final Map<Long, Comment> comments = new LinkedHashMap<>();
 
         private FakeCommentRepository(Comment... comments) {
-            this.comments = List.of(comments);
+            for (Comment comment : comments) {
+                this.comments.put(comment.id(), comment);
+            }
         }
 
         @Override
         public Optional<Comment> findById(long commentId) {
-            return comments.stream()
-                    .filter(comment -> comment.id() == commentId)
-                    .findFirst();
+            return Optional.ofNullable(comments.get(commentId));
         }
 
         @Override
         public List<Comment> findByIssueId(long issueId) {
-            return comments.stream()
+            return comments.values().stream()
                     .filter(comment -> comment.issueId() == issueId)
                     .toList();
         }
 
         @Override
         public Comment saveCommentAndRecordHistory(Comment comment, IssueHistory history) {
-            throw new UnsupportedOperationException("Comment writes are outside this presenter test.");
+            Comment saved = comment;
+            if (comment.id() == 0L) {
+                long nextId = comments.keySet().stream().mapToLong(Long::longValue).max().orElse(99L) + 1L;
+                saved = Comment.fromPersistence(
+                        nextId,
+                        comment.issueId(),
+                        comment.writerId(),
+                        comment.content(),
+                        comment.purpose(),
+                        comment.createdDate(),
+                        comment.updatedDate());
+            }
+            comments.put(saved.id(), saved);
+            return saved;
         }
 
         @Override
@@ -434,7 +523,7 @@ class IssueDetailPresenterTest {
                 long commentId,
                 String writerLoginId,
                 IssueHistory history) {
-            throw new UnsupportedOperationException("Comment deletes are outside this presenter test.");
+            comments.remove(commentId);
         }
     }
 

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -14,6 +14,7 @@ import com.github.marcellokim.issuetracker.controller.IssueController;
 import com.github.marcellokim.issuetracker.controller.IssueStateController;
 import com.github.marcellokim.issuetracker.controller.ProjectController;
 import com.github.marcellokim.issuetracker.domain.Comment;
+import com.github.marcellokim.issuetracker.domain.CommentPurpose;
 import com.github.marcellokim.issuetracker.domain.Issue;
 import com.github.marcellokim.issuetracker.domain.IssueHistory;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
@@ -559,7 +560,8 @@ class SwingAppPanelTest {
                         (parent, mode, options) -> Optional.of(new IssueAssignmentRequest(
                                 mode,
                                 assignee.getLoginId(),
-                                verifier.getLoginId()))),
+                                verifier.getLoginId())),
+                        IssueCommentDialogs::prompt),
                 recommendations,
                 pl,
                 assignee,
@@ -590,6 +592,86 @@ class SwingAppPanelTest {
         assertTrue(recommendations.awaitCandidateLookup());
         assertFalse(recommendations.candidateLookupOnEdt());
         awaitIssueDetailState(panel, "ASSIGNED / CRITICAL");
+    }
+
+    @Test
+    @DisplayName("issue detail comment actions add, update, cancel delete, and delete")
+    void issueDetailCommentActionsAddUpdateCancelDeleteAndDelete() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        User reporter = user("dev1", Role.DEV);
+        Issue issue = issue(7L, 7L, "Login bug", Priority.CRITICAL, reporter);
+        AtomicBoolean deleteConfirmed = new AtomicBoolean(false);
+        IssueCommentPrompt commentPrompt = (parent, mode, selection) -> switch (mode) {
+            case ADD -> Optional.of(IssueCommentRequest.add("new comment through swing"));
+            case UPDATE -> Optional.of(IssueCommentRequest.update(selection.commentId(), "edited through swing"));
+            case DELETE -> deleteConfirmed.get()
+                    ? Optional.of(IssueCommentRequest.delete(selection.commentId()))
+                    : Optional.empty();
+        };
+        SwingAppPanel panel = loginProjectUser(
+                passwordHashing,
+                titles,
+                List.of(projectSnapshot(7L, "Alpha", 3, 7)),
+                List.of(issue),
+                List.of(comment(100L, issue.id(), reporter, "original comment")),
+                IssueStatusChangeDialogs::prompt,
+                IssueAssignmentDialogs::prompt,
+                commentPrompt,
+                reporter);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable projects = SwingComponentTestSupport.find(panel, "projectListTable", JTable.class);
+            projects.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openProjectIssuesButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openProjectIssuesButton", JButton.class).doClick());
+        awaitIssueRows(panel, 1);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable issues = SwingComponentTestSupport.find(panel, "issueListTable", JTable.class);
+            issues.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openIssueDetailButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick());
+        awaitIssueDetailTitle(panel, "[ISSUE-7] Login bug");
+        awaitRows(panel, "issueCommentTable", 1);
+
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "issueActionButton_ADD_COMMENT", JButton.class).doClick());
+        awaitRows(panel, "issueCommentTable", 2);
+        awaitCommentContent(panel, 1, "new comment through swing");
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable comments = SwingComponentTestSupport.find(panel, "issueCommentTable", JTable.class);
+            comments.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "editCommentButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "editCommentButton", JButton.class).doClick());
+        awaitCommentContent(panel, 0, "edited through swing");
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable comments = SwingComponentTestSupport.find(panel, "issueCommentTable", JTable.class);
+            comments.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "deleteCommentButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "deleteCommentButton", JButton.class).doClick());
+        awaitRows(panel, "issueCommentTable", 2);
+
+        deleteConfirmed.set(true);
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable comments = SwingComponentTestSupport.find(panel, "issueCommentTable", JTable.class);
+            comments.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "deleteCommentButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "deleteCommentButton", JButton.class).doClick());
+        awaitRows(panel, "issueCommentTable", 1);
+        awaitCommentContent(panel, 0, "new comment through swing");
     }
 
     @Test
@@ -647,46 +729,15 @@ class SwingAppPanelTest {
             SwingPromptSupport prompts,
             AssignmentRecommendationRepository recommendationRepository,
             User... users) throws Exception {
-        var panelRef = new AtomicReference<SwingAppPanel>();
-        var workerDone = new CountDownLatch(1);
-        SwingControllerFixture controllers = controllers(passwordHashing, projects, issues, recommendationRepository, users);
-
-        SwingComponentTestSupport.onEdt(() -> {
-            SwingAppPanel panel = new SwingAppPanel(
-                    controllers.authenticationController(),
-                    controllers.dashboardController(),
-                    controllers.accountController(),
-                    controllers.projectController(),
-                    controllers.issueController(),
-                    new IssueActionSupport(
-                            new IssueStatusChangeSupport(controllers.issueStateController(), prompts.statusChangePrompt()),
-                            controllers.assignmentController(),
-                            prompts.assignmentPrompt()),
-                    titles::update);
-            panelRef.set(panel);
-            User user = users[0];
-            SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText(user.getLoginId());
-            SwingComponentTestSupport.find(panel, "passwordField", JPasswordField.class).setText("submitted-password");
-            SwingComponentTestSupport.find(panel, "signInButton", JButton.class).doClick();
-            SwingWorker<?, ?> worker = loginWorker(panel);
-            worker.addPropertyChangeListener(event -> {
-                if ("state".equals(event.getPropertyName())
-                        && SwingWorker.StateValue.DONE == event.getNewValue()) {
-                    workerDone.countDown();
-                }
-            });
-            if (SwingWorker.StateValue.DONE == worker.getState()) {
-                workerDone.countDown();
-            }
-        });
-
-        assertTrue(passwordHashing.awaitMatch());
-        assertTrue(titles.awaitProjectList());
-        assertTrue(workerDone.await(5, TimeUnit.SECONDS));
-        SwingAppPanel panel = panelRef.get();
-        assertNotNull(panel);
-        awaitProjectListRows(panel, projects.size());
-        return panel;
+        return loginProjectUser(
+                passwordHashing,
+                titles,
+                projects,
+                issues,
+                List.of(),
+                prompts,
+                recommendationRepository,
+                users);
     }
 
     private static SwingAppPanel loginProjectUser(
@@ -719,9 +770,91 @@ class SwingAppPanelTest {
                 titles,
                 projects,
                 issues,
-                new SwingPromptSupport(statusChangePrompt, assignmentPrompt),
+                List.of(),
+                new SwingPromptSupport(statusChangePrompt, assignmentPrompt, IssueCommentDialogs::prompt),
                 new InMemoryAssignmentRecommendationRepository(users),
                 users);
+    }
+
+    private static SwingAppPanel loginProjectUser(
+            RecordingPasswordHashing passwordHashing,
+            RecordingTitleUpdater titles,
+            List<DashboardProjectSnapshot> projects,
+            List<Issue> issues,
+            List<Comment> comments,
+            IssueStatusChangePrompt statusChangePrompt,
+            IssueAssignmentPrompt assignmentPrompt,
+            IssueCommentPrompt commentPrompt,
+            User... users) throws Exception {
+        return loginProjectUser(
+                passwordHashing,
+                titles,
+                projects,
+                issues,
+                comments,
+                new SwingPromptSupport(statusChangePrompt, assignmentPrompt, commentPrompt),
+                new InMemoryAssignmentRecommendationRepository(users),
+                users);
+    }
+
+    private static SwingAppPanel loginProjectUser(
+            RecordingPasswordHashing passwordHashing,
+            RecordingTitleUpdater titles,
+            List<DashboardProjectSnapshot> projects,
+            List<Issue> issues,
+            List<Comment> comments,
+            SwingPromptSupport prompts,
+            AssignmentRecommendationRepository recommendationRepository,
+            User... users) throws Exception {
+        var panelRef = new AtomicReference<SwingAppPanel>();
+        var workerDone = new CountDownLatch(1);
+        SwingControllerFixture controllers = controllers(
+                passwordHashing,
+                projects,
+                issues,
+                comments,
+                recommendationRepository,
+                users);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            SwingAppPanel panel = new SwingAppPanel(
+                    controllers.authenticationController(),
+                    controllers.dashboardController(),
+                    controllers.accountController(),
+                    controllers.projectController(),
+                    controllers.issueController(),
+                    new IssueActionSupport(
+                            new IssueStatusChangeSupport(
+                                    controllers.issueStateController(),
+                                    prompts.statusChangePrompt()),
+                            controllers.assignmentController(),
+                            prompts.assignmentPrompt(),
+                            prompts.commentPrompt()),
+                    titles::update);
+            panelRef.set(panel);
+            User user = users[0];
+            SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class).setText(user.getLoginId());
+            SwingComponentTestSupport.find(panel, "passwordField", JPasswordField.class).setText("submitted-password");
+            SwingComponentTestSupport.find(panel, "signInButton", JButton.class).doClick();
+            SwingWorker<?, ?> worker = loginWorker(panel);
+            worker.addPropertyChangeListener(event -> {
+                if ("state".equals(event.getPropertyName())
+                        && SwingWorker.StateValue.DONE == event.getNewValue()) {
+                    workerDone.countDown();
+                }
+            });
+            if (SwingWorker.StateValue.DONE == worker.getState()) {
+                workerDone.countDown();
+            }
+        });
+
+        assertTrue(passwordHashing.awaitMatch());
+        assertTrue(titles.awaitProjectList());
+        assertTrue(workerDone.await(5, TimeUnit.SECONDS));
+        SwingAppPanel panel = panelRef.get();
+        assertNotNull(panel);
+        awaitProjectListRows(panel, projects.size());
+        return panel;
     }
 
     private static SwingWorker<?, ?> loginWorker(SwingAppPanel panel) throws ReflectiveOperationException {
@@ -853,6 +986,39 @@ class SwingAppPanelTest {
         });
     }
 
+    private static void awaitCommentContent(SwingAppPanel panel, int row, String expectedContent) throws Exception {
+        CountDownLatch contentReady = new CountDownLatch(1);
+        AtomicReference<Timer> timerRef = new AtomicReference<>();
+        SwingComponentTestSupport.onEdt(() -> {
+            Timer timer = new Timer(25, event -> {
+                try {
+                    JTable comments = SwingComponentTestSupport.find(panel, "issueCommentTable", JTable.class);
+                    if (row < comments.getRowCount() && expectedContent.equals(comments.getValueAt(row, 3))) {
+                        ((Timer) event.getSource()).stop();
+                        contentReady.countDown();
+                    }
+                } catch (AssertionError ignored) {
+                    // Comment table reloads asynchronously after comment actions.
+                }
+            });
+            timer.setRepeats(true);
+            timerRef.set(timer);
+            timer.start();
+        });
+
+        boolean ready = contentReady.await(5, TimeUnit.SECONDS);
+        SwingComponentTestSupport.onEdt(() -> {
+            Timer timer = timerRef.get();
+            if (timer != null) {
+                timer.stop();
+            }
+            if (!ready) {
+                JTable comments = SwingComponentTestSupport.find(panel, "issueCommentTable", JTable.class);
+                assertEquals(expectedContent, comments.getValueAt(row, 3));
+            }
+        });
+    }
+
     private static void awaitButtonEnabled(SwingAppPanel panel, String buttonName) throws Exception {
         CountDownLatch enabled = new CountDownLatch(1);
         AtomicReference<Timer> timerRef = new AtomicReference<>();
@@ -931,6 +1097,7 @@ class SwingAppPanelTest {
                 passwordHashing,
                 projects,
                 issues,
+                List.of(),
                 new InMemoryAssignmentRecommendationRepository(users),
                 users);
     }
@@ -939,6 +1106,7 @@ class SwingAppPanelTest {
             PasswordHashing passwordHashing,
             List<DashboardProjectSnapshot> projects,
             List<Issue> issues,
+            List<Comment> comments,
             AssignmentRecommendationRepository recommendationRepository,
             User... users) {
         var repository = new InMemoryUserRepository(users);
@@ -959,7 +1127,7 @@ class SwingAppPanelTest {
         });
         var issueRepository = new InMemoryIssueRepository(issues.toArray(Issue[]::new));
         var dependencyRepository = new FakeIssueDependencyRepository();
-        var commentRepository = new FakeCommentRepository();
+        var commentRepository = new FakeCommentRepository(comments);
         var historyRepository = new FakeIssueHistoryRepository();
         var service = new AuthenticationService(repository, passwordHashing, new SessionStore());
         PermissionPolicy permissionPolicy = new PermissionPolicy();
@@ -1076,6 +1244,10 @@ class SwingAppPanelTest {
                 .updatedAt(NOW));
     }
 
+    private static Comment comment(long id, long issueId, User writer, String content) {
+        return Comment.fromPersistence(id, issueId, writer.getLoginId(), content, CommentPurpose.GENERAL, NOW, NOW);
+    }
+
     private record SwingControllerFixture(
             AuthenticationController authenticationController,
             DashboardController dashboardController,
@@ -1088,24 +1260,51 @@ class SwingAppPanelTest {
 
     private record SwingPromptSupport(
             IssueStatusChangePrompt statusChangePrompt,
-            IssueAssignmentPrompt assignmentPrompt) {
+            IssueAssignmentPrompt assignmentPrompt,
+            IssueCommentPrompt commentPrompt) {
     }
 
     private static final class FakeCommentRepository implements CommentRepository {
 
+        private final Map<Long, Comment> comments = new java.util.LinkedHashMap<>();
+
+        private FakeCommentRepository() {
+        }
+
+        private FakeCommentRepository(List<Comment> comments) {
+            for (Comment comment : comments) {
+                this.comments.put(comment.id(), comment);
+            }
+        }
+
         @Override
         public Optional<Comment> findById(long commentId) {
-            return Optional.empty();
+            return Optional.ofNullable(comments.get(commentId));
         }
 
         @Override
         public List<Comment> findByIssueId(long issueId) {
-            return List.of();
+            return comments.values().stream()
+                    .filter(comment -> comment.issueId() == issueId)
+                    .toList();
         }
 
         @Override
         public Comment saveCommentAndRecordHistory(Comment comment, IssueHistory history) {
-            return comment;
+            Comment saved = comment;
+            if (comment.id() == 0L) {
+                long nextId = comments.keySet().stream().mapToLong(Long::longValue).max().orElse(99L) + 1L;
+                saved = Comment.fromPersistence(
+                        nextId,
+                        comment.issueId(),
+                        comment.writerId(),
+                        comment.content(),
+                        comment.purpose(),
+                        comment.createdDate(),
+                        comment.updatedDate());
+            }
+            comments.put(saved.id(), saved);
+            return saved;
         }
 
         @Override
@@ -1114,7 +1313,7 @@ class SwingAppPanelTest {
                 long commentId,
                 String writerLoginId,
                 IssueHistory history) {
-            // Comment deletion is outside the app navigation scenarios covered by this fake.
+            comments.remove(commentId);
         }
     }
 


### PR DESCRIPTION
## purpose
Swing 전체 UI에서 이슈 코멘트 추가, 수정, 삭제 흐름을 연결합니다.

Closes #212

## non-goals
- comment ownership, role, status 정책은 Swing에서 재구현하지 않습니다.
- service/repository/domain/JavaFX 구현은 변경하지 않습니다.
- dependency, edit/delete issue, deleted issue, statistics 화면은 후속 PR에서 다룹니다.

## diff map
- 핵심 변경: `IssueComment*` dialog/request/prompt/selection 추가
- 화면 변경: issue detail comment section에 Add/Edit/Delete toolbar 추가
- 정책 연결: `IssueDetailPresenter`가 `viewCommentActions` 결과를 comment action state로 전달
- 실행 흐름: `IssueController.addComment`, `updateComment`, `deleteComment` 호출 후 상세 reload
- 테스트: request validation, dialog snapshot, panel button state/callback, presenter add/update/delete, app 통합 흐름 추가

## verification evidence
- `git diff --check origin/dev...HEAD && git diff --check`
- `./gradlew test --tests '*IssueComment*' --tests '*IssueDetailPresenterTest*' --tests '*SwingAppPanelTest*' --console=plain`
- `./gradlew check --console=plain`
- pre-push `test + verifyRepositorySetup`
- screenshot: `build/reports/ui/issue-comment-dialog.png`
- screenshot: `build/reports/ui/issue-detail-panel.png`

## reviewer focus areas
- comment 수정/삭제 enable 기준이 Swing 직접 판단이 아니라 controller-derived `viewCommentActions` 결과인지
- 실행용 comment id가 표시 문자열과 분리되어 `Long numericCommentId`로 흐르는지
- add/edit/delete 후 상세 reload로 comment 목록과 permission 상태가 다시 계산되는지
- 검증 실패 시 comment dialog가 입력값을 유지하고 재입력을 받는지

## risk / rollback
- 이 PR은 Swing issue detail의 comment action wiring에 한정됩니다.
- 문제가 있으면 이 PR만 되돌려도 이전 issue detail, status change, assignment 흐름은 유지됩니다.