### PR TITLE
feat: Swing 이슈 dependency action 구현

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentIssueDetailView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentIssueDetailView.java
@@ -1,5 +1,6 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
+import com.github.marcellokim.issuetracker.service.DependencyResult;
 import com.github.marcellokim.issuetracker.service.IssueDetailResult;
 import com.github.marcellokim.issuetracker.service.IssueWorkflowActions;
 import java.util.List;
@@ -21,8 +22,11 @@ final class CurrentIssueDetailView implements IssueDetailView {
     }
 
     @Override
-    public void showDetail(IssueDetailResult detail, List<IssueCommentActionState> commentActions) {
-        gate.update(() -> delegate.showDetail(detail, commentActions));
+    public void showDetail(
+            IssueDetailResult detail,
+            List<IssueCommentActionState> commentActions,
+            List<DependencyResult> projectDependencies) {
+        gate.update(() -> delegate.showDetail(detail, commentActions, projectDependencies));
     }
 
     @Override

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueActionSupport.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueActionSupport.java
@@ -8,12 +8,14 @@ record IssueActionSupport(
         IssueStatusChangeSupport statusChange,
         AssignmentController assignmentController,
         IssueAssignmentPrompt assignmentPrompt,
-        IssueCommentPrompt commentPrompt) {
+        IssueCommentPrompt commentPrompt,
+        IssueDependencyPrompt dependencyPrompt) {
 
     IssueActionSupport {
         Objects.requireNonNull(statusChange, "statusChange");
         Objects.requireNonNull(assignmentPrompt, "assignmentPrompt");
         Objects.requireNonNull(commentPrompt, "commentPrompt");
+        Objects.requireNonNull(dependencyPrompt, "dependencyPrompt");
     }
 
     static IssueActionSupport disabled() {
@@ -21,7 +23,8 @@ record IssueActionSupport(
                 IssueStatusChangeSupport.disabled(),
                 null,
                 IssueAssignmentDialogs::prompt,
-                IssueCommentDialogs::prompt);
+                IssueCommentDialogs::prompt,
+                IssueDependencyDialogs::prompt);
     }
 
     static IssueActionSupport dialogs(
@@ -31,6 +34,7 @@ record IssueActionSupport(
                 IssueStatusChangeSupport.dialog(issueStateController),
                 assignmentController,
                 IssueAssignmentDialogs::prompt,
-                IssueCommentDialogs::prompt);
+                IssueCommentDialogs::prompt,
+                IssueDependencyDialogs::prompt);
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDependencyDialogs.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDependencyDialogs.java
@@ -1,0 +1,128 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.util.Optional;
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+
+final class IssueDependencyDialogs {
+
+    private static final int FIELD_WIDTH = 220;
+    private static final String ADD_DEPENDENCY_TITLE = "Add dependency";
+
+    private IssueDependencyDialogs() {
+    }
+
+    static Optional<IssueDependencyRequest> prompt(
+            Component parent,
+            IssueDependencyMode mode,
+            IssueDependencySelection selection,
+            long defaultBlockedIssueId) {
+        return switch (mode) {
+            case ADD -> promptAdd(parent, defaultBlockedIssueId);
+            case REMOVE -> confirmRemove(parent, requireSelection(selection));
+        };
+    }
+
+    static DependencyForm form(long defaultBlockingIssueId, long defaultBlockedIssueId) {
+        JTextField blockingIssueField = new JTextField(defaultValue(defaultBlockingIssueId));
+        blockingIssueField.setName("dependencyBlockingIssueField");
+        JTextField blockedIssueField = new JTextField(defaultValue(defaultBlockedIssueId));
+        blockedIssueField.setName("dependencyBlockedIssueField");
+
+        JLabel title = new JLabel(ADD_DEPENDENCY_TITLE);
+        title.setName("dependencyDialogTitle");
+
+        JPanel fields = SwingPanelSections.formPanel(
+                FIELD_WIDTH,
+                new JLabel("Blocking issue ID"),
+                blockingIssueField,
+                new JLabel("Blocked issue ID"),
+                blockedIssueField);
+        JPanel panel = new JPanel(new BorderLayout(SwingStyles.ROW_GAP, SwingStyles.ROW_GAP));
+        panel.setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP));
+        panel.add(title, BorderLayout.NORTH);
+        panel.add(fields, BorderLayout.CENTER);
+        return new DependencyForm(panel, blockingIssueField, blockedIssueField);
+    }
+
+    private static Optional<IssueDependencyRequest> promptAdd(Component parent, long defaultBlockedIssueId) {
+        DependencyForm form = form(0L, defaultBlockedIssueId);
+        while (true) {
+            int result = JOptionPane.showConfirmDialog(
+                    parent,
+                    form.panel(),
+                    ADD_DEPENDENCY_TITLE,
+                    JOptionPane.OK_CANCEL_OPTION,
+                    JOptionPane.PLAIN_MESSAGE);
+            if (result != JOptionPane.OK_OPTION) {
+                return Optional.empty();
+            }
+            try {
+                long blockingIssueId = parseIssueId(form.blockingIssueField().getText(), "blockingIssueId");
+                long blockedIssueId = parseIssueId(form.blockedIssueField().getText(), "blockedIssueId");
+                return Optional.of(IssueDependencyRequest.add(blockingIssueId, blockedIssueId));
+            } catch (IllegalArgumentException exception) {
+                JOptionPane.showMessageDialog(
+                        parent,
+                        exception.getMessage(),
+                        ADD_DEPENDENCY_TITLE,
+                        JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private static Optional<IssueDependencyRequest> confirmRemove(
+            Component parent,
+            IssueDependencySelection selection) {
+        int result = JOptionPane.showConfirmDialog(
+                parent,
+                "Remove selected dependency?",
+                "Remove dependency",
+                JOptionPane.OK_CANCEL_OPTION,
+                JOptionPane.WARNING_MESSAGE);
+        if (result != JOptionPane.OK_OPTION) {
+            return Optional.empty();
+        }
+        return Optional.of(IssueDependencyRequest.remove(
+                selection.blockingIssueId(),
+                selection.blockedIssueId()));
+    }
+
+    private static IssueDependencySelection requireSelection(IssueDependencySelection selection) {
+        if (selection == null) {
+            throw new IllegalArgumentException("dependency selection is required");
+        }
+        return selection;
+    }
+
+    private static long parseIssueId(String text, String fieldName) {
+        try {
+            long value = Long.parseLong(text == null ? "" : text.trim());
+            if (value <= 0L) {
+                throw new IllegalArgumentException(fieldName + " must be a positive number");
+            }
+            return value;
+        } catch (NumberFormatException exception) {
+            throw new IllegalArgumentException(fieldName + " must be a positive number", exception);
+        }
+    }
+
+    private static String defaultValue(long value) {
+        return value > 0L ? Long.toString(value) : "";
+    }
+
+    record DependencyForm(
+            JPanel panel,
+            JTextField blockingIssueField,
+            JTextField blockedIssueField) {
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDependencyMode.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDependencyMode.java
@@ -1,0 +1,6 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+enum IssueDependencyMode {
+    ADD,
+    REMOVE
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDependencyPrompt.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDependencyPrompt.java
@@ -1,0 +1,14 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.awt.Component;
+import java.util.Optional;
+
+@FunctionalInterface
+interface IssueDependencyPrompt {
+
+    Optional<IssueDependencyRequest> prompt(
+            Component parent,
+            IssueDependencyMode mode,
+            IssueDependencySelection selection,
+            long defaultBlockedIssueId);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDependencyRequest.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDependencyRequest.java
@@ -1,0 +1,24 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.util.Objects;
+
+record IssueDependencyRequest(IssueDependencyMode mode, long blockingIssueId, long blockedIssueId) {
+
+    IssueDependencyRequest {
+        Objects.requireNonNull(mode, "mode");
+        if (blockingIssueId <= 0L) {
+            throw new IllegalArgumentException("blockingIssueId must be positive");
+        }
+        if (blockedIssueId <= 0L) {
+            throw new IllegalArgumentException("blockedIssueId must be positive");
+        }
+    }
+
+    static IssueDependencyRequest add(long blockingIssueId, long blockedIssueId) {
+        return new IssueDependencyRequest(IssueDependencyMode.ADD, blockingIssueId, blockedIssueId);
+    }
+
+    static IssueDependencyRequest remove(long blockingIssueId, long blockedIssueId) {
+        return new IssueDependencyRequest(IssueDependencyMode.REMOVE, blockingIssueId, blockedIssueId);
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDependencySelection.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDependencySelection.java
@@ -1,0 +1,13 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+record IssueDependencySelection(long blockingIssueId, long blockedIssueId) {
+
+    IssueDependencySelection {
+        if (blockingIssueId <= 0L) {
+            throw new IllegalArgumentException("blockingIssueId must be positive");
+        }
+        if (blockedIssueId <= 0L) {
+            throw new IllegalArgumentException("blockedIssueId must be positive");
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
@@ -38,12 +38,14 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
     private static final long serialVersionUID = 1L;
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
     private static final String DEFAULT_ERROR_MESSAGE = "Issue detail failed. Please try again.";
+    private static final String ADD_DEPENDENCY_ACTION = "ADD_DEPENDENCY";
+    private static final String REMOVE_DEPENDENCY_ACTION = "REMOVE_DEPENDENCY";
     private static final Color SELECTION_BACKGROUND = new Color(219, 234, 254);
     private static final int SUMMARY_SECTION_HEIGHT = 168;
     private static final int ACTION_SECTION_HEIGHT = 150;
     private static final int COMMENT_SECTION_HEIGHT = 220;
     private static final int HISTORY_SECTION_HEIGHT = 170;
-    private static final int DEPENDENCY_SECTION_HEIGHT = 150;
+    private static final int DEPENDENCY_SECTION_HEIGHT = 180;
     private static final String[] COMMENT_COLUMNS = {
             "ID", "Purpose", "Writer", "Content", "Updated", "Edit", "Delete"
     };
@@ -65,8 +67,8 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
             new ActionSpec("CHANGE_TESTER", "Change tester"),
             new ActionSpec("UPDATE_ISSUE", "Edit issue"),
             new ActionSpec("CHANGE_PRIORITY", "Change priority"),
-            new ActionSpec("ADD_DEPENDENCY", "Add dependency"),
-            new ActionSpec("REMOVE_DEPENDENCY", "Remove dependency"),
+            new ActionSpec(ADD_DEPENDENCY_ACTION, "Add dependency"),
+            new ActionSpec(REMOVE_DEPENDENCY_ACTION, "Remove dependency"),
             new ActionSpec("ADD_COMMENT", "Add comment"),
             new ActionSpec("SOFT_DELETE", "Delete issue"));
 
@@ -90,10 +92,13 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
     private final JButton addCommentButton = new JButton("Add comment");
     private final JButton editCommentButton = new JButton("Edit selected");
     private final JButton deleteCommentButton = new JButton("Delete selected");
+    private final JButton addDependencyButton = new JButton("Add dependency");
+    private final JButton removeDependencyButton = new JButton("Remove selected");
     private final Map<String, JButton> actionButtons = new LinkedHashMap<>();
     private boolean busy;
     private Set<String> availableActions = Set.of();
     private transient List<IssueCommentActionState> commentActionStates = List.of();
+    private transient List<DependencyResult> dependencyActionStates = List.of();
 
     IssueDetailPanel(UserResult user, IssueDetailActions actions) {
         Objects.requireNonNull(user, "user");
@@ -112,13 +117,18 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         add(header(), BorderLayout.NORTH);
         add(content(), BorderLayout.CENTER);
         configureCommentActions();
+        configureDependencyActions();
         updateActionButtons();
     }
 
     @Override
-    public void showDetail(IssueDetailResult detail, List<IssueCommentActionState> commentActions) {
+    public void showDetail(
+            IssueDetailResult detail,
+            List<IssueCommentActionState> commentActions,
+            List<DependencyResult> projectDependencies) {
         Objects.requireNonNull(detail, "detail");
         Objects.requireNonNull(commentActions, "commentActions");
+        Objects.requireNonNull(projectDependencies, "projectDependencies");
         Map<String, IssueCommentActionState> commentActionById = commentActionById(commentActions);
         runOnEdt(() -> {
             titleLabel.setText("[" + detail.issueId() + "] " + detail.title());
@@ -131,12 +141,15 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
             resolverLabel.setText("Resolver: " + formatUser(detail.resolver()));
             availableActions = Set.copyOf(detail.availableActions());
             commentActionStates = List.copyOf(commentActions);
+            dependencyActionStates = List.copyOf(projectDependencies);
             replaceRows(commentTableModel, commentRows(detail.comments(), commentActionById));
             commentTable.clearSelection();
             replaceRows(historyTableModel, historyRows(detail.histories()));
-            replaceRows(dependencyTableModel, dependencyRows(detail.dependencies()));
+            replaceRows(dependencyTableModel, dependencyRows(projectDependencies));
+            dependencyTable.clearSelection();
             updateActionButtons();
             updateCommentButtons();
+            updateDependencyButtons();
         });
     }
 
@@ -146,6 +159,7 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         runOnEdt(() -> {
             availableActions = Set.copyOf(actions.availableActionNames());
             updateActionButtons();
+            updateDependencyButtons();
         });
     }
 
@@ -166,6 +180,7 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
             dependencyTable.setEnabled(!busy);
             updateActionButtons();
             updateCommentButtons();
+            updateDependencyButtons();
         });
     }
 
@@ -199,9 +214,7 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         content.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
         content.add(constrainedSection(SwingPanelSections.tableSection("History", historyTable), HISTORY_SECTION_HEIGHT));
         content.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
-        content.add(constrainedSection(
-                SwingPanelSections.tableSection("Dependencies", dependencyTable),
-                DEPENDENCY_SECTION_HEIGHT));
+        content.add(constrainedSection(dependencySection(), DEPENDENCY_SECTION_HEIGHT));
 
         return SwingPanelSections.verticalScrollPanel(content);
     }
@@ -240,10 +253,7 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         for (ActionSpec spec : ACTION_SPECS) {
             JButton button = new JButton(spec.label());
             button.setName("issueActionButton_" + spec.action());
-            button.addActionListener(event ->
-                    actions.onAction().accept(this, IssueAssignmentActions.effectiveAction(
-                            spec.action(),
-                            availableActions)));
+            button.addActionListener(event -> publishAction(spec.action()));
             actionButtons.put(spec.action(), button);
             buttons.add(button);
         }
@@ -279,6 +289,32 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         return section;
     }
 
+    private JPanel dependencySection() {
+        JPanel section = new JPanel(new BorderLayout(0, SwingStyles.ROW_GAP));
+        section.setBackground(SwingStyles.SURFACE);
+        section.setBorder(SwingStyles.surfaceBorder());
+
+        JPanel header = new JPanel(new BorderLayout(SwingStyles.ROW_GAP, 0));
+        header.setOpaque(false);
+        JLabel title = new JLabel("Dependencies");
+        SwingStyles.applySectionTitle(title);
+        header.add(title, BorderLayout.WEST);
+
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT, SwingStyles.ROW_GAP, 0));
+        buttons.setOpaque(false);
+        addDependencyButton.setName("addDependencyButton");
+        removeDependencyButton.setName("removeDependencyButton");
+        buttons.add(addDependencyButton);
+        buttons.add(removeDependencyButton);
+        header.add(buttons, BorderLayout.EAST);
+
+        JScrollPane scrollPane = new JScrollPane(dependencyTable);
+        scrollPane.setColumnHeaderView(dependencyTable.getTableHeader());
+        section.add(header, BorderLayout.NORTH);
+        section.add(scrollPane, BorderLayout.CENTER);
+        return section;
+    }
+
     private static JPanel constrainedSection(JPanel section, int height) {
         Dimension size = new Dimension(SwingStyles.WINDOW_SIZE.width - SwingStyles.OUTER_PADDING * 2, height);
         section.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -305,8 +341,30 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
 
     private void updateActionButtons() {
         boolean enabled = !busy;
-        actionButtons.forEach((action, button) -> button.setEnabled(enabled && availableActions.contains(action)));
+        actionButtons.forEach((action, button) -> {
+            boolean canRun = availableActions.contains(action);
+            if (REMOVE_DEPENDENCY_ACTION.equals(action)) {
+                canRun = canRun && selectedDependency().isPresent();
+            }
+            button.setEnabled(enabled && canRun);
+        });
         addCommentButton.setEnabled(enabled && availableActions.contains("ADD_COMMENT"));
+        addDependencyButton.setEnabled(enabled && availableActions.contains(ADD_DEPENDENCY_ACTION));
+    }
+
+    private void publishAction(String action) {
+        if (ADD_DEPENDENCY_ACTION.equals(action)) {
+            actions.onDependencyAction().accept(this, IssueDependencyMode.ADD, null);
+            return;
+        }
+        if (REMOVE_DEPENDENCY_ACTION.equals(action)) {
+            selectedDependency().ifPresent(selection -> actions.onDependencyAction().accept(
+                    this,
+                    IssueDependencyMode.REMOVE,
+                    selection));
+            return;
+        }
+        actions.onAction().accept(this, IssueAssignmentActions.effectiveAction(action, availableActions));
     }
 
     private void configureCommentActions() {
@@ -324,6 +382,24 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         deleteCommentButton.addActionListener(event -> selectedComment()
                 .ifPresent(selection -> actions.onCommentAction().accept(this, IssueCommentMode.DELETE, selection)));
         updateCommentButtons();
+    }
+
+    private void configureDependencyActions() {
+        dependencyTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        setColumnWidths(dependencyTable, 64, 160, 120, 120, 132);
+        dependencyTable.getSelectionModel().addListSelectionListener(event -> {
+            if (!event.getValueIsAdjusting()) {
+                updateDependencyButtons();
+            }
+        });
+        addDependencyButton.addActionListener(event ->
+                actions.onDependencyAction().accept(this, IssueDependencyMode.ADD, null));
+        removeDependencyButton.addActionListener(event -> selectedDependency()
+                .ifPresent(selection -> actions.onDependencyAction().accept(
+                        this,
+                        IssueDependencyMode.REMOVE,
+                        selection)));
+        updateDependencyButtons();
     }
 
     private static void setColumnWidths(JTable table, int... widths) {
@@ -354,6 +430,30 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
             return Optional.empty();
         }
         return Optional.of(commentActionStates.get(modelRow));
+    }
+
+    private void updateDependencyButtons() {
+        boolean enabled = !busy && availableActions.contains(REMOVE_DEPENDENCY_ACTION) && selectedDependency().isPresent();
+        removeDependencyButton.setEnabled(enabled);
+        JButton removeActionButton = actionButtons.get(REMOVE_DEPENDENCY_ACTION);
+        if (removeActionButton != null) {
+            removeActionButton.setEnabled(enabled);
+        }
+    }
+
+    private Optional<IssueDependencySelection> selectedDependency() {
+        int selectedRow = dependencyTable.getSelectedRow();
+        if (selectedRow < 0 || selectedRow >= dependencyTable.getRowCount()) {
+            return Optional.empty();
+        }
+        int modelRow = dependencyTable.convertRowIndexToModel(selectedRow);
+        if (modelRow < 0 || modelRow >= dependencyActionStates.size()) {
+            return Optional.empty();
+        }
+        DependencyResult dependency = dependencyActionStates.get(modelRow);
+        return Optional.of(new IssueDependencySelection(
+                dependency.blockingIssueId(),
+                dependency.blockedIssueId()));
     }
 
     private static Map<String, IssueCommentActionState> commentActionById(
@@ -459,20 +559,38 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         void accept(IssueDetailPanel panel, IssueCommentMode mode, IssueCommentSelection selection);
     }
 
+    @FunctionalInterface
+    interface PanelDependencyConsumer {
+
+        void accept(IssueDetailPanel panel, IssueDependencyMode mode, IssueDependencySelection selection);
+    }
+
     record IssueDetailActions(
             PanelStringConsumer onAction,
             PanelCommentConsumer onCommentAction,
+            PanelDependencyConsumer onDependencyAction,
             Runnable onBack,
             Runnable onLogout) {
 
         IssueDetailActions(PanelStringConsumer onAction, Runnable onBack, Runnable onLogout) {
             this(onAction, (panel, mode, selection) -> {
+            }, (panel, mode, selection) -> {
+            }, onBack, onLogout);
+        }
+
+        IssueDetailActions(
+                PanelStringConsumer onAction,
+                PanelCommentConsumer onCommentAction,
+                Runnable onBack,
+                Runnable onLogout) {
+            this(onAction, onCommentAction, (panel, mode, selection) -> {
             }, onBack, onLogout);
         }
 
         IssueDetailActions {
             Objects.requireNonNull(onAction, "onAction");
             Objects.requireNonNull(onCommentAction, "onCommentAction");
+            Objects.requireNonNull(onDependencyAction, "onDependencyAction");
             Objects.requireNonNull(onBack, "onBack");
             Objects.requireNonNull(onLogout, "onLogout");
         }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenter.java
@@ -6,6 +6,7 @@ import com.github.marcellokim.issuetracker.controller.IssueStateController;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.service.CommentActionResult;
 import com.github.marcellokim.issuetracker.service.CommentResult;
+import com.github.marcellokim.issuetracker.service.DependencyResult;
 import com.github.marcellokim.issuetracker.service.IssueDetailResult;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -13,6 +14,8 @@ import java.util.Map;
 import java.util.Objects;
 
 final class IssueDetailPresenter {
+
+    private static final String REQUEST_PARAM = "request";
 
     private final IssueController issueController;
     private final IssueStateController issueStateController;
@@ -44,7 +47,9 @@ final class IssueDetailPresenter {
     void loadIssue(long issueId) {
         try {
             IssueDetailResult detail = issueController.viewIssueDetail(issueId);
-            view.showDetail(detail, commentActions(issueId, detail.comments()));
+            List<DependencyResult> projectDependencies =
+                    issueController.viewProjectDependencies(detail.projectId());
+            view.showDetail(detail, commentActions(issueId, detail.comments()), projectDependencies);
             view.showMessage(" ", false);
         } catch (RuntimeException exception) {
             view.showMessage(exception.getMessage(), true);
@@ -71,7 +76,7 @@ final class IssueDetailPresenter {
 
     void changeAssignment(long issueId, IssueAssignmentRequest request) {
         try {
-            IssueAssignmentRequest requiredRequest = Objects.requireNonNull(request, "request");
+            IssueAssignmentRequest requiredRequest = Objects.requireNonNull(request, REQUEST_PARAM);
             switch (requiredRequest.mode()) {
                 case ASSIGN -> requireAssignmentController().assignIssue(
                         issueId,
@@ -91,11 +96,25 @@ final class IssueDetailPresenter {
     }
 
     void changeComment(long issueId, IssueCommentRequest request) {
-        IssueCommentRequest requiredRequest = Objects.requireNonNull(request, "request");
+        IssueCommentRequest requiredRequest = Objects.requireNonNull(request, REQUEST_PARAM);
         switch (requiredRequest.mode()) {
             case ADD -> addComment(issueId, requiredRequest.content());
             case UPDATE -> updateComment(issueId, requiredRequest.commentId(), requiredRequest.content());
             case DELETE -> deleteComment(issueId, requiredRequest.commentId());
+        }
+    }
+
+    void changeDependency(long issueId, IssueDependencyRequest request) {
+        IssueDependencyRequest requiredRequest = Objects.requireNonNull(request, REQUEST_PARAM);
+        switch (requiredRequest.mode()) {
+            case ADD -> addDependency(
+                    issueId,
+                    requiredRequest.blockingIssueId(),
+                    requiredRequest.blockedIssueId());
+            case REMOVE -> removeDependency(
+                    issueId,
+                    requiredRequest.blockingIssueId(),
+                    requiredRequest.blockedIssueId());
         }
     }
 
@@ -120,6 +139,24 @@ final class IssueDetailPresenter {
     void deleteComment(long issueId, long commentId) {
         try {
             issueController.deleteComment(issueId, commentId);
+            loadIssue(issueId);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    void addDependency(long issueId, long blockingIssueId, long blockedIssueId) {
+        try {
+            issueController.addDependency(blockingIssueId, blockedIssueId);
+            loadIssue(issueId);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    void removeDependency(long issueId, long blockingIssueId, long blockedIssueId) {
+        try {
+            issueController.removeDependency(blockingIssueId, blockedIssueId);
             loadIssue(issueId);
         } catch (RuntimeException exception) {
             view.showMessage(exception.getMessage(), true);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailView.java
@@ -1,12 +1,16 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
+import com.github.marcellokim.issuetracker.service.DependencyResult;
 import com.github.marcellokim.issuetracker.service.IssueDetailResult;
 import com.github.marcellokim.issuetracker.service.IssueWorkflowActions;
 import java.util.List;
 
 interface IssueDetailView {
 
-    void showDetail(IssueDetailResult detail, List<IssueCommentActionState> commentActions);
+    void showDetail(
+            IssueDetailResult detail,
+            List<IssueCommentActionState> commentActions,
+            List<DependencyResult> projectDependencies);
 
     void showActions(IssueWorkflowActions actions);
 

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -388,6 +388,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
                     new IssueDetailPanel.IssueDetailActions(
                             (panelRef, action) -> showIssueAction(user, projectId, issueId, panelRef, action),
                             (panelRef, mode, selection) -> showIssueComment(issueId, panelRef, mode, selection),
+                            (panelRef, mode, selection) -> showIssueDependency(issueId, panelRef, mode, selection),
                             () -> showIssueList(user, projectId),
                             this::logout));
             projectListCard.removeAll();
@@ -425,6 +426,10 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             showIssueComment(issueId, panel, IssueCommentMode.ADD, null);
             return;
         }
+        if ("ADD_DEPENDENCY".equals(action)) {
+            showIssueDependency(issueId, panel, IssueDependencyMode.ADD, null);
+            return;
+        }
         SwingUtilities.invokeLater(() -> {
             cancelDashboardWorker();
             cancelAccountWorker();
@@ -453,6 +458,21 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
                     .ifPresent(request -> startIssueDetailTask(
                             panel,
                             presenter -> presenter.changeComment(issueId, request)));
+        } catch (RuntimeException exception) {
+            panel.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    private void showIssueDependency(
+            long issueId,
+            IssueDetailPanel panel,
+            IssueDependencyMode mode,
+            IssueDependencySelection selection) {
+        try {
+            issueActionSupport.dependencyPrompt().prompt(panel, mode, selection, issueId)
+                    .ifPresent(request -> startIssueDetailTask(
+                            panel,
+                            presenter -> presenter.changeDependency(issueId, request)));
         } catch (RuntimeException exception) {
             panel.showMessage(exception.getMessage(), true);
         }

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDependencyDialogsTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDependencyDialogsTest.java
@@ -1,0 +1,84 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.imageio.ImageIO;
+import javax.swing.JLabel;
+import javax.swing.JTextField;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing issue dependency dialogs")
+class IssueDependencyDialogsTest {
+
+    @Test
+    @DisplayName("renders dependency add form snapshot")
+    void rendersDependencyAddFormSnapshot() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            IssueDependencyDialogs.DependencyForm form =
+                    IssueDependencyDialogs.form(12L, 7L);
+            assertEquals(
+                    "Add dependency",
+                    SwingComponentTestSupport.find(form.panel(), "dependencyDialogTitle", JLabel.class).getText());
+            assertEquals(
+                    "12",
+                    SwingComponentTestSupport.find(
+                            form.panel(),
+                            "dependencyBlockingIssueField",
+                            JTextField.class).getText());
+            assertEquals(
+                    "7",
+                    SwingComponentTestSupport.find(
+                            form.panel(),
+                            "dependencyBlockedIssueField",
+                            JTextField.class).getText());
+            form.panel().setSize(560, 220);
+            layoutRecursively(form.panel());
+
+            BufferedImage image = render(form.panel(), Path.of("build/reports/ui/issue-dependency-dialog.png"));
+            assertTrue(hasRenderedContent(image));
+        });
+    }
+
+    private static void layoutRecursively(Container container) {
+        container.doLayout();
+        for (java.awt.Component child : container.getComponents()) {
+            if (child instanceof Container nested) {
+                layoutRecursively(nested);
+            }
+        }
+    }
+
+    private static BufferedImage render(Container panel, Path output) throws java.io.IOException {
+        BufferedImage image = new BufferedImage(560, 220, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            panel.printAll(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        Files.createDirectories(output.getParent());
+        ImageIO.write(image, "png", output.toFile());
+        return image;
+    }
+
+    private static boolean hasRenderedContent(BufferedImage image) {
+        int white = Color.WHITE.getRGB();
+        int contentPixels = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                if (image.getRGB(x, y) != white) {
+                    contentPixels++;
+                }
+            }
+        }
+        return contentPixels > 1_000;
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDependencyRequestTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDependencyRequestTest.java
@@ -1,0 +1,37 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing issue dependency request")
+class IssueDependencyRequestTest {
+
+    @Test
+    @DisplayName("validates add dependency issue ids")
+    void validatesAddDependencyRequest() {
+        IssueDependencyRequest request = IssueDependencyRequest.add(3L, 7L);
+
+        assertEquals(IssueDependencyMode.ADD, request.mode());
+        assertEquals(3L, request.blockingIssueId());
+        assertEquals(7L, request.blockedIssueId());
+
+        assertThrows(IllegalArgumentException.class, () -> IssueDependencyRequest.add(0L, 7L));
+        assertThrows(IllegalArgumentException.class, () -> IssueDependencyRequest.add(3L, 0L));
+    }
+
+    @Test
+    @DisplayName("validates remove dependency issue ids")
+    void validatesRemoveDependencyRequest() {
+        IssueDependencyRequest request = IssueDependencyRequest.remove(3L, 7L);
+
+        assertEquals(IssueDependencyMode.REMOVE, request.mode());
+        assertEquals(3L, request.blockingIssueId());
+        assertEquals(7L, request.blockedIssueId());
+
+        assertThrows(IllegalArgumentException.class, () -> IssueDependencyRequest.remove(-1L, 7L));
+        assertThrows(IllegalArgumentException.class, () -> IssueDependencyRequest.remove(3L, -1L));
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanelTest.java
@@ -18,6 +18,8 @@ import com.github.marcellokim.issuetracker.service.UserResult;
 import java.awt.Color;
 import java.awt.Container;
 import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,6 +31,8 @@ import javax.imageio.ImageIO;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JTable;
+import javax.swing.JViewport;
+import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -43,8 +47,9 @@ class IssueDetailPanelTest {
         SwingComponentTestSupport.onEdt(() -> {
             IssueDetailPanel panel = panel();
             panel.showDetail(
-                    detail(List.of("UPDATE_ISSUE", "ADD_COMMENT")),
-                    List.of(new IssueCommentActionState("100", 100L, "Confirmed in local run.", true, true)));
+                    detail(List.of("UPDATE_ISSUE", "ADD_DEPENDENCY", "REMOVE_DEPENDENCY", "ADD_COMMENT")),
+                    List.of(new IssueCommentActionState("100", 100L, "Confirmed in local run.", true, true)),
+                    List.of(dependency()));
 
             assertEquals(
                     "[ISSUE-7] Login bug",
@@ -58,6 +63,8 @@ class IssueDetailPanelTest {
                     .isEnabled());
             assertFalse(SwingComponentTestSupport.find(panel, "issueActionButton_MARK_FIXED", JButton.class)
                     .isEnabled());
+            assertTrue(SwingComponentTestSupport.find(panel, "addDependencyButton", JButton.class).isEnabled());
+            assertFalse(SwingComponentTestSupport.find(panel, "removeDependencyButton", JButton.class).isEnabled());
 
             JTable comments = SwingComponentTestSupport.find(panel, "issueCommentTable", JTable.class);
             assertEquals(1, comments.getRowCount());
@@ -77,6 +84,8 @@ class IssueDetailPanelTest {
 
             JTable dependencies = SwingComponentTestSupport.find(panel, "issueDependencyTable", JTable.class);
             assertEquals("ISSUE-3", dependencies.getValueAt(0, 2));
+            dependencies.setRowSelectionInterval(0, 0);
+            assertTrue(SwingComponentTestSupport.find(panel, "removeDependencyButton", JButton.class).isEnabled());
         });
     }
 
@@ -86,6 +95,8 @@ class IssueDetailPanelTest {
         AtomicReference<String> actionRef = new AtomicReference<>();
         AtomicReference<IssueCommentMode> commentModeRef = new AtomicReference<>();
         AtomicReference<IssueCommentSelection> commentSelectionRef = new AtomicReference<>();
+        AtomicReference<IssueDependencyMode> dependencyModeRef = new AtomicReference<>();
+        AtomicReference<IssueDependencySelection> dependencySelectionRef = new AtomicReference<>();
         AtomicInteger backClicks = new AtomicInteger();
         AtomicInteger logoutClicks = new AtomicInteger();
 
@@ -98,17 +109,26 @@ class IssueDetailPanelTest {
                                 commentModeRef.set(mode);
                                 commentSelectionRef.set(selection);
                             },
+                            (source, mode, selection) -> {
+                                dependencyModeRef.set(mode);
+                                dependencySelectionRef.set(selection);
+                            },
                             backClicks::incrementAndGet,
                             logoutClicks::incrementAndGet));
             panel.showDetail(
-                    detail(List.of("ADD_COMMENT")),
-                    List.of(new IssueCommentActionState("100", 100L, "Confirmed in local run.", true, true)));
+                    detail(List.of("ADD_COMMENT", "ADD_DEPENDENCY", "REMOVE_DEPENDENCY")),
+                    List.of(new IssueCommentActionState("100", 100L, "Confirmed in local run.", true, true)),
+                    List.of(dependency()));
 
             SwingComponentTestSupport.find(panel, "issueActionButton_ADD_COMMENT", JButton.class).doClick();
             SwingComponentTestSupport.find(panel, "addCommentButton", JButton.class).doClick();
             JTable comments = SwingComponentTestSupport.find(panel, "issueCommentTable", JTable.class);
             comments.setRowSelectionInterval(0, 0);
             SwingComponentTestSupport.find(panel, "editCommentButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "addDependencyButton", JButton.class).doClick();
+            JTable dependencies = SwingComponentTestSupport.find(panel, "issueDependencyTable", JTable.class);
+            dependencies.setRowSelectionInterval(0, 0);
+            SwingComponentTestSupport.find(panel, "removeDependencyButton", JButton.class).doClick();
             SwingComponentTestSupport.find(panel, "issueDetailBackButton", JButton.class).doClick();
             SwingComponentTestSupport.find(panel, "issueDetailLogoutButton", JButton.class).doClick();
         });
@@ -117,6 +137,9 @@ class IssueDetailPanelTest {
         assertEquals(IssueCommentMode.UPDATE, commentModeRef.get());
         assertEquals(100L, commentSelectionRef.get().commentId());
         assertEquals("Confirmed in local run.", commentSelectionRef.get().content());
+        assertEquals(IssueDependencyMode.REMOVE, dependencyModeRef.get());
+        assertEquals(3L, dependencySelectionRef.get().blockingIssueId());
+        assertEquals(7L, dependencySelectionRef.get().blockedIssueId());
         assertEquals(1, backClicks.get());
         assertEquals(1, logoutClicks.get());
     }
@@ -128,7 +151,8 @@ class IssueDetailPanelTest {
             IssueDetailPanel panel = panel();
             panel.showDetail(
                     detail(List.of("ADD_COMMENT")),
-                    List.of(new IssueCommentActionState("legacy-id", null, "Legacy comment", false, false)));
+                    List.of(new IssueCommentActionState("legacy-id", null, "Legacy comment", false, false)),
+                    List.of());
 
             JTable comments = SwingComponentTestSupport.find(panel, "issueCommentTable", JTable.class);
             comments.setRowSelectionInterval(0, 0);
@@ -145,13 +169,20 @@ class IssueDetailPanelTest {
         SwingComponentTestSupport.onEdt(() -> {
             IssueDetailPanel panel = panel();
             panel.showDetail(
-                    detail(List.of("UPDATE_ISSUE", "ADD_COMMENT")),
-                    List.of(new IssueCommentActionState("100", 100L, "Confirmed in local run.", true, true)));
+                    detail(List.of("UPDATE_ISSUE", "ADD_COMMENT", "ADD_DEPENDENCY", "REMOVE_DEPENDENCY")),
+                    List.of(new IssueCommentActionState("100", 100L, "Confirmed in local run.", true, true)),
+                    List.of(dependency()));
             panel.setSize(SwingStyles.WINDOW_SIZE);
             layoutRecursively(panel);
 
             BufferedImage image = render(panel, Path.of("build/reports/ui/issue-detail-panel.png"));
             assertTrue(hasRenderedContent(image));
+
+            scrollToDependencies(panel);
+            BufferedImage dependencyImage = render(
+                    panel,
+                    Path.of("build/reports/ui/issue-detail-dependency-section.png"));
+            assertTrue(hasRenderedContent(dependencyImage));
         });
     }
 
@@ -160,6 +191,8 @@ class IssueDetailPanelTest {
                 userResult("dev1", Role.DEV),
                 new IssueDetailPanel.IssueDetailActions(
                         (source, action) -> {
+                        },
+                        (source, mode, selection) -> {
                         },
                         (source, mode, selection) -> {
                         },
@@ -237,6 +270,20 @@ class IssueDetailPanelTest {
         Files.createDirectories(output.getParent());
         ImageIO.write(image, "png", output.toFile());
         return image;
+    }
+
+    private static void scrollToDependencies(IssueDetailPanel panel) {
+        JTable dependencies = SwingComponentTestSupport.find(panel, "issueDependencyTable", JTable.class);
+        dependencies.scrollRectToVisible(new Rectangle(0, 0, dependencies.getWidth(), dependencies.getHeight()));
+        Container ancestor = dependencies.getParent();
+        while (ancestor != null) {
+            if (ancestor instanceof JViewport viewport && viewport.getView() != null) {
+                Point position = SwingUtilities.convertPoint(dependencies, 0, 0, viewport.getView());
+                viewport.setViewPosition(new Point(0, Math.max(0, position.y - SwingStyles.ROW_GAP)));
+            }
+            ancestor = ancestor.getParent();
+        }
+        layoutRecursively(panel);
     }
 
     private static boolean hasRenderedContent(BufferedImage image) {

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
@@ -9,6 +9,7 @@ import com.github.marcellokim.issuetracker.controller.IssueStateController;
 import com.github.marcellokim.issuetracker.domain.Comment;
 import com.github.marcellokim.issuetracker.domain.CommentPurpose;
 import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueDependency;
 import com.github.marcellokim.issuetracker.domain.IssueHistory;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.Priority;
@@ -19,6 +20,7 @@ import com.github.marcellokim.issuetracker.repository.CommentRepository;
 import com.github.marcellokim.issuetracker.service.AssignmentRecommendationService;
 import com.github.marcellokim.issuetracker.service.AssignmentService;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.DependencyResult;
 import com.github.marcellokim.issuetracker.service.IssueDetailResult;
 import com.github.marcellokim.issuetracker.service.IssueService;
 import com.github.marcellokim.issuetracker.service.IssueStateService;
@@ -53,12 +55,20 @@ class IssueDetailPresenterTest {
     void loadsIssueDetailWithActionsAndCommentPermissions() {
         User reporter = user("dev1", Role.DEV);
         Issue issue = issue(7L, "Login bug", reporter);
+        Issue related = issue(8L, "Profile bug", reporter);
         FakeCommentRepository comments = new FakeCommentRepository(
                 comment(100L, issue.id(), reporter, CommentPurpose.GENERAL),
                 comment(101L, issue.id(), reporter, CommentPurpose.STATUS_CHANGE));
+        IssueDetailControllerFixture fixture = controllerFixture(reporter, comments, issue, related);
+        fixture.dependencyRepository().addFixture(IssueDependency.fromPersistence(
+                1L,
+                IssueDependency.dependencyIdFor(issue.id(), related.id()),
+                issue.id(),
+                related.id(),
+                NOW));
         RecordingIssueDetailView view = new RecordingIssueDetailView();
         IssueDetailPresenter presenter = new IssueDetailPresenter(
-                controller(reporter, comments, issue),
+                fixture.issueController(),
                 view);
 
         presenter.loadIssue(issue.id());
@@ -70,6 +80,10 @@ class IssueDetailPresenterTest {
         assertEquals(true, view.commentAction(100L).canUpdate());
         assertEquals(true, view.commentAction(100L).canDelete());
         assertEquals(false, view.commentAction(101L).canUpdate());
+        assertTrue(view.detail().dependencies().isEmpty());
+        assertEquals(1, view.projectDependencies().size());
+        assertEquals(issue.id(), view.projectDependencies().getFirst().blockingIssueId());
+        assertEquals(related.id(), view.projectDependencies().getFirst().blockedIssueId());
         assertEquals(" ", view.message());
     }
 
@@ -268,6 +282,54 @@ class IssueDetailPresenterTest {
     }
 
     @Test
+    @DisplayName("adds and removes dependencies through issue controller and reloads project dependencies")
+    void changesDependenciesAndReloadsProjectDependencies() {
+        User pl = user("pl1", Role.PL);
+        Issue blockingIssue = issue(7L, "Login bug", pl);
+        Issue blockedIssue = issue(8L, "Profile bug", pl);
+        IssueDetailControllerFixture fixture = controllerFixture(
+                pl,
+                new FakeCommentRepository(),
+                blockingIssue,
+                blockedIssue);
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(fixture.issueController(), view);
+
+        presenter.changeDependency(
+                blockingIssue.id(),
+                IssueDependencyRequest.add(blockingIssue.id(), blockedIssue.id()));
+
+        assertEquals(1, view.projectDependencies().size());
+        DependencyResult added = view.projectDependencies().getFirst();
+        assertEquals(blockingIssue.id(), added.blockingIssueId());
+        assertEquals(blockedIssue.id(), added.blockedIssueId());
+
+        presenter.changeDependency(
+                blockingIssue.id(),
+                IssueDependencyRequest.remove(blockingIssue.id(), blockedIssue.id()));
+
+        assertTrue(view.projectDependencies().isEmpty());
+        assertEquals(" ", view.message());
+    }
+
+    @Test
+    @DisplayName("shows dependency action errors without replacing current detail")
+    void showsDependencyActionErrorsWithoutReplacingCurrentDetail() {
+        User pl = user("pl1", Role.PL);
+        Issue issue = issue(7L, "Login bug", pl);
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                controller(pl, new FakeCommentRepository(), issue),
+                view);
+        presenter.loadIssue(issue.id());
+
+        presenter.changeDependency(issue.id(), IssueDependencyRequest.add(issue.id(), issue.id()));
+
+        assertEquals("Login bug", view.detail().title());
+        assertEquals("Issue cannot depend on itself", view.message());
+    }
+
+    @Test
     @DisplayName("shows comment action errors without replacing current detail")
     void showsCommentActionErrorsWithoutReplacingCurrentDetail() {
         User reporter = user("dev1", Role.DEV);
@@ -378,7 +440,11 @@ class IssueDetailPresenterTest {
                                 new InMemoryAssignmentRecommendationRepository(extraUsers.toArray(User[]::new)),
                                 new KNNAssignmentRecommendation()),
                         () -> NOW));
-        return new IssueDetailControllerFixture(issueController, issueStateController, assignmentController);
+        return new IssueDetailControllerFixture(
+                issueController,
+                issueStateController,
+                assignmentController,
+                dependencies);
     }
 
     private static Project project() {
@@ -431,7 +497,8 @@ class IssueDetailPresenterTest {
     private record IssueDetailControllerFixture(
             IssueController issueController,
             IssueStateController issueStateController,
-            AssignmentController assignmentController) {
+            AssignmentController assignmentController,
+            FakeIssueDependencyRepository dependencyRepository) {
     }
 
     private static final class RecordingIssueDetailView implements IssueDetailView {
@@ -439,12 +506,17 @@ class IssueDetailPresenterTest {
         private IssueDetailResult detail;
         private IssueWorkflowActions actions;
         private List<IssueCommentActionState> commentActions = List.of();
+        private List<DependencyResult> projectDependencies = List.of();
         private String message = " ";
 
         @Override
-        public void showDetail(IssueDetailResult detail, List<IssueCommentActionState> commentActions) {
+        public void showDetail(
+                IssueDetailResult detail,
+                List<IssueCommentActionState> commentActions,
+                List<DependencyResult> projectDependencies) {
             this.detail = detail;
             this.commentActions = List.copyOf(commentActions);
+            this.projectDependencies = List.copyOf(projectDependencies);
         }
 
         @Override
@@ -470,6 +542,10 @@ class IssueDetailPresenterTest {
                     .filter(action -> action.numericCommentId() != null && action.numericCommentId() == commentId)
                     .findFirst()
                     .orElseThrow();
+        }
+
+        private List<DependencyResult> projectDependencies() {
+            return projectDependencies;
         }
 
         private String message() {

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -561,7 +561,8 @@ class SwingAppPanelTest {
                                 mode,
                                 assignee.getLoginId(),
                                 verifier.getLoginId())),
-                        IssueCommentDialogs::prompt),
+                        IssueCommentDialogs::prompt,
+                        IssueDependencyDialogs::prompt),
                 recommendations,
                 pl,
                 assignee,
@@ -675,6 +676,88 @@ class SwingAppPanelTest {
     }
 
     @Test
+    @DisplayName("issue detail dependency actions add, cancel remove, and remove")
+    void issueDetailDependencyActionsAddCancelRemoveAndRemove() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        User pl = user("pl1", Role.PL);
+        Issue blockedIssue = issue(7L, 7L, "Login bug", Priority.CRITICAL, pl);
+        Issue blockingIssue = issue(8L, 7L, "Profile bug", Priority.MAJOR, pl);
+        AtomicBoolean removeConfirmed = new AtomicBoolean(false);
+        AtomicReference<IssueDependencyMode> promptedMode = new AtomicReference<>();
+        IssueDependencyPrompt dependencyPrompt = (parent, mode, selection, defaultBlockedIssueId) -> {
+            promptedMode.set(mode);
+            return switch (mode) {
+                case ADD -> {
+                    assertEquals(blockedIssue.id(), defaultBlockedIssueId);
+                    yield Optional.of(IssueDependencyRequest.add(blockingIssue.id(), blockedIssue.id()));
+                }
+                case REMOVE -> removeConfirmed.get()
+                        ? Optional.of(IssueDependencyRequest.remove(
+                                selection.blockingIssueId(),
+                                selection.blockedIssueId()))
+                        : Optional.empty();
+            };
+        };
+        SwingAppPanel panel = loginProjectUser(
+                passwordHashing,
+                titles,
+                List.of(projectSnapshot(7L, "Alpha", 3, 2)),
+                List.of(blockedIssue, blockingIssue),
+                List.of(),
+                IssueStatusChangeDialogs::prompt,
+                IssueAssignmentDialogs::prompt,
+                IssueCommentDialogs::prompt,
+                dependencyPrompt,
+                pl);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable projects = SwingComponentTestSupport.find(panel, "projectListTable", JTable.class);
+            projects.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openProjectIssuesButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openProjectIssuesButton", JButton.class).doClick());
+        awaitIssueRows(panel, 2);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable issues = SwingComponentTestSupport.find(panel, "issueListTable", JTable.class);
+            issues.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openIssueDetailButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick());
+        awaitIssueDetailTitle(panel, "[ISSUE-7] Login bug");
+        awaitRows(panel, "issueDependencyTable", 0);
+
+        awaitButtonEnabled(panel, "addDependencyButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "addDependencyButton", JButton.class).doClick());
+        awaitRows(panel, "issueDependencyTable", 1);
+        assertEquals(IssueDependencyMode.ADD, promptedMode.get());
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable dependencies = SwingComponentTestSupport.find(panel, "issueDependencyTable", JTable.class);
+            dependencies.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "removeDependencyButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "removeDependencyButton", JButton.class).doClick());
+        awaitRows(panel, "issueDependencyTable", 1);
+        assertEquals(IssueDependencyMode.REMOVE, promptedMode.get());
+
+        removeConfirmed.set(true);
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable dependencies = SwingComponentTestSupport.find(panel, "issueDependencyTable", JTable.class);
+            dependencies.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "removeDependencyButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "removeDependencyButton", JButton.class).doClick());
+        awaitRows(panel, "issueDependencyTable", 0);
+    }
+
+    @Test
     @DisplayName("project list logout returns to login")
     void projectListLogoutReturnsToLogin() throws Exception {
         var passwordHashing = new RecordingPasswordHashing();
@@ -771,7 +854,11 @@ class SwingAppPanelTest {
                 projects,
                 issues,
                 List.of(),
-                new SwingPromptSupport(statusChangePrompt, assignmentPrompt, IssueCommentDialogs::prompt),
+                new SwingPromptSupport(
+                        statusChangePrompt,
+                        assignmentPrompt,
+                        IssueCommentDialogs::prompt,
+                        IssueDependencyDialogs::prompt),
                 new InMemoryAssignmentRecommendationRepository(users),
                 users);
     }
@@ -792,7 +879,31 @@ class SwingAppPanelTest {
                 projects,
                 issues,
                 comments,
-                new SwingPromptSupport(statusChangePrompt, assignmentPrompt, commentPrompt),
+                statusChangePrompt,
+                assignmentPrompt,
+                commentPrompt,
+                IssueDependencyDialogs::prompt,
+                users);
+    }
+
+    private static SwingAppPanel loginProjectUser(
+            RecordingPasswordHashing passwordHashing,
+            RecordingTitleUpdater titles,
+            List<DashboardProjectSnapshot> projects,
+            List<Issue> issues,
+            List<Comment> comments,
+            IssueStatusChangePrompt statusChangePrompt,
+            IssueAssignmentPrompt assignmentPrompt,
+            IssueCommentPrompt commentPrompt,
+            IssueDependencyPrompt dependencyPrompt,
+            User... users) throws Exception {
+        return loginProjectUser(
+                passwordHashing,
+                titles,
+                projects,
+                issues,
+                comments,
+                new SwingPromptSupport(statusChangePrompt, assignmentPrompt, commentPrompt, dependencyPrompt),
                 new InMemoryAssignmentRecommendationRepository(users),
                 users);
     }
@@ -829,7 +940,8 @@ class SwingAppPanelTest {
                                     prompts.statusChangePrompt()),
                             controllers.assignmentController(),
                             prompts.assignmentPrompt(),
-                            prompts.commentPrompt()),
+                            prompts.commentPrompt(),
+                            prompts.dependencyPrompt()),
                     titles::update);
             panelRef.set(panel);
             User user = users[0];
@@ -1261,7 +1373,8 @@ class SwingAppPanelTest {
     private record SwingPromptSupport(
             IssueStatusChangePrompt statusChangePrompt,
             IssueAssignmentPrompt assignmentPrompt,
-            IssueCommentPrompt commentPrompt) {
+            IssueCommentPrompt commentPrompt,
+            IssueDependencyPrompt dependencyPrompt) {
     }
 
     private static final class FakeCommentRepository implements CommentRepository {


### PR DESCRIPTION
## purpose
Swing 이슈 상세 화면에서 프로젝트 dependency 목록 조회, 추가, 제거 action을 연결합니다.

Closes #213

## non-goals
- dependency graph/cycle 검증을 Swing에서 직접 구현하지 않습니다.
- dependency type/name 확장은 포함하지 않습니다.
- repository 직접 호출 없이 controller 계약만 사용합니다.

## diff map
- 핵심 변경: `IssueDetailPresenter`가 `viewProjectDependencies(projectId)`를 함께 조회하고 add/remove 후 상세를 다시 로드합니다.
- UI 변경: dependency table toolbar, add/remove dialog, 선택 기반 remove enable 상태를 추가했습니다.
- 테스트 변경: request/dialog/panel/presenter/app panel 경로를 Swing 테스트로 보강했습니다.

## verification evidence
- `git diff --check origin/dev...HEAD && git diff --check`
- `./gradlew test --tests '*IssueDependency*' --tests '*IssueDetailPanelTest*' --tests '*IssueDetailPresenterTest*' --tests '*SwingAppPanelTest*' --console=plain`
- `./gradlew check --console=plain`
- pre-push `test + verifyRepositorySetup`
- visual evidence: `build/reports/ui/issue-dependency-dialog.png`, `build/reports/ui/issue-detail-dependency-section.png`

## reviewer focus areas
- `IssueDetailResult.dependencies()` 의미를 보존하고 project dependency 조회 결과를 별도로 전달하는지
- add/remove가 `IssueController` 계약만 사용하고 정책 판단을 UI에서 반복하지 않는지
- remove action이 JTable 문자열이 아니라 backing `DependencyResult` 값으로 실행되는지

## risk / rollback
origin/dev 기준 단일 dependency action PR입니다. 문제 발생 시 이 PR 커밋만 되돌리면 Swing dependency action 연결만 제거됩니다.
