### PR TITLE
feat: Swing 통계 화면 구현

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentStatisticsView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentStatisticsView.java
@@ -1,0 +1,30 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.StatisticsReportResult;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.swing.SwingWorker;
+
+final class CurrentStatisticsView implements StatisticsView {
+
+    private final StatisticsPanel delegate;
+    private final CurrentViewGate gate;
+
+    CurrentStatisticsView(
+            StatisticsPanel delegate,
+            SwingWorker<?, ?> worker,
+            Supplier<? extends SwingWorker<?, ?>> currentWorker) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.gate = new CurrentViewGate(worker, currentWorker);
+    }
+
+    @Override
+    public void showReport(StatisticsReportResult report) {
+        delegate.showReport(report, gate::isCurrent);
+    }
+
+    @Override
+    public void showMessage(String message, boolean error) {
+        gate.update(() -> delegate.showMessage(message, error));
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentViewGate.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentViewGate.java
@@ -23,7 +23,7 @@ final class CurrentViewGate {
         });
     }
 
-    private boolean isCurrent() {
+    boolean isCurrent() {
         return currentWorker.get() == worker && !worker.isCancelled();
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanel.java
@@ -56,6 +56,7 @@ final class IssueListPanel extends JPanel implements IssueListView {
     private final JButton searchButton = new JButton("Search");
     private final JButton registerButton = new JButton("Register issue");
     private final JButton openButton = new JButton("Open detail");
+    private final JButton statisticsButton = new JButton("Statistics");
     private boolean busy;
     private boolean registerAllowed;
 
@@ -216,6 +217,10 @@ final class IssueListPanel extends JPanel implements IssueListView {
         openButton.addActionListener(event -> selectedIssue()
                 .ifPresent(issue -> actions.onOpenIssue().accept(issue.id())));
         panel.add(openButton);
+
+        statisticsButton.setName("statisticsButton");
+        statisticsButton.addActionListener(event -> actions.onStatistics().run());
+        panel.add(statisticsButton);
         return panel;
     }
 
@@ -287,6 +292,7 @@ final class IssueListPanel extends JPanel implements IssueListView {
         boolean enabled = !busy;
         registerButton.setEnabled(enabled && registerAllowed);
         openButton.setEnabled(enabled && selectedIssue().isPresent());
+        statisticsButton.setEnabled(enabled);
     }
 
     private void applyColumnWidths(JTable table) {
@@ -303,6 +309,7 @@ final class IssueListPanel extends JPanel implements IssueListView {
             PanelConsumer<IssueSearchRequest> onSearch,
             PanelConsumer<IssueRegisterRequest> onRegister,
             LongConsumer onOpenIssue,
+            Runnable onStatistics,
             Runnable onBack,
             Runnable onLogout) {
 
@@ -310,6 +317,7 @@ final class IssueListPanel extends JPanel implements IssueListView {
             Objects.requireNonNull(onSearch, "onSearch");
             Objects.requireNonNull(onRegister, "onRegister");
             Objects.requireNonNull(onOpenIssue, "onOpenIssue");
+            Objects.requireNonNull(onStatistics, "onStatistics");
             Objects.requireNonNull(onBack, "onBack");
             Objects.requireNonNull(onLogout, "onLogout");
         }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsPanel.java
@@ -1,0 +1,386 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.service.DailyCountResult;
+import com.github.marcellokim.issuetracker.service.MonthlyCountResult;
+import com.github.marcellokim.issuetracker.service.StatisticsReportResult;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.GridLayout;
+import java.awt.Insets;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTabbedPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+
+final class StatisticsPanel extends JPanel implements StatisticsView {
+
+    private static final long serialVersionUID = 1L;
+    private static final String DEFAULT_ERROR_MESSAGE = "Statistics failed. Please try again.";
+    private static final Color SELECTION_BACKGROUND = new Color(219, 234, 254);
+    private static final String COUNT_LABEL = "Count";
+    private static final String[] COUNT_COLUMNS = {"Value", COUNT_LABEL};
+    private static final String[] DATE_COUNT_COLUMNS = {"Date", COUNT_LABEL};
+    private static final String[] MONTH_COUNT_COLUMNS = {"Month", COUNT_LABEL};
+    private static final String[] MONTHLY_COUNT_COLUMNS = {"Month", "Value", COUNT_LABEL};
+    private static final List<IssueStatus> VISIBLE_STATUSES = Arrays.stream(IssueStatus.values())
+            .filter(status -> status != IssueStatus.DELETED)
+            .toList();
+    private static final List<Priority> PRIORITY_VALUES = Arrays.asList(Priority.values());
+
+    private final transient StatisticsActions actions;
+    private final JLabel messageLabel = new JLabel(" ");
+    private final JTextField dailyFromField = new JTextField();
+    private final JTextField dailyToField = new JTextField();
+    private final JTextField monthlyFromField = new JTextField();
+    private final JTextField monthlyToField = new JTextField();
+    private final JButton loadButton = new JButton("Apply filter");
+    private final DefaultTableModel statusModel = readOnlyTableModel(COUNT_COLUMNS);
+    private final DefaultTableModel priorityModel = readOnlyTableModel(COUNT_COLUMNS);
+    private final DefaultTableModel dailyModel = readOnlyTableModel(DATE_COUNT_COLUMNS);
+    private final DefaultTableModel monthlyModel = readOnlyTableModel(MONTH_COUNT_COLUMNS);
+    private final DefaultTableModel monthlyStatusModel = readOnlyTableModel(MONTHLY_COUNT_COLUMNS);
+    private final DefaultTableModel monthlyPriorityModel = readOnlyTableModel(MONTHLY_COUNT_COLUMNS);
+    private final DefaultTableModel dailyStatusChangeModel = readOnlyTableModel(DATE_COUNT_COLUMNS);
+    private final DefaultTableModel monthlyStatusChangeModel = readOnlyTableModel(MONTH_COUNT_COLUMNS);
+    private final DefaultTableModel dailyCommentModel = readOnlyTableModel(DATE_COUNT_COLUMNS);
+    private final DefaultTableModel monthlyCommentModel = readOnlyTableModel(MONTH_COUNT_COLUMNS);
+    private final JTable statusTable = table("statisticsStatusTable", statusModel);
+    private final JTable priorityTable = table("statisticsPriorityTable", priorityModel);
+    private final JTable dailyTable = table("statisticsDailyTable", dailyModel);
+    private final JTable monthlyTable = table("statisticsMonthlyTable", monthlyModel);
+    private final JTable monthlyStatusTable = table("statisticsMonthlyStatusTable", monthlyStatusModel);
+    private final JTable monthlyPriorityTable = table("statisticsMonthlyPriorityTable", monthlyPriorityModel);
+    private final JTable dailyStatusChangeTable = table("statisticsDailyStatusChangeTable", dailyStatusChangeModel);
+    private final JTable monthlyStatusChangeTable = table("statisticsMonthlyStatusChangeTable", monthlyStatusChangeModel);
+    private final JTable dailyCommentTable = table("statisticsDailyCommentTable", dailyCommentModel);
+    private final JTable monthlyCommentTable = table("statisticsMonthlyCommentTable", monthlyCommentModel);
+    private boolean busy;
+
+    StatisticsPanel(UserResult user, StatisticsActions actions) {
+        Objects.requireNonNull(user, "user");
+        this.actions = Objects.requireNonNull(actions, "actions");
+
+        setName("statisticsPanel");
+        setLayout(new BorderLayout(SwingStyles.SECTION_GAP, SwingStyles.SECTION_GAP));
+        setBackground(SwingStyles.BACKGROUND);
+        setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING));
+
+        add(topSection(user), BorderLayout.NORTH);
+        add(tabs(), BorderLayout.CENTER);
+    }
+
+    @Override
+    public void showReport(StatisticsReportResult report) {
+        showReport(report, () -> true);
+    }
+
+    void showReport(StatisticsReportResult report, BooleanSupplier shouldApply) {
+        Objects.requireNonNull(report, "report");
+        Objects.requireNonNull(shouldApply, "shouldApply");
+        List<Object[]> statusRows = statusRows(report.statusCounts());
+        List<Object[]> priorityRows = priorityRows(report.priorityCounts());
+        List<Object[]> dailyRows = dailyRows(report.dailyCounts());
+        List<Object[]> monthlyRows = monthlyRows(report.monthlyCounts());
+        List<Object[]> monthlyStatusRows = monthlyStatusRows(report.monthlyStatusCounts());
+        List<Object[]> monthlyPriorityRows = monthlyPriorityRows(report.monthlyPriorityCounts());
+        List<Object[]> dailyStatusChangeRows = dailyRows(report.dailyStatusChangeCounts());
+        List<Object[]> monthlyStatusChangeRows = monthlyRows(report.monthlyStatusChangeCounts());
+        List<Object[]> dailyCommentRows = dailyRows(report.dailyCommentCounts());
+        List<Object[]> monthlyCommentRows = monthlyRows(report.monthlyCommentCounts());
+
+        runOnEdt(() -> {
+            if (!shouldApply.getAsBoolean()) {
+                return;
+            }
+            replaceRows(statusModel, statusRows);
+            replaceRows(priorityModel, priorityRows);
+            replaceRows(dailyModel, dailyRows);
+            replaceRows(monthlyModel, monthlyRows);
+            replaceRows(monthlyStatusModel, monthlyStatusRows);
+            replaceRows(monthlyPriorityModel, monthlyPriorityRows);
+            replaceRows(dailyStatusChangeModel, dailyStatusChangeRows);
+            replaceRows(monthlyStatusChangeModel, monthlyStatusChangeRows);
+            replaceRows(dailyCommentModel, dailyCommentRows);
+            replaceRows(monthlyCommentModel, monthlyCommentRows);
+        });
+    }
+
+    @Override
+    public void showMessage(String message, boolean error) {
+        runOnEdt(() -> SwingPanelSections.updateMessage(
+                messageLabel,
+                message,
+                error,
+                DEFAULT_ERROR_MESSAGE));
+    }
+
+    void setBusy(boolean busy) {
+        runOnEdt(() -> {
+            this.busy = busy;
+            boolean enabled = !busy;
+            dailyFromField.setEnabled(enabled);
+            dailyToField.setEnabled(enabled);
+            monthlyFromField.setEnabled(enabled);
+            monthlyToField.setEnabled(enabled);
+            loadButton.setEnabled(enabled);
+        });
+    }
+
+    private JPanel topSection(UserResult user) {
+        JPanel top = new JPanel(new BorderLayout(0, SwingStyles.SECTION_GAP));
+        top.setOpaque(false);
+        top.add(SwingPanelSections.managementHeader(
+                new SwingPanelSections.HeaderLabels(
+                        "Statistics",
+                        "statisticsTitle",
+                        "statisticsUser",
+                        "statisticsMessage",
+                        "statisticsBackButton",
+                        "statisticsLogoutButton"),
+                user,
+                messageLabel,
+                new SwingPanelSections.NavigationActions(actions.onBack(), actions.onLogout())), BorderLayout.NORTH);
+        top.add(filterPanel(), BorderLayout.SOUTH);
+        return top;
+    }
+
+    private JPanel filterPanel() {
+        JPanel panel = new JPanel(new GridBagLayout());
+        panel.setBackground(SwingStyles.SURFACE);
+        panel.setBorder(SwingStyles.surfaceBorder());
+
+        dailyFromField.setName("statisticsDailyFromField");
+        dailyToField.setName("statisticsDailyToField");
+        monthlyFromField.setName("statisticsMonthlyFromField");
+        monthlyToField.setName("statisticsMonthlyToField");
+        dailyFromField.setColumns(10);
+        dailyToField.setColumns(10);
+        monthlyFromField.setColumns(8);
+        monthlyToField.setColumns(8);
+        loadButton.setName("loadStatisticsButton");
+        loadButton.addActionListener(event -> publishRangeRequest());
+
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.insets = new Insets(4, 4, 4, 4);
+        constraints.fill = GridBagConstraints.HORIZONTAL;
+        addFilter(panel, constraints, 0, "Daily from", dailyFromField);
+        addFilter(panel, constraints, 2, "Daily to", dailyToField);
+        addFilter(panel, constraints, 4, "Monthly from", monthlyFromField);
+        addFilter(panel, constraints, 6, "Monthly to", monthlyToField);
+        constraints.gridx = 8;
+        constraints.gridy = 0;
+        constraints.weightx = 0.0;
+        panel.add(loadButton, constraints);
+        return panel;
+    }
+
+    private void publishRangeRequest() {
+        if (busy) {
+            return;
+        }
+        try {
+            actions.onLoad().accept(this, StatisticsRangeRequest.parse(
+                    dailyFromField.getText(),
+                    dailyToField.getText(),
+                    monthlyFromField.getText(),
+                    monthlyToField.getText()));
+        } catch (IllegalArgumentException exception) {
+            showMessage(exception.getMessage(), true);
+        }
+    }
+
+    private JTabbedPane tabs() {
+        JTabbedPane tabs = new JTabbedPane();
+        tabs.setName("statisticsTabs");
+        tabs.addTab("Summary", pairedTables("Status", statusTable, "Priority", priorityTable));
+        tabs.addTab("Created", pairedTables("Daily created", dailyTable, "Monthly created", monthlyTable));
+        tabs.addTab("Distribution", pairedTables(
+                "Monthly status",
+                monthlyStatusTable,
+                "Monthly priority",
+                monthlyPriorityTable));
+        tabs.addTab("Activity", activityTables());
+        return tabs;
+    }
+
+    private JPanel pairedTables(String firstTitle, JTable first, String secondTitle, JTable second) {
+        JPanel panel = new JPanel(new GridLayout(1, 2, SwingStyles.SECTION_GAP, SwingStyles.SECTION_GAP));
+        panel.setBackground(SwingStyles.SURFACE);
+        panel.add(tableSection(firstTitle, first));
+        panel.add(tableSection(secondTitle, second));
+        return panel;
+    }
+
+    private JPanel activityTables() {
+        JPanel panel = new JPanel(new GridLayout(2, 2, SwingStyles.SECTION_GAP, SwingStyles.SECTION_GAP));
+        panel.setBackground(SwingStyles.SURFACE);
+        panel.add(tableSection("Daily status changes", dailyStatusChangeTable));
+        panel.add(tableSection("Monthly status changes", monthlyStatusChangeTable));
+        panel.add(tableSection("Daily comments", dailyCommentTable));
+        panel.add(tableSection("Monthly comments", monthlyCommentTable));
+        return panel;
+    }
+
+    private JPanel tableSection(String title, JTable table) {
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.setBackground(SwingStyles.SURFACE);
+        panel.setBorder(SwingStyles.surfaceBorder());
+        JLabel titleLabel = new JLabel(title);
+        SwingStyles.applySectionTitle(titleLabel);
+        panel.add(titleLabel, BorderLayout.NORTH);
+        JScrollPane scrollPane = new JScrollPane(table);
+        scrollPane.setColumnHeaderView(table.getTableHeader());
+        panel.add(scrollPane, BorderLayout.CENTER);
+        return panel;
+    }
+
+    private JTable table(String name, DefaultTableModel model) {
+        JTable table = new JTable(model) {
+            @Override
+            public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
+                return SwingPanelSections.stripedTableCell(
+                        this,
+                        super.prepareRenderer(renderer, row, column),
+                        row,
+                        SELECTION_BACKGROUND);
+            }
+        };
+        SwingPanelSections.configureReadOnlyTable(table, name, SELECTION_BACKGROUND);
+        return table;
+    }
+
+    private static void addFilter(
+            JPanel panel,
+            GridBagConstraints constraints,
+            int column,
+            String labelText,
+            JTextField field) {
+        constraints.gridx = column;
+        constraints.gridy = 0;
+        constraints.weightx = 0.0;
+        panel.add(new JLabel(labelText), constraints);
+        constraints.gridx = column + 1;
+        constraints.weightx = 1.0;
+        panel.add(field, constraints);
+    }
+
+    private static List<Object[]> statusRows(Map<IssueStatus, Integer> counts) {
+        List<Object[]> rows = new ArrayList<>();
+        for (IssueStatus status : VISIBLE_STATUSES) {
+            Integer count = counts.get(status);
+            if (count != null) {
+                rows.add(new Object[]{status, count});
+            }
+        }
+        return rows;
+    }
+
+    private static List<Object[]> priorityRows(Map<Priority, Integer> counts) {
+        List<Object[]> rows = new ArrayList<>();
+        for (Priority priority : PRIORITY_VALUES) {
+            Integer count = counts.get(priority);
+            if (count != null) {
+                rows.add(new Object[]{priority, count});
+            }
+        }
+        return rows;
+    }
+
+    private static List<Object[]> dailyRows(List<DailyCountResult> counts) {
+        return counts.stream()
+                .map(count -> new Object[]{count.date(), count.count()})
+                .toList();
+    }
+
+    private static List<Object[]> monthlyRows(List<MonthlyCountResult> counts) {
+        return counts.stream()
+                .map(count -> new Object[]{count.month(), count.count()})
+                .toList();
+    }
+
+    private static List<Object[]> monthlyStatusRows(Map<YearMonth, Map<IssueStatus, Integer>> counts) {
+        return monthlyValueRows(counts, VISIBLE_STATUSES);
+    }
+
+    private static List<Object[]> monthlyPriorityRows(Map<YearMonth, Map<Priority, Integer>> counts) {
+        return monthlyValueRows(counts, PRIORITY_VALUES);
+    }
+
+    private static <T> List<Object[]> monthlyValueRows(Map<YearMonth, Map<T, Integer>> counts, List<T> values) {
+        List<Object[]> rows = new ArrayList<>();
+        counts.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> {
+                    for (T value : values) {
+                        rows.add(new Object[]{entry.getKey(), value, entry.getValue().getOrDefault(value, 0)});
+                    }
+                });
+        return rows;
+    }
+
+    private static void replaceRows(DefaultTableModel model, List<Object[]> rows) {
+        model.setRowCount(0);
+        for (Object[] row : rows) {
+            model.addRow(row);
+        }
+    }
+
+    private static DefaultTableModel readOnlyTableModel(String[] columns) {
+        return new DefaultTableModel(columns, 0) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return false;
+            }
+        };
+    }
+
+    private static void runOnEdt(Runnable action) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            action.run();
+            return;
+        }
+        SwingUtilities.invokeLater(action);
+    }
+
+    @FunctionalInterface
+    interface PanelConsumer<T> {
+
+        void accept(StatisticsPanel panel, T value);
+    }
+
+    record StatisticsActions(
+            PanelConsumer<StatisticsRangeRequest> onLoad,
+            Runnable onBack,
+            Runnable onLogout) {
+
+        StatisticsActions {
+            Objects.requireNonNull(onLoad, "onLoad");
+            Objects.requireNonNull(onBack, "onBack");
+            Objects.requireNonNull(onLogout, "onLogout");
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsPresenter.java
@@ -1,0 +1,41 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.controller.StatisticsController;
+import com.github.marcellokim.issuetracker.service.StatisticsReportResult;
+import java.util.Objects;
+
+final class StatisticsPresenter {
+
+    private final StatisticsController statisticsController;
+    private final StatisticsView view;
+
+    StatisticsPresenter(StatisticsController statisticsController, StatisticsView view) {
+        this.statisticsController = Objects.requireNonNull(statisticsController, "statisticsController");
+        this.view = Objects.requireNonNull(view, "view");
+    }
+
+    void loadStatistics(long projectId) {
+        loadStatistics(projectId, StatisticsRangeRequest.allTime());
+    }
+
+    void loadStatistics(long projectId, StatisticsRangeRequest request) {
+        Objects.requireNonNull(request, "request");
+        try {
+            StatisticsReportResult report = statisticsController.viewStatistics(
+                    projectId,
+                    request.dailyFromInclusive(),
+                    request.dailyToInclusive(),
+                    request.monthlyFromInclusive(),
+                    request.monthlyToInclusive());
+            view.showReport(report);
+            view.showMessage(summaryMessage(report), false);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    private static String summaryMessage(StatisticsReportResult report) {
+        int visibleIssues = report.statusCounts().values().stream().mapToInt(Integer::intValue).sum();
+        return visibleIssues + " issues";
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsRangeRequest.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsRangeRequest.java
@@ -1,0 +1,67 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+
+record StatisticsRangeRequest(
+        LocalDate dailyFromInclusive,
+        LocalDate dailyToInclusive,
+        YearMonth monthlyFromInclusive,
+        YearMonth monthlyToInclusive) {
+
+    static StatisticsRangeRequest allTime() {
+        return new StatisticsRangeRequest(null, null, null, null);
+    }
+
+    static StatisticsRangeRequest parse(
+            String dailyFromText,
+            String dailyToText,
+            String monthlyFromText,
+            String monthlyToText) {
+        LocalDate dailyFrom = parseDate(dailyFromText, "Daily from");
+        LocalDate dailyTo = parseDate(dailyToText, "Daily to");
+        YearMonth monthlyFrom = parseMonth(monthlyFromText, "Monthly from");
+        YearMonth monthlyTo = parseMonth(monthlyToText, "Monthly to");
+        requireOrdered(dailyFrom, dailyTo, "Daily from must be <= daily to.");
+        requireOrdered(monthlyFrom, monthlyTo, "Monthly from must be <= monthly to.");
+        return new StatisticsRangeRequest(dailyFrom, dailyTo, monthlyFrom, monthlyTo);
+    }
+
+    private static LocalDate parseDate(String text, String fieldName) {
+        String value = normalized(text);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(value);
+        } catch (DateTimeParseException exception) {
+            throw new IllegalArgumentException(fieldName + " must use yyyy-MM-dd.", exception);
+        }
+    }
+
+    private static YearMonth parseMonth(String text, String fieldName) {
+        String value = normalized(text);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return YearMonth.parse(value);
+        } catch (DateTimeParseException exception) {
+            throw new IllegalArgumentException(fieldName + " must use yyyy-MM.", exception);
+        }
+    }
+
+    private static <T extends Comparable<T>> void requireOrdered(T fromInclusive, T toInclusive, String message) {
+        if (fromInclusive != null && toInclusive != null && fromInclusive.compareTo(toInclusive) > 0) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+    private static String normalized(String text) {
+        if (text == null || text.isBlank()) {
+            return null;
+        }
+        return text.trim();
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsView.java
@@ -1,0 +1,10 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.StatisticsReportResult;
+
+interface StatisticsView {
+
+    void showReport(StatisticsReportResult report);
+
+    void showMessage(String message, boolean error);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
@@ -1,13 +1,6 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
 import com.github.marcellokim.issuetracker.config.ApplicationContext;
-import com.github.marcellokim.issuetracker.controller.AccountController;
-import com.github.marcellokim.issuetracker.controller.AssignmentController;
-import com.github.marcellokim.issuetracker.controller.AuthenticationController;
-import com.github.marcellokim.issuetracker.controller.DashboardController;
-import com.github.marcellokim.issuetracker.controller.IssueController;
-import com.github.marcellokim.issuetracker.controller.IssueStateController;
-import com.github.marcellokim.issuetracker.controller.ProjectController;
 import java.util.Objects;
 import javax.swing.JFrame;
 import javax.swing.WindowConstants;
@@ -19,38 +12,36 @@ public final class SwingAppFrame extends JFrame {
     private final SwingAppPanel appPanel;
 
     public SwingAppFrame(ApplicationContext context) {
-        this(
-                Objects.requireNonNull(context, "context").authenticationController(),
-                context.dashboardController(),
-                context.accountController(),
-                context.projectController(),
-                context.issueController(),
-                context.issueStateController(),
-                context.assignmentController());
+        this(swingControllers(context), issueActionSupport(context));
     }
 
-    SwingAppFrame(
-            AuthenticationController authenticationController,
-            DashboardController dashboardController,
-            AccountController accountController,
-            ProjectController projectController,
-            IssueController issueController,
-            IssueStateController issueStateController,
-            AssignmentController assignmentController) {
+    SwingAppFrame(SwingControllers controllers, IssueActionSupport issueActionSupport) {
         super("Issue Tracker");
         this.appPanel = new SwingAppPanel(
-                authenticationController,
-                dashboardController,
-                accountController,
-                projectController,
-                issueController,
-                IssueActionSupport.dialogs(issueStateController, assignmentController),
+                controllers,
+                issueActionSupport,
                 this::setTitle);
         setContentPane(appPanel);
         setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         setSize(SwingStyles.WINDOW_SIZE);
         setMinimumSize(SwingStyles.MINIMUM_SIZE);
         setLocationRelativeTo(null);
+    }
+
+    private static SwingControllers swingControllers(ApplicationContext context) {
+        ApplicationContext checked = Objects.requireNonNull(context, "context");
+        return new SwingControllers(
+                checked.authenticationController(),
+                checked.dashboardController(),
+                checked.accountController(),
+                checked.projectController(),
+                checked.issueController(),
+                checked.statisticsController());
+    }
+
+    private static IssueActionSupport issueActionSupport(ApplicationContext context) {
+        ApplicationContext checked = Objects.requireNonNull(context, "context");
+        return IssueActionSupport.dialogs(checked.issueStateController(), checked.assignmentController());
     }
 
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -6,6 +6,7 @@ import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
 import com.github.marcellokim.issuetracker.controller.IssueController;
 import com.github.marcellokim.issuetracker.controller.ProjectController;
+import com.github.marcellokim.issuetracker.controller.StatisticsController;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.service.AssignmentOptionsResult;
 import com.github.marcellokim.issuetracker.service.UserResult;
@@ -30,11 +31,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private static final String ADMIN_DASHBOARD_CARD = "adminDashboard";
     private static final String PROJECT_LIST_CARD = "projectList";
 
-    private final transient AuthenticationController authenticationController;
-    private final transient DashboardController dashboardController;
-    private final transient AccountController accountController;
-    private final transient ProjectController projectController;
-    private final transient IssueController issueController;
+    private final transient SwingControllers controllers;
     private final transient IssueActionSupport issueActionSupport;
     private final transient Consumer<String> titleUpdater;
     private final CardLayout cardLayout = new CardLayout();
@@ -49,6 +46,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private final transient AtomicReference<SwingWorker<Void, Void>> projectListWorker = new AtomicReference<>();
     private final transient AtomicReference<SwingWorker<Void, Void>> issueListWorker = new AtomicReference<>();
     private final transient AtomicReference<SwingWorker<Void, Void>> issueDetailWorker = new AtomicReference<>();
+    private final transient AtomicReference<SwingWorker<Void, Void>> statisticsWorker = new AtomicReference<>();
 
     SwingAppPanel(
             AuthenticationController authenticationController,
@@ -58,11 +56,12 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             IssueController issueController,
             Consumer<String> titleUpdater) {
         this(
-                authenticationController,
-                dashboardController,
-                accountController,
-                projectController,
-                issueController,
+                SwingControllers.withoutStatistics(
+                        authenticationController,
+                        dashboardController,
+                        accountController,
+                        projectController,
+                        issueController),
                 IssueActionSupport.disabled(),
                 titleUpdater);
     }
@@ -75,11 +74,22 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             IssueController issueController,
             IssueActionSupport issueActionSupport,
             Consumer<String> titleUpdater) {
-        this.authenticationController = Objects.requireNonNull(authenticationController, "authenticationController");
-        this.dashboardController = Objects.requireNonNull(dashboardController, "dashboardController");
-        this.accountController = Objects.requireNonNull(accountController, "accountController");
-        this.projectController = Objects.requireNonNull(projectController, "projectController");
-        this.issueController = Objects.requireNonNull(issueController, "issueController");
+        this(
+                SwingControllers.withoutStatistics(
+                        authenticationController,
+                        dashboardController,
+                        accountController,
+                        projectController,
+                        issueController),
+                issueActionSupport,
+                titleUpdater);
+    }
+
+    SwingAppPanel(
+            SwingControllers controllers,
+            IssueActionSupport issueActionSupport,
+            Consumer<String> titleUpdater) {
+        this.controllers = Objects.requireNonNull(controllers, "controllers");
         this.issueActionSupport = Objects.requireNonNull(issueActionSupport, "issueActionSupport");
         this.titleUpdater = Objects.requireNonNull(titleUpdater, "titleUpdater");
 
@@ -104,6 +114,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectListWorker();
             cancelIssueListWorker();
             cancelIssueDetailWorker();
+            cancelStatisticsWorker();
             titleUpdater.accept("Issue Tracker");
             loginPanel.showMessage(" ", false);
             loginPanel.clearPassword();
@@ -123,6 +134,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectListWorker();
             cancelIssueListWorker();
             cancelIssueDetailWorker();
+            cancelStatisticsWorker();
             titleUpdater.accept("Admin dashboard");
             AdminDashboardPanel panel = new AdminDashboardPanel(
                     user,
@@ -149,6 +161,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectListWorker();
             cancelIssueListWorker();
             cancelIssueDetailWorker();
+            cancelStatisticsWorker();
             titleUpdater.accept("Project list");
             ProjectListPanel panel = new ProjectListPanel(
                     user,
@@ -172,7 +185,8 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         cancelProjectListWorker();
         cancelIssueListWorker();
         cancelIssueDetailWorker();
-        authenticationController.logout();
+        cancelStatisticsWorker();
+        controllers.authenticationController().logout();
         showLogin();
     }
 
@@ -182,7 +196,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         }
 
         LoginView capturedView = captureLoginRequest();
-        LoginPresenter presenter = new LoginPresenter(authenticationController, capturedView, this);
+        LoginPresenter presenter = new LoginPresenter(controllers.authenticationController(), capturedView, this);
         SwingWorker<Void, Void> worker = new SwingWorker<>() {
             @Override
             protected Void doInBackground() {
@@ -237,6 +251,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectListWorker();
             cancelIssueListWorker();
             cancelIssueDetailWorker();
+            cancelStatisticsWorker();
             titleUpdater.accept("Account management");
             AccountManagementPanel panel = new AccountManagementPanel(
                     user,
@@ -268,6 +283,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectListWorker();
             cancelIssueListWorker();
             cancelIssueDetailWorker();
+            cancelStatisticsWorker();
             titleUpdater.accept("Project management");
             ProjectManagementPanel panel = new ProjectManagementPanel(
                     user,
@@ -306,6 +322,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectListWorker();
             cancelIssueListWorker();
             cancelIssueDetailWorker();
+            cancelStatisticsWorker();
             titleUpdater.accept("Project detail");
             ProjectDetailPanel panel = new ProjectDetailPanel(
                     user,
@@ -348,6 +365,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectListWorker();
             cancelIssueListWorker();
             cancelIssueDetailWorker();
+            cancelStatisticsWorker();
             titleUpdater.accept("Issue list");
             IssueListPanel panel = new IssueListPanel(
                     user,
@@ -362,6 +380,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
                                             panelRef,
                                             presenter -> presenter.registerIssue(projectId, request)),
                             issueId -> showIssueDetail(user, projectId, issueId),
+                            () -> showStatistics(user, projectId),
                             () -> showProjectList(user),
                             this::logout));
             projectListCard.removeAll();
@@ -370,6 +389,35 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             projectListCard.repaint();
             cardLayout.show(this, PROJECT_LIST_CARD);
             startIssueListTask(panel, presenter -> presenter.loadProjectAndIssues(projectId));
+        });
+    }
+
+    private void showStatistics(UserResult user, long projectId) {
+        SwingUtilities.invokeLater(() -> {
+            cancelDashboardWorker();
+            cancelAccountWorker();
+            cancelProjectWorker();
+            cancelProjectDetailWorker();
+            cancelProjectListWorker();
+            cancelIssueListWorker();
+            cancelIssueDetailWorker();
+            cancelStatisticsWorker();
+            titleUpdater.accept("Statistics");
+            StatisticsPanel panel = new StatisticsPanel(
+                    user,
+                    new StatisticsPanel.StatisticsActions(
+                            (panelRef, request) ->
+                                    startStatisticsTask(
+                                            panelRef,
+                                            presenter -> presenter.loadStatistics(projectId, request)),
+                            () -> showIssueList(user, projectId),
+                            this::logout));
+            projectListCard.removeAll();
+            projectListCard.add(panel, BorderLayout.CENTER);
+            projectListCard.revalidate();
+            projectListCard.repaint();
+            cardLayout.show(this, PROJECT_LIST_CARD);
+            startStatisticsTask(panel, presenter -> presenter.loadStatistics(projectId));
         });
     }
 
@@ -382,6 +430,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectListWorker();
             cancelIssueListWorker();
             cancelIssueDetailWorker();
+            cancelStatisticsWorker();
             titleUpdater.accept("Issue detail");
             IssueDetailPanel panel = new IssueDetailPanel(
                     user,
@@ -438,6 +487,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             cancelProjectListWorker();
             cancelIssueListWorker();
             cancelIssueDetailWorker();
+            cancelStatisticsWorker();
             titleUpdater.accept("Issue action");
             showPlaceholder(
                     projectListCard,
@@ -603,6 +653,23 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         }
     }
 
+    private void startStatisticsTask(StatisticsPanel panel, StatisticsTask task) {
+        Objects.requireNonNull(panel, "panel");
+        Objects.requireNonNull(task, "task");
+        cancelStatisticsWorker();
+        panel.setBusy(true);
+        StatisticsWorker worker = new StatisticsWorker(panel, task);
+        statisticsWorker.set(worker);
+        worker.execute();
+    }
+
+    private void cancelStatisticsWorker() {
+        SwingWorker<Void, Void> worker = statisticsWorker.getAndSet(null);
+        if (worker != null && !worker.isDone()) {
+            worker.cancel(true);
+        }
+    }
+
     private void showLoginFailure(String message) {
         runOnEdtAndWait(() -> {
             loginPanel.showMessage(message, true);
@@ -655,7 +722,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         @Override
         protected Void doInBackground() {
             AdminDashboardPresenter presenter = new AdminDashboardPresenter(
-                    dashboardController,
+                    controllers.dashboardController(),
                     new CurrentDashboardView(panel, this, dashboardWorker::get));
             presenter.load();
             return null;
@@ -680,8 +747,8 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         @Override
         protected Void doInBackground() {
             AccountManagementPresenter presenter = new AccountManagementPresenter(
-                    dashboardController,
-                    accountController,
+                    controllers.dashboardController(),
+                    controllers.accountController(),
                     new CurrentAccountManagementView(panel, this, accountWorker::get));
             task.run(presenter);
             return null;
@@ -706,8 +773,8 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         @Override
         protected Void doInBackground() {
             ProjectManagementPresenter presenter = new ProjectManagementPresenter(
-                    dashboardController,
-                    projectController,
+                    controllers.dashboardController(),
+                    controllers.projectController(),
                     new CurrentProjectSummaryView(panel, this, projectWorker::get));
             task.run(presenter);
             return null;
@@ -732,7 +799,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         @Override
         protected Void doInBackground() {
             ProjectDetailPresenter presenter = new ProjectDetailPresenter(
-                    projectController,
+                    controllers.projectController(),
                     new CurrentProjectDetailView(panel, this, projectDetailWorker::get));
             task.run(presenter);
             return null;
@@ -757,7 +824,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         @Override
         protected Void doInBackground() {
             ProjectListPresenter presenter = new ProjectListPresenter(
-                    dashboardController,
+                    controllers.dashboardController(),
                     new CurrentProjectSummaryView(panel, this, projectListWorker::get));
             task.run(presenter);
             return null;
@@ -782,8 +849,8 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         @Override
         protected Void doInBackground() {
             IssueListPresenter presenter = new IssueListPresenter(
-                    projectController,
-                    issueController,
+                    controllers.projectController(),
+                    controllers.issueController(),
                     new CurrentIssueListView(panel, this, issueListWorker::get));
             task.run(presenter);
             return null;
@@ -808,7 +875,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         @Override
         protected Void doInBackground() {
             IssueDetailPresenter presenter = new IssueDetailPresenter(
-                    issueController,
+                    controllers.issueController(),
                     issueActionSupport.statusChange().issueStateController(),
                     issueActionSupport.assignmentController(),
                     new CurrentIssueDetailView(panel, this, issueDetailWorker::get));
@@ -871,6 +938,38 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         }
     }
 
+    private final class StatisticsWorker extends SwingWorker<Void, Void> {
+
+        private final StatisticsPanel panel;
+        private final StatisticsTask task;
+
+        private StatisticsWorker(StatisticsPanel panel, StatisticsTask task) {
+            this.panel = Objects.requireNonNull(panel, "panel");
+            this.task = Objects.requireNonNull(task, "task");
+        }
+
+        @Override
+        protected Void doInBackground() {
+            StatisticsPresenter presenter = new StatisticsPresenter(
+                    requireStatisticsController(),
+                    new CurrentStatisticsView(panel, this, statisticsWorker::get));
+            task.run(presenter);
+            return null;
+        }
+
+        @Override
+        protected void done() {
+            finishWorker(statisticsWorker, this, () -> panel.setBusy(false), panel::showMessage, "Statistics");
+        }
+
+        private StatisticsController requireStatisticsController() {
+            if (controllers.statisticsController() == null) {
+                throw new IllegalStateException("Statistics controller is not configured.");
+            }
+            return controllers.statisticsController();
+        }
+    }
+
     private static void finishWorker(
             AtomicReference<SwingWorker<Void, Void>> workerRef,
             SwingWorker<Void, Void> worker,
@@ -928,6 +1027,12 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private interface IssueDetailTask {
 
         void run(IssueDetailPresenter presenter);
+    }
+
+    @FunctionalInterface
+    private interface StatisticsTask {
+
+        void run(StatisticsPresenter presenter);
     }
 
     @FunctionalInterface

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingControllers.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingControllers.java
@@ -1,0 +1,41 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.controller.AccountController;
+import com.github.marcellokim.issuetracker.controller.AuthenticationController;
+import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.controller.IssueController;
+import com.github.marcellokim.issuetracker.controller.ProjectController;
+import com.github.marcellokim.issuetracker.controller.StatisticsController;
+import java.util.Objects;
+
+record SwingControllers(
+        AuthenticationController authenticationController,
+        DashboardController dashboardController,
+        AccountController accountController,
+        ProjectController projectController,
+        IssueController issueController,
+        StatisticsController statisticsController) {
+
+    SwingControllers {
+        Objects.requireNonNull(authenticationController, "authenticationController");
+        Objects.requireNonNull(dashboardController, "dashboardController");
+        Objects.requireNonNull(accountController, "accountController");
+        Objects.requireNonNull(projectController, "projectController");
+        Objects.requireNonNull(issueController, "issueController");
+    }
+
+    static SwingControllers withoutStatistics(
+            AuthenticationController authenticationController,
+            DashboardController dashboardController,
+            AccountController accountController,
+            ProjectController projectController,
+            IssueController issueController) {
+        return new SwingControllers(
+                authenticationController,
+                dashboardController,
+                accountController,
+                projectController,
+                issueController,
+                null);
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/support/FakeStatisticsRepository.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/support/FakeStatisticsRepository.java
@@ -1,0 +1,64 @@
+package com.github.marcellokim.issuetracker.support;
+
+import com.github.marcellokim.issuetracker.repository.StatisticsReport;
+import com.github.marcellokim.issuetracker.repository.StatisticsRepository;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Objects;
+
+public final class FakeStatisticsRepository implements StatisticsRepository {
+
+    private StatisticsReport report;
+    private RuntimeException failure;
+    private long lastProjectId;
+    private LocalDate lastDailyFromInclusive;
+    private LocalDate lastDailyToInclusive;
+    private YearMonth lastMonthlyFromInclusive;
+    private YearMonth lastMonthlyToInclusive;
+
+    public FakeStatisticsRepository(StatisticsReport report) {
+        this.report = Objects.requireNonNull(report, "report");
+    }
+
+    public void failWith(RuntimeException failure) {
+        this.failure = Objects.requireNonNull(failure, "failure");
+    }
+
+    public long lastProjectId() {
+        return lastProjectId;
+    }
+
+    public LocalDate lastDailyFromInclusive() {
+        return lastDailyFromInclusive;
+    }
+
+    public LocalDate lastDailyToInclusive() {
+        return lastDailyToInclusive;
+    }
+
+    public YearMonth lastMonthlyFromInclusive() {
+        return lastMonthlyFromInclusive;
+    }
+
+    public YearMonth lastMonthlyToInclusive() {
+        return lastMonthlyToInclusive;
+    }
+
+    @Override
+    public StatisticsReport calculateProjectStatistics(
+            long projectId,
+            LocalDate dailyFromInclusive,
+            LocalDate dailyToInclusive,
+            YearMonth monthlyFromInclusive,
+            YearMonth monthlyToInclusive) {
+        if (failure != null) {
+            throw failure;
+        }
+        lastProjectId = projectId;
+        lastDailyFromInclusive = dailyFromInclusive;
+        lastDailyToInclusive = dailyToInclusive;
+        lastMonthlyFromInclusive = monthlyFromInclusive;
+        lastMonthlyToInclusive = monthlyToInclusive;
+        return report;
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanelTest.java
@@ -66,11 +66,12 @@ class IssueListPanelTest {
     }
 
     @Test
-    @DisplayName("publishes search, register, open, back, and logout actions")
+    @DisplayName("publishes search, register, open, statistics, back, and logout actions")
     void publishesActions() throws Exception {
         var searchRef = new AtomicReference<IssueSearchRequest>();
         var registerRef = new AtomicReference<IssueRegisterRequest>();
         var openRef = new AtomicLong();
+        var statisticsClicks = new AtomicInteger();
         var backClicks = new AtomicInteger();
         var logoutClicks = new AtomicInteger();
         FixedIssueDialogs dialogs = new FixedIssueDialogs();
@@ -83,6 +84,7 @@ class IssueListPanelTest {
                             (source, request) -> searchRef.set(request),
                             (source, request) -> registerRef.set(request),
                             openRef::set,
+                            statisticsClicks::incrementAndGet,
                             backClicks::incrementAndGet,
                             logoutClicks::incrementAndGet));
             panel.showProject(project());
@@ -99,6 +101,7 @@ class IssueListPanelTest {
             JTable table = SwingComponentTestSupport.find(panel, "issueListTable", JTable.class);
             table.setRowSelectionInterval(0, 0);
             SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "statisticsButton", JButton.class).doClick();
             SwingComponentTestSupport.find(panel, "issueListBackButton", JButton.class).doClick();
             SwingComponentTestSupport.find(panel, "issueListLogoutButton", JButton.class).doClick();
         });
@@ -106,6 +109,7 @@ class IssueListPanelTest {
         assertEquals(new IssueSearchRequest("login", IssueStatus.NEW, Priority.CRITICAL), searchRef.get());
         assertEquals(new IssueRegisterRequest("New issue", "New issue description", Priority.MINOR), registerRef.get());
         assertEquals(7L, openRef.get());
+        assertEquals(1, statisticsClicks.get());
         assertEquals(1, backClicks.get());
         assertEquals(1, logoutClicks.get());
     }
@@ -125,6 +129,8 @@ class IssueListPanelTest {
                             (source, request) -> {
                             },
                             openRef::set,
+                            () -> {
+                            },
                             () -> {
                             },
                             () -> {
@@ -195,6 +201,8 @@ class IssueListPanelTest {
                         (source, request) -> {
                         },
                         issueId -> {
+                        },
+                        () -> {
                         },
                         () -> {
                         },

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsPanelTest.java
@@ -1,0 +1,253 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.StatisticsReport;
+import com.github.marcellokim.issuetracker.repository.StatisticsRepository.DailyIssueCount;
+import com.github.marcellokim.issuetracker.repository.StatisticsRepository.MonthlyIssueCount;
+import com.github.marcellokim.issuetracker.service.StatisticsReportResult;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.imageio.ImageIO;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JTabbedPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing statistics panel")
+class StatisticsPanelTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("renders report tables and publishes filter/back/logout actions")
+    void rendersReportTablesAndPublishesActions() throws Exception {
+        AtomicReference<StatisticsRangeRequest> requestRef = new AtomicReference<>();
+        AtomicInteger backClicks = new AtomicInteger();
+        AtomicInteger logoutClicks = new AtomicInteger();
+
+        SwingComponentTestSupport.onEdt(() -> {
+            StatisticsPanel panel = panel(requestRef, backClicks, logoutClicks);
+            panel.showReport(StatisticsReportResult.from(report()));
+            panel.showMessage("3 issues", false);
+
+            assertEquals("Statistics", SwingComponentTestSupport.find(panel, "statisticsTitle", JLabel.class)
+                    .getText());
+            assertEquals("3 issues", SwingComponentTestSupport.find(panel, "statisticsMessage", JLabel.class)
+                    .getText());
+            assertEquals(2, SwingComponentTestSupport.find(panel, "statisticsStatusTable", JTable.class)
+                    .getRowCount());
+            assertEquals(IssueStatus.NEW, SwingComponentTestSupport.find(panel, "statisticsStatusTable", JTable.class)
+                    .getValueAt(0, 0));
+            assertEquals(2, SwingComponentTestSupport.find(panel, "statisticsPriorityTable", JTable.class)
+                    .getRowCount());
+            assertEquals(1, SwingComponentTestSupport.find(panel, "statisticsDailyTable", JTable.class).getRowCount());
+            assertEquals(1, SwingComponentTestSupport.find(panel, "statisticsMonthlyTable", JTable.class).getRowCount());
+            JTable monthlyStatusTable = SwingComponentTestSupport.find(
+                    panel, "statisticsMonthlyStatusTable", JTable.class);
+            assertEquals(visibleStatusCount(), monthlyStatusTable.getRowCount());
+            assertEquals(2, countFor(monthlyStatusTable, IssueStatus.NEW));
+            assertEquals(0, countFor(monthlyStatusTable, IssueStatus.CLOSED));
+            JTable monthlyPriorityTable = SwingComponentTestSupport.find(
+                    panel, "statisticsMonthlyPriorityTable", JTable.class);
+            assertEquals(Priority.values().length, monthlyPriorityTable.getRowCount());
+            assertEquals(1, countFor(monthlyPriorityTable, Priority.CRITICAL));
+            assertEquals(0, countFor(monthlyPriorityTable, Priority.MAJOR));
+            assertEquals(1, SwingComponentTestSupport.find(panel, "statisticsDailyStatusChangeTable", JTable.class)
+                    .getRowCount());
+            assertEquals(1, SwingComponentTestSupport.find(panel, "statisticsMonthlyCommentTable", JTable.class)
+                    .getRowCount());
+
+            SwingComponentTestSupport.find(panel, "statisticsDailyFromField", JTextField.class)
+                    .setText("2026-05-01");
+            SwingComponentTestSupport.find(panel, "statisticsDailyToField", JTextField.class)
+                    .setText("2026-05-31");
+            SwingComponentTestSupport.find(panel, "statisticsMonthlyFromField", JTextField.class)
+                    .setText("2026-05");
+            SwingComponentTestSupport.find(panel, "statisticsMonthlyToField", JTextField.class)
+                    .setText("2026-06");
+            SwingComponentTestSupport.find(panel, "loadStatisticsButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "statisticsBackButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "statisticsLogoutButton", JButton.class).doClick();
+        });
+
+        assertEquals(
+                new StatisticsRangeRequest(
+                        LocalDate.of(2026, 5, 1),
+                        LocalDate.of(2026, 5, 31),
+                        YearMonth.of(2026, 5),
+                        YearMonth.of(2026, 6)),
+                requestRef.get());
+        assertEquals(1, backClicks.get());
+        assertEquals(1, logoutClicks.get());
+    }
+
+    @Test
+    @DisplayName("shows validation errors without publishing a filter request")
+    void showsValidationErrorsWithoutPublishingFilterRequest() throws Exception {
+        AtomicReference<StatisticsRangeRequest> requestRef = new AtomicReference<>();
+
+        SwingComponentTestSupport.onEdt(() -> {
+            StatisticsPanel panel = panel(requestRef, new AtomicInteger(), new AtomicInteger());
+            SwingComponentTestSupport.find(panel, "statisticsDailyFromField", JTextField.class)
+                    .setText("2026/05/01");
+            SwingComponentTestSupport.find(panel, "loadStatisticsButton", JButton.class).doClick();
+
+            assertEquals(
+                    "Daily from must use yyyy-MM-dd.",
+                    SwingComponentTestSupport.find(panel, "statisticsMessage", JLabel.class).getText());
+        });
+
+        assertEquals(null, requestRef.get());
+    }
+
+    @Test
+    @DisplayName("renders statistics screen snapshot")
+    void rendersStatisticsSnapshot() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            StatisticsPanel panel = panel(new AtomicReference<>(), new AtomicInteger(), new AtomicInteger());
+            panel.showReport(StatisticsReportResult.from(report()));
+            panel.setSize(SwingStyles.WINDOW_SIZE);
+            layoutRecursively(panel);
+
+            BufferedImage image = render(panel, Path.of("build/reports/ui/swing-statistics-view.png"));
+
+            assertTrue(hasRenderedContent(image));
+        });
+    }
+
+    @Test
+    @DisplayName("renders statistics distribution snapshot")
+    void rendersDistributionSnapshot() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            StatisticsPanel panel = panel(new AtomicReference<>(), new AtomicInteger(), new AtomicInteger());
+            panel.showReport(StatisticsReportResult.from(report()));
+            SwingComponentTestSupport.find(panel, "statisticsTabs", JTabbedPane.class).setSelectedIndex(2);
+            panel.setSize(SwingStyles.WINDOW_SIZE);
+            layoutRecursively(panel);
+
+            BufferedImage image = render(panel, Path.of("build/reports/ui/swing-statistics-distribution-view.png"));
+
+            assertTrue(hasRenderedContent(image));
+        });
+    }
+
+    private static StatisticsPanel panel(
+            AtomicReference<StatisticsRangeRequest> requestRef,
+            AtomicInteger backClicks,
+            AtomicInteger logoutClicks) {
+        return new StatisticsPanel(
+                userResult("dev1", Role.DEV),
+                new StatisticsPanel.StatisticsActions(
+                        (source, request) -> requestRef.set(request),
+                        backClicks::incrementAndGet,
+                        logoutClicks::incrementAndGet));
+    }
+
+    private static StatisticsReport report() {
+        Map<IssueStatus, Integer> statusCounts = new EnumMap<>(IssueStatus.class);
+        statusCounts.put(IssueStatus.NEW, 2);
+        statusCounts.put(IssueStatus.CLOSED, 1);
+        Map<Priority, Integer> priorityCounts = new EnumMap<>(Priority.class);
+        priorityCounts.put(Priority.CRITICAL, 1);
+        priorityCounts.put(Priority.MAJOR, 2);
+        Map<YearMonth, Map<IssueStatus, Integer>> monthlyStatusCounts = Map.of(
+                YearMonth.of(2026, 5),
+                Map.of(IssueStatus.NEW, 2));
+        Map<YearMonth, Map<Priority, Integer>> monthlyPriorityCounts = Map.of(
+                YearMonth.of(2026, 5),
+                Map.of(Priority.CRITICAL, 1));
+        return StatisticsReport.create(
+                statusCounts,
+                priorityCounts,
+                List.of(new DailyIssueCount(LocalDate.of(2026, 5, 31), 3)),
+                List.of(new MonthlyIssueCount(YearMonth.of(2026, 5), 3)),
+                monthlyStatusCounts,
+                monthlyPriorityCounts,
+                List.of(new DailyIssueCount(LocalDate.of(2026, 5, 31), 2)),
+                List.of(new MonthlyIssueCount(YearMonth.of(2026, 5), 2)),
+                List.of(new DailyIssueCount(LocalDate.of(2026, 5, 31), 4)),
+                List.of(new MonthlyIssueCount(YearMonth.of(2026, 5), 4)));
+    }
+
+    private static UserResult userResult(String loginId, Role role) {
+        return UserResult.from(User.fromPersistence(loginId, loginId, "stored-password", role, true, NOW, NOW));
+    }
+
+    private static int visibleStatusCount() {
+        return (int) Arrays.stream(IssueStatus.values())
+                .filter(status -> status != IssueStatus.DELETED)
+                .count();
+    }
+
+    private static int countFor(JTable table, Object value) {
+        for (int row = 0; row < table.getRowCount(); row++) {
+            if (value == table.getValueAt(row, 1)) {
+                return ((Number) table.getValueAt(row, 2)).intValue();
+            }
+        }
+        throw new AssertionError("Missing row for " + value);
+    }
+
+    private static void layoutRecursively(Container container) {
+        container.doLayout();
+        for (java.awt.Component child : container.getComponents()) {
+            if (child instanceof Container nested) {
+                layoutRecursively(nested);
+            }
+        }
+    }
+
+    private static BufferedImage render(StatisticsPanel panel, Path output) throws java.io.IOException {
+        BufferedImage image = new BufferedImage(
+                SwingStyles.WINDOW_SIZE.width,
+                SwingStyles.WINDOW_SIZE.height,
+                BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            panel.printAll(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        Files.createDirectories(output.getParent());
+        ImageIO.write(image, "png", output.toFile());
+        return image;
+    }
+
+    private static boolean hasRenderedContent(BufferedImage image) {
+        int background = SwingStyles.BACKGROUND.getRGB();
+        int white = Color.WHITE.getRGB();
+        int contentPixels = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                int pixel = image.getRGB(x, y);
+                if (pixel != background && pixel != white) {
+                    contentPixels++;
+                }
+            }
+        }
+        return contentPixels > 10_000;
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsPresenterTest.java
@@ -1,0 +1,151 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.github.marcellokim.issuetracker.controller.AuthenticationController;
+import com.github.marcellokim.issuetracker.controller.StatisticsController;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.repository.StatisticsRepository.DailyIssueCount;
+import com.github.marcellokim.issuetracker.repository.StatisticsRepository.MonthlyIssueCount;
+import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.PasswordHashing;
+import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.service.StatisticsReportResult;
+import com.github.marcellokim.issuetracker.service.StatisticsService;
+import com.github.marcellokim.issuetracker.support.FakeStatisticsRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.support.StatisticsReportTestFactory;
+import com.github.marcellokim.issuetracker.technical.SessionStore;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing statistics presenter")
+class StatisticsPresenterTest {
+
+    private static final long PROJECT_ID = 7L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("loads default and filtered statistics through the controller")
+    void loadsDefaultAndFilteredStatistics() {
+        User dev = user("dev1", Role.DEV);
+        FakeStatisticsRepository statistics = new FakeStatisticsRepository(report());
+        StatisticsPresenter presenter = new StatisticsPresenter(controller(statistics, dev), new RecordingView());
+
+        presenter.loadStatistics(PROJECT_ID);
+
+        assertEquals(PROJECT_ID, statistics.lastProjectId());
+        assertNull(statistics.lastDailyFromInclusive());
+
+        presenter.loadStatistics(PROJECT_ID, new StatisticsRangeRequest(
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 5, 31),
+                YearMonth.of(2026, 5),
+                YearMonth.of(2026, 6)));
+
+        assertEquals(LocalDate.of(2026, 5, 1), statistics.lastDailyFromInclusive());
+        assertEquals(LocalDate.of(2026, 5, 31), statistics.lastDailyToInclusive());
+        assertEquals(YearMonth.of(2026, 5), statistics.lastMonthlyFromInclusive());
+        assertEquals(YearMonth.of(2026, 6), statistics.lastMonthlyToInclusive());
+    }
+
+    @Test
+    @DisplayName("keeps statistics failures in the view message")
+    void keepsStatisticsFailuresInViewMessage() {
+        User dev = user("dev1", Role.DEV);
+        FakeStatisticsRepository statistics = new FakeStatisticsRepository(report());
+        statistics.failWith(new IllegalArgumentException("dailyFromInclusive must be <= dailyToInclusive"));
+        RecordingView view = new RecordingView();
+        StatisticsPresenter presenter = new StatisticsPresenter(controller(statistics, dev), view);
+
+        presenter.loadStatistics(PROJECT_ID);
+
+        assertEquals("dailyFromInclusive must be <= dailyToInclusive", view.message);
+        assertEquals(true, view.error);
+        assertNull(view.report);
+    }
+
+    private static StatisticsController controller(FakeStatisticsRepository statistics, User actor) {
+        InMemoryUserRepository users = new InMemoryUserRepository(actor)
+                .withProjectMembers(PROJECT_ID, actor.getLoginId());
+        AuthenticationService authentication = new AuthenticationService(users, new PlainPasswordHashing(), new SessionStore());
+        new AuthenticationController(authentication).login(actor.getLoginId(), "password");
+        return new StatisticsController(
+                authentication,
+                new StatisticsService(new PermissionPolicy(), statistics, users));
+    }
+
+    private static User user(String loginId, Role role) {
+        return User.fromPersistence(loginId, loginId, "password", role, true, NOW, NOW);
+    }
+
+    private static com.github.marcellokim.issuetracker.repository.StatisticsReport report() {
+        Map<IssueStatus, Integer> statusCounts = new EnumMap<>(IssueStatus.class);
+        statusCounts.put(IssueStatus.NEW, 2);
+        statusCounts.put(IssueStatus.CLOSED, 1);
+        Map<Priority, Integer> priorityCounts = new EnumMap<>(Priority.class);
+        priorityCounts.put(Priority.CRITICAL, 1);
+        priorityCounts.put(Priority.MAJOR, 2);
+        return StatisticsReportTestFactory.create(
+                statusCounts,
+                priorityCounts,
+                List.of(new DailyIssueCount(LocalDate.of(2026, 5, 31), 3)),
+                List.of(new MonthlyIssueCount(YearMonth.of(2026, 5), 3)));
+    }
+
+    private static final class RecordingView implements StatisticsView {
+
+        private StatisticsReportResult report;
+        private String message;
+        private boolean error;
+
+        @Override
+        public void showReport(StatisticsReportResult report) {
+            this.report = report;
+        }
+
+        @Override
+        public void showMessage(String message, boolean error) {
+            this.message = message;
+            this.error = error;
+        }
+    }
+
+    private static final class PlainPasswordHashing implements PasswordHashing {
+
+        @Override
+        public String hash(String password) {
+            return password;
+        }
+
+        @Override
+        public boolean matches(String password, String storedCredential) {
+            return storedCredential.equals(password);
+        }
+
+        @Override
+        public boolean isHashed(String storedCredential) {
+            return true;
+        }
+
+        @Override
+        public String saltOf(String storedCredential) {
+            return "salt";
+        }
+
+        @Override
+        public String hashOf(String storedCredential) {
+            return storedCredential;
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsRangeRequestTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsRangeRequestTest.java
@@ -1,0 +1,51 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing statistics range request")
+class StatisticsRangeRequestTest {
+
+    @Test
+    @DisplayName("parses blank values as an all-time range")
+    void parsesBlankValuesAsAllTimeRange() {
+        StatisticsRangeRequest request = StatisticsRangeRequest.parse(" ", "", null, "   ");
+
+        assertNull(request.dailyFromInclusive());
+        assertNull(request.dailyToInclusive());
+        assertNull(request.monthlyFromInclusive());
+        assertNull(request.monthlyToInclusive());
+    }
+
+    @Test
+    @DisplayName("parses ISO date and year-month text")
+    void parsesIsoDateAndYearMonthText() {
+        StatisticsRangeRequest request = StatisticsRangeRequest.parse(
+                "2026-05-01",
+                "2026-05-31",
+                "2026-05",
+                "2026-06");
+
+        assertEquals(LocalDate.of(2026, 5, 1), request.dailyFromInclusive());
+        assertEquals(LocalDate.of(2026, 5, 31), request.dailyToInclusive());
+        assertEquals(YearMonth.of(2026, 5), request.monthlyFromInclusive());
+        assertEquals(YearMonth.of(2026, 6), request.monthlyToInclusive());
+    }
+
+    @Test
+    @DisplayName("rejects invalid text and reversed ranges before calling controllers")
+    void rejectsInvalidTextAndReversedRanges() {
+        assertThrows(IllegalArgumentException.class,
+                () -> StatisticsRangeRequest.parse("2026/05/01", null, null, null));
+        assertThrows(IllegalArgumentException.class,
+                () -> StatisticsRangeRequest.parse("2026-05-31", "2026-05-01", null, null));
+        assertThrows(IllegalArgumentException.class,
+                () -> StatisticsRangeRequest.parse(null, null, "2026-08", "2026-07"));
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -13,6 +13,7 @@ import com.github.marcellokim.issuetracker.controller.DashboardController;
 import com.github.marcellokim.issuetracker.controller.IssueController;
 import com.github.marcellokim.issuetracker.controller.IssueStateController;
 import com.github.marcellokim.issuetracker.controller.ProjectController;
+import com.github.marcellokim.issuetracker.controller.StatisticsController;
 import com.github.marcellokim.issuetracker.domain.Comment;
 import com.github.marcellokim.issuetracker.domain.CommentPurpose;
 import com.github.marcellokim.issuetracker.domain.Issue;
@@ -26,6 +27,9 @@ import com.github.marcellokim.issuetracker.repository.AssignmentRecommendationRe
 import com.github.marcellokim.issuetracker.repository.CommentRepository;
 import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository;
 import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository.DashboardProjectSnapshot;
+import com.github.marcellokim.issuetracker.repository.StatisticsReport;
+import com.github.marcellokim.issuetracker.repository.StatisticsRepository.DailyIssueCount;
+import com.github.marcellokim.issuetracker.repository.StatisticsRepository.MonthlyIssueCount;
 import com.github.marcellokim.issuetracker.service.AccountService;
 import com.github.marcellokim.issuetracker.service.AssignmentRecommendationService;
 import com.github.marcellokim.issuetracker.service.AssignmentService;
@@ -38,15 +42,19 @@ import com.github.marcellokim.issuetracker.service.KNNAssignmentRecommendation;
 import com.github.marcellokim.issuetracker.service.PasswordHashing;
 import com.github.marcellokim.issuetracker.service.PermissionPolicy;
 import com.github.marcellokim.issuetracker.service.ProjectService;
+import com.github.marcellokim.issuetracker.service.StatisticsService;
 import com.github.marcellokim.issuetracker.support.FakeIssueDependencyRepository;
 import com.github.marcellokim.issuetracker.support.FakeIssueHistoryRepository;
+import com.github.marcellokim.issuetracker.support.FakeStatisticsRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryAssignmentRecommendationRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
 import com.github.marcellokim.issuetracker.technical.SessionStore;
 import java.lang.reflect.Field;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -436,6 +444,45 @@ class SwingAppPanelTest {
                     SwingComponentTestSupport.find(panel, "issueDetailTitle", JLabel.class).getText());
             SwingComponentTestSupport.find(panel, "issueDetailBackButton", JButton.class).doClick();
         });
+        awaitIssueRows(panel, 1);
+    }
+
+    @Test
+    @DisplayName("issue list opens statistics and returns to issue list")
+    void issueListOpensStatisticsAndReturnsToIssueList() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        User dev = user("dev1", Role.DEV);
+        SwingAppPanel panel = loginProjectUser(
+                passwordHashing,
+                titles,
+                List.of(projectSnapshot(7L, "Alpha", 3, 7)),
+                List.of(issue(7L, 7L, "Login bug", Priority.CRITICAL, dev)),
+                dev);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable projects = SwingComponentTestSupport.find(panel, "projectListTable", JTable.class);
+            projects.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openProjectIssuesButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openProjectIssuesButton", JButton.class).doClick());
+        awaitIssueRows(panel, 1);
+        awaitButtonEnabled(panel, "statisticsButton");
+
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "statisticsButton", JButton.class).doClick());
+        awaitRows(panel, "statisticsStatusTable", 2);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            assertEquals(
+                    "Statistics",
+                    SwingComponentTestSupport.find(panel, "statisticsTitle", JLabel.class).getText());
+            JTable statusTable = SwingComponentTestSupport.find(panel, "statisticsStatusTable", JTable.class);
+            assertEquals(IssueStatus.NEW, statusTable.getValueAt(0, 0));
+            SwingComponentTestSupport.find(panel, "statisticsBackButton", JButton.class).doClick();
+        });
+
         awaitIssueRows(panel, 1);
     }
 
@@ -929,11 +976,7 @@ class SwingAppPanelTest {
 
         SwingComponentTestSupport.onEdt(() -> {
             SwingAppPanel panel = new SwingAppPanel(
-                    controllers.authenticationController(),
-                    controllers.dashboardController(),
-                    controllers.accountController(),
-                    controllers.projectController(),
-                    controllers.issueController(),
+                    controllers.swingControllers(),
                     new IssueActionSupport(
                             new IssueStatusChangeSupport(
                                     controllers.issueStateController(),
@@ -1241,6 +1284,7 @@ class SwingAppPanelTest {
         var dependencyRepository = new FakeIssueDependencyRepository();
         var commentRepository = new FakeCommentRepository(comments);
         var historyRepository = new FakeIssueHistoryRepository();
+        var statisticsRepository = new FakeStatisticsRepository(statisticsReport());
         var service = new AuthenticationService(repository, passwordHashing, new SessionStore());
         PermissionPolicy permissionPolicy = new PermissionPolicy();
         IssueStateController issueStateController = new IssueStateController(
@@ -1304,6 +1348,9 @@ class SwingAppPanelTest {
                                 commentRepository,
                                 repository,
                                 permissionPolicy)),
+                new StatisticsController(
+                        service,
+                        new StatisticsService(permissionPolicy, statisticsRepository, repository)),
                 issueStateController,
                 assignmentController);
     }
@@ -1360,14 +1407,39 @@ class SwingAppPanelTest {
         return Comment.fromPersistence(id, issueId, writer.getLoginId(), content, CommentPurpose.GENERAL, NOW, NOW);
     }
 
+    private static StatisticsReport statisticsReport() {
+        return StatisticsReport.create(
+                Map.of(IssueStatus.NEW, 2, IssueStatus.CLOSED, 1),
+                Map.of(Priority.CRITICAL, 1, Priority.MAJOR, 2),
+                List.of(new DailyIssueCount(LocalDate.of(2026, 5, 31), 3)),
+                List.of(new MonthlyIssueCount(YearMonth.of(2026, 5), 3)),
+                Map.of(YearMonth.of(2026, 5), Map.of(IssueStatus.NEW, 2, IssueStatus.CLOSED, 1)),
+                Map.of(YearMonth.of(2026, 5), Map.of(Priority.CRITICAL, 1, Priority.MAJOR, 2)),
+                List.of(new DailyIssueCount(LocalDate.of(2026, 5, 31), 2)),
+                List.of(new MonthlyIssueCount(YearMonth.of(2026, 5), 2)),
+                List.of(new DailyIssueCount(LocalDate.of(2026, 5, 31), 4)),
+                List.of(new MonthlyIssueCount(YearMonth.of(2026, 5), 4)));
+    }
+
     private record SwingControllerFixture(
             AuthenticationController authenticationController,
             DashboardController dashboardController,
             AccountController accountController,
             ProjectController projectController,
             IssueController issueController,
+            StatisticsController statisticsController,
             IssueStateController issueStateController,
             AssignmentController assignmentController) {
+
+        SwingControllers swingControllers() {
+            return new SwingControllers(
+                    authenticationController,
+                    dashboardController,
+                    accountController,
+                    projectController,
+                    issueController,
+                    statisticsController);
+        }
     }
 
     private record SwingPromptSupport(


### PR DESCRIPTION
## purpose
Swing 전체 UI에서 프로젝트 이슈 목록에서 진입 가능한 statistics view를 구현합니다.

Closes #216

## non-goals
- Swing에서 통계 SQL, 집계 로직, DELETED 제외 정책을 재구현하지 않습니다.
- Swing에서 권한/프로젝트 멤버십 정책을 직접 판단하지 않습니다.
- 차트 구현은 이번 범위에 포함하지 않습니다.

## diff map
- 핵심 변경: `StatisticsPanel`, `StatisticsPresenter`, `StatisticsRangeRequest`, `StatisticsView`, `CurrentStatisticsView`를 추가했습니다.
- 진입 연결: `IssueListPanel`에 Statistics 버튼을 추가하고 `SwingAppPanel`/`SwingAppFrame`에 `StatisticsController` 주입 및 화면 전환을 연결했습니다.
- 리뷰 반영: 통계 테이블 행 변환을 EDT 밖에서 준비하고, 월별 분포 테이블은 `DELETED`를 제외한 누락 조합을 0으로 표시합니다.
- 테스트 변경: range parsing, presenter, panel rendering, app navigation 테스트를 추가했습니다.
- 화면 증빙: Swing statistics summary/distribution 화면과 issue list action bar offscreen render snapshot을 생성했습니다.

## verification evidence
- `git diff --check origin/dev...HEAD && git diff --check`
- `./gradlew test --tests '*Statistics*' --tests '*IssueListPanelTest*' --tests '*SwingAppPanelTest*' --console=plain`
- `./gradlew test --tests '*StatisticsPanelTest*' --console=plain`
- `./gradlew check --console=plain`
- pre-push `test + verifyRepositorySetup`
- visual evidence: `build/reports/ui/swing-statistics-view.png`, `build/reports/ui/swing-statistics-distribution-view.png`, `build/reports/ui/issue-list-panel.png`

## reviewer focus areas
- `StatisticsRangeRequest`가 입력 파싱과 from/to 순서 검증까지만 담당하는지
- 통계 권한, 프로젝트 멤버십, 집계 정책이 controller/service 경계에 남아 있는지
- `SwingAppPanel`의 statistics worker 취소/복귀 흐름이 기존 화면 전환 패턴과 맞는지
- issue list action bar에서 Statistics 진입이 기존 검색/등록/상세 진입 흐름을 깨지 않는지
- 월별 분포 테이블에서 `DELETED` 제외와 0건 조합 표시가 함께 유지되는지

## risk / rollback
origin/dev 기준 단일 statistics view PR입니다. 문제 발생 시 이 PR 커밋만 되돌리면 Swing statistics 진입과 전용 화면만 제거되며 backend/application 통계 계약에는 영향 없습니다.
