### PR TITLE
feat: 이슈 dependency 그래프 시각화 화면 추가

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueGraphScreen.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueGraphScreen.java
@@ -1,0 +1,178 @@
+package com.github.marcellokim.issuetracker.ui.javafx;
+
+import com.github.marcellokim.issuetracker.controller.IssueController;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.service.DependencyResult;
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
+
+final class IssueGraphScreen extends VBox {
+
+    private static final double NODE_RADIUS = 24;
+    private static final double PADDING = 60;
+    private static final Map<IssueStatus, Color> STATUS_COLORS = Map.of(
+            IssueStatus.NEW, Color.web("#60A5FA"),
+            IssueStatus.ASSIGNED, Color.web("#FBBF24"),
+            IssueStatus.FIXED, Color.web("#34D399"),
+            IssueStatus.RESOLVED, Color.web("#A78BFA"),
+            IssueStatus.CLOSED, Color.web("#9CA3AF"),
+            IssueStatus.REOPENED, Color.web("#F87171"),
+            IssueStatus.DELETED, Color.web("#6B7280"));
+
+    private final IssueController issueController;
+    private final long projectId;
+    private final Label messageLabel = ScreenComponents.messageLabel();
+    private Runnable onBack;
+
+    IssueGraphScreen(IssueController issueController, long projectId){
+        this.issueController = issueController;
+        this.projectId = projectId;
+        ScreenComponents.applyScreenDefaults(this);
+
+        Button backButton = ScreenComponents.backButton("← Issues", () -> { if (onBack != null) onBack.run(); });
+        Label titleLabel = ScreenComponents.titleLabel("Issue Dependency Graph");
+
+        Label legend = new Label("NEW(blue) ASSIGNED(yellow) FIXED(green) RESOLVED(purple) CLOSED(gray) REOPENED(red)");
+        legend.setStyle("-fx-font-size: 11px; -fx-text-fill: #888;");
+
+        Pane canvasHolder = new Pane();
+        VBox.setVgrow(canvasHolder, Priority.ALWAYS);
+
+        getChildren().addAll(
+                ScreenComponents.header(backButton, titleLabel),
+                legend, canvasHolder, messageLabel);
+
+        canvasHolder.widthProperty().addListener((obs, old, val) -> drawGraph(canvasHolder));
+        canvasHolder.heightProperty().addListener((obs, old, val) -> drawGraph(canvasHolder));
+    }
+
+    void setOnBack(Runnable action){ this.onBack = action; }
+
+    private void drawGraph(Pane holder){
+        double w = holder.getWidth();
+        double h = holder.getHeight();
+        if (w <= 0 || h <= 0) return;
+
+        holder.getChildren().clear();
+        Canvas canvas = new Canvas(w, h);
+        holder.getChildren().add(canvas);
+        GraphicsContext gc = canvas.getGraphicsContext2D();
+        gc.clearRect(0, 0, w, h);
+
+        try{
+            List<IssueSummary> issues = issueController.viewRelatedProjectIssues(projectId);
+            List<DependencyResult> deps = issueController.viewProjectDependencies(projectId);
+            if (issues.isEmpty()){
+                ScreenComponents.showInfo(messageLabel, "No issues to display");
+                return;
+            }
+
+            Map<Long, double[]> positions = layoutNodes(issues, w, h);
+            Map<Long, IssueSummary> issueMap = new HashMap<>();
+            for (IssueSummary issue : issues) issueMap.put(issue.id(), issue);
+
+            drawEdges(gc, deps, positions);
+            drawNodes(gc, issues, positions);
+
+            ScreenComponents.showInfo(messageLabel, issues.size() + " issues, " + deps.size() + " dependencies");
+        } catch (Exception exception){
+            ScreenComponents.showError(messageLabel, exception);
+        }
+    }
+
+    private static Map<Long, double[]> layoutNodes(List<IssueSummary> issues, double w, double h){
+        Map<Long, double[]> positions = new HashMap<>();
+        int count = issues.size();
+        double usableW = w - PADDING * 2;
+        double usableH = h - PADDING * 2;
+
+        if (count <= 8){
+            double cx = w / 2;
+            double cy = h / 2;
+            double radius = Math.min(usableW, usableH) / 2.5;
+            for (int i = 0; i < count; i++){
+                double angle = 2 * Math.PI * i / count - Math.PI / 2;
+                double x = cx + radius * Math.cos(angle);
+                double y = cy + radius * Math.sin(angle);
+                positions.put(issues.get(i).id(), new double[]{x, y});
+            }
+        } else{
+            int cols = (int) Math.ceil(Math.sqrt(count));
+            int rows = (int) Math.ceil((double) count / cols);
+            double cellW = usableW / cols;
+            double cellH = usableH / rows;
+            for (int i = 0; i < count; i++){
+                int col = i % cols;
+                int row = i / cols;
+                double x = PADDING + cellW * col + cellW / 2;
+                double y = PADDING + cellH * row + cellH / 2;
+                positions.put(issues.get(i).id(), new double[]{x, y});
+            }
+        }
+        return positions;
+    }
+
+    private static void drawEdges(GraphicsContext gc, List<DependencyResult> deps, Map<Long, double[]> positions){
+        gc.setStroke(Color.web("#94A3B8"));
+        gc.setLineWidth(1.5);
+        for (DependencyResult dep : deps){
+            double[] from = positions.get(dep.blockingIssueId());
+            double[] to = positions.get(dep.blockedIssueId());
+            if (from == null || to == null) continue;
+
+            double dx = to[0] - from[0];
+            double dy = to[1] - from[1];
+            double dist = Math.sqrt(dx * dx + dy * dy);
+            if (dist < 1) continue;
+            double ux = dx / dist;
+            double uy = dy / dist;
+
+            double x1 = from[0] + ux * NODE_RADIUS;
+            double y1 = from[1] + uy * NODE_RADIUS;
+            double x2 = to[0] - ux * NODE_RADIUS;
+            double y2 = to[1] - uy * NODE_RADIUS;
+
+            gc.strokeLine(x1, y1, x2, y2);
+
+            double arrowSize = 8;
+            double ax = x2 - ux * arrowSize;
+            double ay = y2 - uy * arrowSize;
+            gc.fillPolygon(
+                    new double[]{x2, ax + uy * arrowSize * 0.4, ax - uy * arrowSize * 0.4},
+                    new double[]{y2, ay - ux * arrowSize * 0.4, ay + ux * arrowSize * 0.4},
+                    3);
+        }
+    }
+
+    private static void drawNodes(GraphicsContext gc, List<IssueSummary> issues, Map<Long, double[]> positions){
+        gc.setFont(Font.font("System", 10));
+        for (IssueSummary issue : issues){
+            double[] pos = positions.get(issue.id());
+            if (pos == null) continue;
+            double x = pos[0];
+            double y = pos[1];
+
+            Color color = STATUS_COLORS.getOrDefault(issue.status(), Color.GRAY);
+            gc.setFill(color);
+            gc.fillOval(x - NODE_RADIUS, y - NODE_RADIUS, NODE_RADIUS * 2, NODE_RADIUS * 2);
+            gc.setStroke(color.darker());
+            gc.setLineWidth(1.5);
+            gc.strokeOval(x - NODE_RADIUS, y - NODE_RADIUS, NODE_RADIUS * 2, NODE_RADIUS * 2);
+
+            gc.setFill(Color.WHITE);
+            String label = issue.issueId();
+            gc.fillText(label, x - label.length() * 3, y + 4);
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueGraphScreen.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueGraphScreen.java
@@ -33,6 +33,8 @@ final class IssueGraphScreen extends VBox {
     private final IssueController issueController;
     private final long projectId;
     private final Label messageLabel = ScreenComponents.messageLabel();
+    private List<IssueSummary> cachedIssues;
+    private List<DependencyResult> cachedDeps;
     private Runnable onBack;
 
     IssueGraphScreen(IssueController issueController, long projectId){
@@ -53,16 +55,29 @@ final class IssueGraphScreen extends VBox {
                 ScreenComponents.header(backButton, titleLabel),
                 legend, canvasHolder, messageLabel);
 
-        canvasHolder.widthProperty().addListener((obs, old, val) -> drawGraph(canvasHolder));
-        canvasHolder.heightProperty().addListener((obs, old, val) -> drawGraph(canvasHolder));
+        loadData();
+        canvasHolder.widthProperty().addListener((obs, old, val) -> renderGraph(canvasHolder));
+        canvasHolder.heightProperty().addListener((obs, old, val) -> renderGraph(canvasHolder));
     }
 
     void setOnBack(Runnable action){ this.onBack = action; }
 
-    private void drawGraph(Pane holder){
+    private void loadData(){
+        try{
+            cachedIssues = issueController.viewRelatedProjectIssues(projectId);
+            cachedDeps = issueController.viewProjectDependencies(projectId);
+            ScreenComponents.showInfo(messageLabel, cachedIssues.size() + " issues, " + cachedDeps.size() + " dependencies");
+        } catch (Exception exception){
+            cachedIssues = List.of();
+            cachedDeps = List.of();
+            ScreenComponents.showError(messageLabel, exception);
+        }
+    }
+
+    private void renderGraph(Pane holder){
         double w = holder.getWidth();
         double h = holder.getHeight();
-        if (w <= 0 || h <= 0) return;
+        if (w <= 0 || h <= 0 || cachedIssues.isEmpty()) return;
 
         holder.getChildren().clear();
         Canvas canvas = new Canvas(w, h);
@@ -70,25 +85,9 @@ final class IssueGraphScreen extends VBox {
         GraphicsContext gc = canvas.getGraphicsContext2D();
         gc.clearRect(0, 0, w, h);
 
-        try{
-            List<IssueSummary> issues = issueController.viewRelatedProjectIssues(projectId);
-            List<DependencyResult> deps = issueController.viewProjectDependencies(projectId);
-            if (issues.isEmpty()){
-                ScreenComponents.showInfo(messageLabel, "No issues to display");
-                return;
-            }
-
-            Map<Long, double[]> positions = layoutNodes(issues, w, h);
-            Map<Long, IssueSummary> issueMap = new HashMap<>();
-            for (IssueSummary issue : issues) issueMap.put(issue.id(), issue);
-
-            drawEdges(gc, deps, positions);
-            drawNodes(gc, issues, positions);
-
-            ScreenComponents.showInfo(messageLabel, issues.size() + " issues, " + deps.size() + " dependencies");
-        } catch (Exception exception){
-            ScreenComponents.showError(messageLabel, exception);
-        }
+        Map<Long, double[]> positions = layoutNodes(cachedIssues, w, h);
+        drawEdges(gc, cachedDeps, positions);
+        drawNodes(gc, cachedIssues, positions);
     }
 
     private static Map<Long, double[]> layoutNodes(List<IssueSummary> issues, double w, double h){

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueListScreen.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueListScreen.java
@@ -32,6 +32,7 @@ final class IssueListScreen extends VBox {
     private Runnable onBack;
     private Runnable onDeletedIssueManage;
     private Runnable onStatistics;
+    private Runnable onGraph;
 
     IssueListScreen(IssueController issueController, ProjectController projectController, long projectId, boolean isPl){
         this.issueController = issueController;
@@ -69,6 +70,10 @@ final class IssueListScreen extends VBox {
         statsButton.setOnAction(event -> { if (onStatistics != null) onStatistics.run(); });
         toolbar.getChildren().add(statsButton);
 
+        Button graphButton = new Button("Dependency Graph");
+        graphButton.setOnAction(event -> { if (onGraph != null) onGraph.run(); });
+        toolbar.getChildren().add(graphButton);
+
         issueList.setCellFactory(list -> new IssueCell());
         ScreenComponents.setupListDoubleClick(issueList, i -> { if (onIssueSelected != null) onIssueSelected.accept(i); });
         VBox.setVgrow(issueList, Priority.ALWAYS);
@@ -83,6 +88,7 @@ final class IssueListScreen extends VBox {
     void setOnBack(Runnable action){ this.onBack = action; }
     void setOnDeletedIssueManage(Runnable action){ this.onDeletedIssueManage = action; }
     void setOnStatistics(Runnable action){ this.onStatistics = action; }
+    void setOnGraph(Runnable action){ this.onGraph = action; }
 
     private void loadProjectInfo(ProjectController projectController){
         try{

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/JavaFXApp.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/JavaFXApp.java
@@ -98,6 +98,13 @@ public final class JavaFXApp extends Application {
         screen.setOnBack(this::showProjectList);
         screen.setOnDeletedIssueManage(() -> showDeletedIssueManage(projectId));
         screen.setOnStatistics(() -> showStatistics(projectId));
+        screen.setOnGraph(() -> showIssueGraph(projectId));
+        primaryStage.setScene(new Scene(screen, 1024, 768));
+    }
+
+    private void showIssueGraph(long projectId){
+        IssueGraphScreen screen = new IssueGraphScreen(context.issueController(), projectId);
+        screen.setOnBack(() -> showIssueList(projectId));
         primaryStage.setScene(new Scene(screen, 1024, 768));
     }
 


### PR DESCRIPTION
## 요약
- IssueGraphScreen: Canvas 기반 노드-엣지 그래프 렌더링
  - viewRelatedProjectIssues() → 노드, viewProjectDependencies() → 엣지
  - 이슈를 상태별 색상(NEW=blue, ASSIGNED=yellow, FIXED=green 등) 원형 노드로 표시
  - dependency를 화살표 엣지로 연결 (blocking → blocked)
  - 8개 이하 원형 배치, 초과 시 격자 배치
- IssueListScreen: "Dependency Graph" 버튼 추가
- JavaFXApp: 그래프 화면 전환 연결

## 검증
- ./gradlew check 통과
- controller 레이어 기존 메서드만 사용 (viewRelatedProjectIssues, viewProjectDependencies)
- 새 controller/service 메서드 추가 없음