### PR TITLE
feat: Swing 이슈 수정/삭제 액션 구현

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueActionSupport.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueActionSupport.java
@@ -1,6 +1,7 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
 import com.github.marcellokim.issuetracker.controller.AssignmentController;
+import com.github.marcellokim.issuetracker.controller.DeletedIssueController;
 import com.github.marcellokim.issuetracker.controller.IssueStateController;
 import java.util.Objects;
 
@@ -9,13 +10,16 @@ record IssueActionSupport(
         AssignmentController assignmentController,
         IssueAssignmentPrompt assignmentPrompt,
         IssueCommentPrompt commentPrompt,
-        IssueDependencyPrompt dependencyPrompt) {
+        IssueDependencyPrompt dependencyPrompt,
+        DeletedIssueController deletedIssueController,
+        IssueEditPrompt editPrompt) {
 
     IssueActionSupport {
         Objects.requireNonNull(statusChange, "statusChange");
         Objects.requireNonNull(assignmentPrompt, "assignmentPrompt");
         Objects.requireNonNull(commentPrompt, "commentPrompt");
         Objects.requireNonNull(dependencyPrompt, "dependencyPrompt");
+        Objects.requireNonNull(editPrompt, "editPrompt");
     }
 
     static IssueActionSupport disabled() {
@@ -24,17 +28,22 @@ record IssueActionSupport(
                 null,
                 IssueAssignmentDialogs::prompt,
                 IssueCommentDialogs::prompt,
-                IssueDependencyDialogs::prompt);
+                IssueDependencyDialogs::prompt,
+                null,
+                IssueEditDialogs::prompt);
     }
 
     static IssueActionSupport dialogs(
             IssueStateController issueStateController,
-            AssignmentController assignmentController) {
+            AssignmentController assignmentController,
+            DeletedIssueController deletedIssueController) {
         return new IssueActionSupport(
                 IssueStatusChangeSupport.dialog(issueStateController),
                 assignmentController,
                 IssueAssignmentDialogs::prompt,
                 IssueCommentDialogs::prompt,
-                IssueDependencyDialogs::prompt);
+                IssueDependencyDialogs::prompt,
+                deletedIssueController,
+                IssueEditDialogs::prompt);
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
@@ -1,5 +1,6 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
+import com.github.marcellokim.issuetracker.domain.Priority;
 import com.github.marcellokim.issuetracker.service.CommentResult;
 import com.github.marcellokim.issuetracker.service.DependencyResult;
 import com.github.marcellokim.issuetracker.service.HistoryResult;
@@ -99,6 +100,9 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
     private Set<String> availableActions = Set.of();
     private transient List<IssueCommentActionState> commentActionStates = List.of();
     private transient List<DependencyResult> dependencyActionStates = List.of();
+    private String currentTitle = "Issue";
+    private String currentDescription = " ";
+    private Priority currentPriority = Priority.MAJOR;
 
     IssueDetailPanel(UserResult user, IssueDetailActions actions) {
         Objects.requireNonNull(user, "user");
@@ -134,6 +138,9 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
             titleLabel.setText("[" + detail.issueId() + "] " + detail.title());
             stateLabel.setText(detail.status() + " / " + detail.priority());
             descriptionLabel.setText(detail.description());
+            currentTitle = detail.title();
+            currentDescription = detail.description();
+            currentPriority = detail.priority();
             reporterLabel.setText("Reporter: " + formatUser(detail.reporter()));
             assigneeLabel.setText("Assignee: " + formatUser(detail.assignee()));
             verifierLabel.setText("Verifier: " + formatUser(detail.verifier()));
@@ -182,6 +189,10 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
             updateCommentButtons();
             updateDependencyButtons();
         });
+    }
+
+    IssueEditContext currentIssueEditContext() {
+        return new IssueEditContext(currentTitle, currentDescription, currentPriority);
     }
 
     private JPanel header() {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenter.java
@@ -1,6 +1,7 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
 import com.github.marcellokim.issuetracker.controller.AssignmentController;
+import com.github.marcellokim.issuetracker.controller.DeletedIssueController;
 import com.github.marcellokim.issuetracker.controller.IssueController;
 import com.github.marcellokim.issuetracker.controller.IssueStateController;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
@@ -20,17 +21,18 @@ final class IssueDetailPresenter {
     private final IssueController issueController;
     private final IssueStateController issueStateController;
     private final AssignmentController assignmentController;
+    private final DeletedIssueController deletedIssueController;
     private final IssueDetailView view;
 
     IssueDetailPresenter(IssueController issueController, IssueDetailView view) {
-        this(issueController, null, null, view);
+        this(issueController, null, null, null, view);
     }
 
     IssueDetailPresenter(
             IssueController issueController,
             IssueStateController issueStateController,
             IssueDetailView view) {
-        this(issueController, issueStateController, null, view);
+        this(issueController, issueStateController, null, null, view);
     }
 
     IssueDetailPresenter(
@@ -38,9 +40,19 @@ final class IssueDetailPresenter {
             IssueStateController issueStateController,
             AssignmentController assignmentController,
             IssueDetailView view) {
+        this(issueController, issueStateController, assignmentController, null, view);
+    }
+
+    IssueDetailPresenter(
+            IssueController issueController,
+            IssueStateController issueStateController,
+            AssignmentController assignmentController,
+            DeletedIssueController deletedIssueController,
+            IssueDetailView view) {
         this.issueController = Objects.requireNonNull(issueController, "issueController");
         this.issueStateController = issueStateController;
         this.assignmentController = assignmentController;
+        this.deletedIssueController = deletedIssueController;
         this.view = Objects.requireNonNull(view, "view");
     }
 
@@ -92,6 +104,38 @@ final class IssueDetailPresenter {
             loadIssue(issueId);
         } catch (RuntimeException exception) {
             view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    void updateIssue(long issueId, IssueEditRequest request) {
+        try {
+            IssueEditRequest requiredRequest = requireEditRequest(request, IssueEditMode.UPDATE);
+            issueController.updateIssue(issueId, requiredRequest.title(), requiredRequest.description());
+            loadIssue(issueId);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    void changePriority(long issueId, IssueEditRequest request) {
+        try {
+            IssueEditRequest requiredRequest = requireEditRequest(request, IssueEditMode.CHANGE_PRIORITY);
+            issueController.changePriority(issueId, requiredRequest.priority());
+            loadIssue(issueId);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    boolean deleteIssue(long issueId, IssueEditRequest request) {
+        try {
+            IssueEditRequest requiredRequest = requireEditRequest(request, IssueEditMode.SOFT_DELETE);
+            requireDeletedIssueController().deleteIssue(issueId, requiredRequest.comment());
+            view.showMessage(" ", false);
+            return true;
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+            return false;
         }
     }
 
@@ -208,5 +252,20 @@ final class IssueDetailPresenter {
             throw new IllegalStateException("Assignment controller is not configured.");
         }
         return assignmentController;
+    }
+
+    private static IssueEditRequest requireEditRequest(IssueEditRequest request, IssueEditMode mode) {
+        IssueEditRequest requiredRequest = Objects.requireNonNull(request, REQUEST_PARAM);
+        if (requiredRequest.mode() != mode) {
+            throw new IllegalArgumentException("Unexpected issue edit request mode.");
+        }
+        return requiredRequest;
+    }
+
+    private DeletedIssueController requireDeletedIssueController() {
+        if (deletedIssueController == null) {
+            throw new IllegalStateException("Deleted issue controller is not configured.");
+        }
+        return deletedIssueController;
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditContext.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditContext.java
@@ -1,0 +1,13 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.domain.Priority;
+import java.util.Objects;
+
+record IssueEditContext(String title, String description, Priority priority) {
+
+    IssueEditContext {
+        Objects.requireNonNull(title, "title");
+        Objects.requireNonNull(description, "description");
+        Objects.requireNonNull(priority, "priority");
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditDialogs.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditDialogs.java
@@ -1,0 +1,196 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.domain.Priority;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.util.Optional;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+
+final class IssueEditDialogs {
+
+    private static final int TEXT_ROWS = 5;
+    private static final int TEXT_COLUMNS = 36;
+    private static final String EDIT_ISSUE_TITLE = "Edit issue";
+    private static final String DELETE_ISSUE_TITLE = "Delete issue";
+
+    private IssueEditDialogs() {
+    }
+
+    static Optional<IssueEditRequest> prompt(Component parent, IssueEditMode mode, IssueEditContext context) {
+        return switch (mode) {
+            case UPDATE -> promptUpdate(parent, context);
+            case CHANGE_PRIORITY -> promptPriority(parent, context.priority());
+            case SOFT_DELETE -> promptDelete(parent);
+        };
+    }
+
+    static UpdateForm updateForm(IssueEditContext context) {
+        JTextField titleField = new JTextField(context.title(), 32);
+        titleField.setName("issueEditTitleField");
+        titleField.setMaximumSize(new Dimension(Integer.MAX_VALUE, SwingStyles.FIELD_HEIGHT));
+        titleField.setAlignmentX(Component.LEFT_ALIGNMENT);
+        JTextArea descriptionArea = new JTextArea(context.description(), TEXT_ROWS, TEXT_COLUMNS);
+        descriptionArea.setName("issueEditDescriptionArea");
+        descriptionArea.setLineWrap(true);
+        descriptionArea.setWrapStyleWord(true);
+        JScrollPane descriptionPane = aligned(new JScrollPane(descriptionArea));
+
+        JPanel fields = verticalFields();
+        fields.add(fieldLabel("Title"));
+        fields.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+        fields.add(titleField);
+        fields.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
+        fields.add(fieldLabel("Description"));
+        fields.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+        fields.add(descriptionPane);
+
+        JPanel panel = formPanel(EDIT_ISSUE_TITLE, "issueEditDialogTitle");
+        panel.add(fields, BorderLayout.CENTER);
+        return new UpdateForm(panel, titleField, descriptionArea);
+    }
+
+    static PriorityForm priorityForm(Priority currentPriority) {
+        JComboBox<Priority> priorityBox = new JComboBox<>(Priority.values());
+        priorityBox.setName("priorityComboBox");
+        priorityBox.setSelectedItem(currentPriority);
+        priorityBox.setMaximumSize(new Dimension(Integer.MAX_VALUE, SwingStyles.FIELD_HEIGHT));
+        priorityBox.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        JPanel fields = verticalFields();
+        fields.add(fieldLabel("Priority"));
+        fields.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+        fields.add(priorityBox);
+
+        JPanel panel = formPanel("Change priority", "priorityDialogTitle");
+        panel.add(fields, BorderLayout.CENTER);
+        return new PriorityForm(panel, priorityBox);
+    }
+
+    static DeleteForm deleteForm() {
+        JTextArea commentArea = new JTextArea(TEXT_ROWS, TEXT_COLUMNS);
+        commentArea.setName("issueDeleteCommentArea");
+        commentArea.setLineWrap(true);
+        commentArea.setWrapStyleWord(true);
+        JScrollPane commentPane = aligned(new JScrollPane(commentArea));
+
+        JPanel panel = formPanel(DELETE_ISSUE_TITLE, "issueDeleteDialogTitle");
+        JPanel fields = verticalFields();
+        fields.add(fieldLabel("Comment"));
+        fields.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+        fields.add(commentPane);
+        panel.add(fields, BorderLayout.CENTER);
+        return new DeleteForm(panel, commentArea);
+    }
+
+    private static Optional<IssueEditRequest> promptUpdate(Component parent, IssueEditContext context) {
+        UpdateForm form = updateForm(context);
+        while (true) {
+            int result = JOptionPane.showConfirmDialog(
+                    parent,
+                    form.panel(),
+                    EDIT_ISSUE_TITLE,
+                    JOptionPane.OK_CANCEL_OPTION,
+                    JOptionPane.PLAIN_MESSAGE);
+            if (result != JOptionPane.OK_OPTION) {
+                return Optional.empty();
+            }
+            try {
+                return Optional.of(IssueEditRequest.update(
+                        form.titleField().getText(),
+                        form.descriptionArea().getText()));
+            } catch (IllegalArgumentException exception) {
+                JOptionPane.showMessageDialog(parent, exception.getMessage(), EDIT_ISSUE_TITLE, JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private static Optional<IssueEditRequest> promptPriority(Component parent, Priority currentPriority) {
+        PriorityForm form = priorityForm(currentPriority);
+        int result = JOptionPane.showConfirmDialog(
+                parent,
+                form.panel(),
+                "Change priority",
+                JOptionPane.OK_CANCEL_OPTION,
+                JOptionPane.PLAIN_MESSAGE);
+        if (result != JOptionPane.OK_OPTION) {
+            return Optional.empty();
+        }
+        return Optional.of(IssueEditRequest.changePriority((Priority) form.priorityBox().getSelectedItem()));
+    }
+
+    private static Optional<IssueEditRequest> promptDelete(Component parent) {
+        DeleteForm form = deleteForm();
+        while (true) {
+            int result = JOptionPane.showConfirmDialog(
+                    parent,
+                    form.panel(),
+                    DELETE_ISSUE_TITLE,
+                    JOptionPane.OK_CANCEL_OPTION,
+                    JOptionPane.WARNING_MESSAGE);
+            if (result != JOptionPane.OK_OPTION) {
+                return Optional.empty();
+            }
+            try {
+                return Optional.of(IssueEditRequest.softDelete(form.commentArea().getText()));
+            } catch (IllegalArgumentException exception) {
+                JOptionPane.showMessageDialog(
+                        parent,
+                        exception.getMessage(),
+                        DELETE_ISSUE_TITLE,
+                        JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private static JPanel formPanel(String titleText, String titleName) {
+        JPanel panel = new JPanel(new BorderLayout(SwingStyles.ROW_GAP, SwingStyles.ROW_GAP));
+        panel.setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP));
+        JLabel title = new JLabel(titleText);
+        title.setName(titleName);
+        SwingStyles.applySectionTitle(title);
+        panel.add(title, BorderLayout.NORTH);
+        return panel;
+    }
+
+    private static JPanel verticalFields() {
+        JPanel fields = new JPanel();
+        fields.setLayout(new BoxLayout(fields, BoxLayout.Y_AXIS));
+        fields.setAlignmentX(Component.LEFT_ALIGNMENT);
+        return fields;
+    }
+
+    private static JLabel fieldLabel(String text) {
+        JLabel label = new JLabel(text);
+        label.setAlignmentX(Component.LEFT_ALIGNMENT);
+        return label;
+    }
+
+    private static <T extends JComponent> T aligned(T component) {
+        component.setAlignmentX(Component.LEFT_ALIGNMENT);
+        return component;
+    }
+
+    record UpdateForm(JPanel panel, JTextField titleField, JTextArea descriptionArea) {
+    }
+
+    record PriorityForm(JPanel panel, JComboBox<Priority> priorityBox) {
+    }
+
+    record DeleteForm(JPanel panel, JTextArea commentArea) {
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditMode.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditMode.java
@@ -1,0 +1,7 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+enum IssueEditMode {
+    UPDATE,
+    CHANGE_PRIORITY,
+    SOFT_DELETE
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditPrompt.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditPrompt.java
@@ -1,0 +1,10 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import java.awt.Component;
+import java.util.Optional;
+
+@FunctionalInterface
+interface IssueEditPrompt {
+
+    Optional<IssueEditRequest> prompt(Component parent, IssueEditMode mode, IssueEditContext context);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditRequest.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditRequest.java
@@ -1,0 +1,55 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.domain.Priority;
+import java.util.Objects;
+
+record IssueEditRequest(
+        IssueEditMode mode,
+        String title,
+        String description,
+        Priority priority,
+        String comment) {
+
+    IssueEditRequest {
+        Objects.requireNonNull(mode, "mode");
+        switch (mode) {
+            case UPDATE -> {
+                title = requireText(title, "title");
+                description = requireText(description, "description");
+                priority = null;
+                comment = null;
+            }
+            case CHANGE_PRIORITY -> {
+                title = null;
+                description = null;
+                Objects.requireNonNull(priority, "priority");
+                comment = null;
+            }
+            case SOFT_DELETE -> {
+                title = null;
+                description = null;
+                priority = null;
+                comment = requireText(comment, "comment");
+            }
+        }
+    }
+
+    static IssueEditRequest update(String title, String description) {
+        return new IssueEditRequest(IssueEditMode.UPDATE, title, description, null, null);
+    }
+
+    static IssueEditRequest changePriority(Priority priority) {
+        return new IssueEditRequest(IssueEditMode.CHANGE_PRIORITY, null, null, priority, null);
+    }
+
+    static IssueEditRequest softDelete(String comment) {
+        return new IssueEditRequest(IssueEditMode.SOFT_DELETE, null, null, null, comment);
+    }
+
+    private static String requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
@@ -41,7 +41,10 @@ public final class SwingAppFrame extends JFrame {
 
     private static IssueActionSupport issueActionSupport(ApplicationContext context) {
         ApplicationContext checked = Objects.requireNonNull(context, "context");
-        return IssueActionSupport.dialogs(checked.issueStateController(), checked.assignmentController());
+        return IssueActionSupport.dialogs(
+                checked.issueStateController(),
+                checked.assignmentController(),
+                checked.deletedIssueController());
     }
 
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -16,7 +16,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.swing.JPanel;
@@ -479,6 +481,18 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             showIssueDependency(issueId, panel, IssueDependencyMode.ADD, null);
             return;
         }
+        if ("UPDATE_ISSUE".equals(action)) {
+            showIssueEdit(issueId, panel, IssueEditMode.UPDATE);
+            return;
+        }
+        if ("CHANGE_PRIORITY".equals(action)) {
+            showIssueEdit(issueId, panel, IssueEditMode.CHANGE_PRIORITY);
+            return;
+        }
+        if ("SOFT_DELETE".equals(action)) {
+            showIssueSoftDelete(user, projectId, issueId, panel);
+            return;
+        }
         SwingUtilities.invokeLater(() -> {
             cancelDashboardWorker();
             cancelAccountWorker();
@@ -523,6 +537,45 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
                     .ifPresent(request -> startIssueDetailTask(
                             panel,
                             presenter -> presenter.changeDependency(issueId, request)));
+        } catch (RuntimeException exception) {
+            panel.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    private void showIssueEdit(long issueId, IssueDetailPanel panel, IssueEditMode mode) {
+        try {
+            issueActionSupport.editPrompt().prompt(panel, mode, panel.currentIssueEditContext())
+                    .ifPresent(request -> startIssueDetailTask(
+                            panel,
+                            presenter -> runIssueEdit(issueId, mode, request, presenter)));
+        } catch (RuntimeException exception) {
+            panel.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    private static void runIssueEdit(
+            long issueId,
+            IssueEditMode mode,
+            IssueEditRequest request,
+            IssueDetailPresenter presenter) {
+        switch (mode) {
+            case UPDATE -> presenter.updateIssue(issueId, request);
+            case CHANGE_PRIORITY -> presenter.changePriority(issueId, request);
+            case SOFT_DELETE -> throw new IllegalArgumentException("Soft delete uses the delete workflow.");
+        }
+    }
+
+    private void showIssueSoftDelete(UserResult user, long projectId, long issueId, IssueDetailPanel panel) {
+        try {
+            issueActionSupport.editPrompt().prompt(panel, IssueEditMode.SOFT_DELETE, panel.currentIssueEditContext())
+                    .ifPresent(request -> {
+                        AtomicBoolean deleted = new AtomicBoolean(false);
+                        startIssueDetailTask(
+                                panel,
+                                presenter -> deleted.set(presenter.deleteIssue(issueId, request)),
+                                deleted::get,
+                                () -> showIssueList(user, projectId));
+                    });
         } catch (RuntimeException exception) {
             panel.showMessage(exception.getMessage(), true);
         }
@@ -627,11 +680,19 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     }
 
     private void startIssueDetailTask(IssueDetailPanel panel, IssueDetailTask task) {
+        startIssueDetailTask(panel, task, null, null);
+    }
+
+    private void startIssueDetailTask(
+            IssueDetailPanel panel,
+            IssueDetailTask task,
+            BooleanSupplier successCondition,
+            Runnable onSuccess) {
         Objects.requireNonNull(panel, "panel");
         Objects.requireNonNull(task, "task");
         cancelIssueDetailWorker();
         panel.setBusy(true);
-        IssueDetailWorker worker = new IssueDetailWorker(panel, task);
+        IssueDetailWorker worker = new IssueDetailWorker(panel, task, successCondition, onSuccess);
         issueDetailWorker.set(worker);
         worker.execute();
     }
@@ -866,10 +927,18 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
         private final IssueDetailPanel panel;
         private final IssueDetailTask task;
+        private final BooleanSupplier successCondition;
+        private final Runnable onSuccess;
 
-        private IssueDetailWorker(IssueDetailPanel panel, IssueDetailTask task) {
+        private IssueDetailWorker(
+                IssueDetailPanel panel,
+                IssueDetailTask task,
+                BooleanSupplier successCondition,
+                Runnable onSuccess) {
             this.panel = Objects.requireNonNull(panel, "panel");
             this.task = Objects.requireNonNull(task, "task");
+            this.successCondition = successCondition;
+            this.onSuccess = onSuccess;
         }
 
         @Override
@@ -878,6 +947,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
                     controllers.issueController(),
                     issueActionSupport.statusChange().issueStateController(),
                     issueActionSupport.assignmentController(),
+                    issueActionSupport.deletedIssueController(),
                     new CurrentIssueDetailView(panel, this, issueDetailWorker::get));
             task.run(presenter);
             return null;
@@ -885,7 +955,24 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
         @Override
         protected void done() {
-            finishWorker(issueDetailWorker, this, () -> panel.setBusy(false), panel::showMessage, "Issue detail");
+            if (!issueDetailWorker.compareAndSet(this, null)) {
+                return;
+            }
+            panel.setBusy(false);
+            if (isCancelled()) {
+                return;
+            }
+            try {
+                get();
+                if (onSuccess != null && (successCondition == null || successCondition.getAsBoolean())) {
+                    onSuccess.run();
+                }
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                panel.showMessage("Issue detail was interrupted. Please try again.", true);
+            } catch (ExecutionException exception) {
+                panel.showMessage("Issue detail failed. Please try again.", true);
+            }
         }
     }
 

--- a/src/test/java/com/github/marcellokim/issuetracker/support/FakeDeletedIssueRepository.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/support/FakeDeletedIssueRepository.java
@@ -1,0 +1,88 @@
+package com.github.marcellokim.issuetracker.support;
+
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.repository.DeletedIssueRepository;
+import com.github.marcellokim.issuetracker.repository.IssueRepository;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class FakeDeletedIssueRepository implements DeletedIssueRepository {
+
+    private final Map<Long, Issue> deletedIssues = new LinkedHashMap<>();
+    private final IssueRepository issueRepository;
+
+    public FakeDeletedIssueRepository() {
+        this(null);
+    }
+
+    public FakeDeletedIssueRepository(IssueRepository issueRepository) {
+        this.issueRepository = issueRepository;
+    }
+
+    @Override
+    public List<Issue> findDeletedByProject(long projectId) {
+        return deletedIssues.values().stream()
+                .filter(issue -> issue.projectId() == projectId)
+                .sorted(Comparator.comparingLong(Issue::id))
+                .toList();
+    }
+
+    @Override
+    public Issue softDelete(Issue issue, String changedById, String message, LocalDateTime changedDate) {
+        Issue deleted = copyWithStatus(issue, IssueStatus.DELETED, changedDate);
+        deletedIssues.put(deleted.id(), deleted);
+        save(deleted);
+        return deleted;
+    }
+
+    @Override
+    public Issue restore(Issue issue, String changedById, String message, LocalDateTime changedDate) {
+        Issue restored = copyWithStatus(issue, IssueStatus.NEW, changedDate);
+        deletedIssues.remove(restored.id());
+        save(restored);
+        return restored;
+    }
+
+    @Override
+    public int purgeDeletedById(long issueId) {
+        return deletedIssues.remove(issueId) == null ? 0 : 1;
+    }
+
+    @Override
+    public int purgeDeletedBeyondLimit(long projectId, int maxDeletedIssues) {
+        List<Issue> deleted = findDeletedByProject(projectId);
+        int overflow = Math.max(0, deleted.size() - maxDeletedIssues);
+        for (int index = 0; index < overflow; index++) {
+            deletedIssues.remove(deleted.get(index).id());
+        }
+        return overflow;
+    }
+
+    private void save(Issue issue) {
+        if (issueRepository != null) {
+            issueRepository.save(issue);
+        }
+    }
+
+    private static Issue copyWithStatus(Issue issue, IssueStatus status, LocalDateTime updatedAt) {
+        return Issue.fromPersistence(Issue.persistedState(
+                issue.projectId(),
+                issue.title(),
+                issue.description(),
+                issue.getReporter())
+                .id(issue.id())
+                .issueId(issue.getIssueId())
+                .reportedDate(issue.reportedDate())
+                .priority(issue.priority())
+                .status(status)
+                .assignee(issue.getAssignee())
+                .verifier(issue.getVerifier())
+                .fixer(issue.getFixer())
+                .resolver(issue.getResolver())
+                .updatedAt(updatedAt));
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanelTest.java
@@ -86,6 +86,11 @@ class IssueDetailPanelTest {
             assertEquals("ISSUE-3", dependencies.getValueAt(0, 2));
             dependencies.setRowSelectionInterval(0, 0);
             assertTrue(SwingComponentTestSupport.find(panel, "removeDependencyButton", JButton.class).isEnabled());
+
+            IssueEditContext editContext = panel.currentIssueEditContext();
+            assertEquals("Login bug", editContext.title());
+            assertEquals("Login fails with valid credentials.", editContext.description());
+            assertEquals(Priority.CRITICAL, editContext.priority());
         });
     }
 

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.marcellokim.issuetracker.controller.AssignmentController;
+import com.github.marcellokim.issuetracker.controller.DeletedIssueController;
 import com.github.marcellokim.issuetracker.controller.IssueController;
 import com.github.marcellokim.issuetracker.controller.IssueStateController;
 import com.github.marcellokim.issuetracker.domain.Comment;
@@ -20,6 +21,7 @@ import com.github.marcellokim.issuetracker.repository.CommentRepository;
 import com.github.marcellokim.issuetracker.service.AssignmentRecommendationService;
 import com.github.marcellokim.issuetracker.service.AssignmentService;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.DeletedIssueService;
 import com.github.marcellokim.issuetracker.service.DependencyResult;
 import com.github.marcellokim.issuetracker.service.IssueDetailResult;
 import com.github.marcellokim.issuetracker.service.IssueService;
@@ -29,6 +31,7 @@ import com.github.marcellokim.issuetracker.service.IssueWorkflowService;
 import com.github.marcellokim.issuetracker.service.KNNAssignmentRecommendation;
 import com.github.marcellokim.issuetracker.service.PasswordHashing;
 import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.support.FakeDeletedIssueRepository;
 import com.github.marcellokim.issuetracker.support.FakeIssueDependencyRepository;
 import com.github.marcellokim.issuetracker.support.FakeIssueHistoryRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryAssignmentRecommendationRepository;
@@ -228,6 +231,97 @@ class IssueDetailPresenterTest {
     }
 
     @Test
+    @DisplayName("updates issue through issue controller and reloads detail")
+    void updatesIssueAndReloadsDetail() {
+        User reporter = user("dev1", Role.DEV);
+        Issue issue = issue(7L, "Login bug", reporter);
+        IssueDetailControllerFixture fixture = controllerFixture(reporter, new FakeCommentRepository(), issue);
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                fixture.issueController(),
+                fixture.issueStateController(),
+                fixture.assignmentController(),
+                fixture.deletedIssueController(),
+                view);
+        presenter.loadIssue(issue.id());
+
+        presenter.updateIssue(
+                issue.id(),
+                IssueEditRequest.update("Edited login bug", "Edited through Swing"));
+
+        assertEquals("Edited login bug", view.detail().title());
+        assertEquals("Edited through Swing", view.detail().description());
+        assertEquals(" ", view.message());
+    }
+
+    @Test
+    @DisplayName("changes priority through issue controller and reloads detail")
+    void changesPriorityAndReloadsDetail() {
+        User pl = user("pl1", Role.PL);
+        Issue issue = issue(7L, "Login bug", pl);
+        IssueDetailControllerFixture fixture = controllerFixture(pl, new FakeCommentRepository(), issue);
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                fixture.issueController(),
+                fixture.issueStateController(),
+                fixture.assignmentController(),
+                fixture.deletedIssueController(),
+                view);
+        presenter.loadIssue(issue.id());
+
+        presenter.changePriority(issue.id(), IssueEditRequest.changePriority(Priority.MINOR));
+
+        assertEquals(Priority.MINOR, view.detail().priority());
+        assertEquals(" ", view.message());
+    }
+
+    @Test
+    @DisplayName("deletes issue through deleted issue controller")
+    void deletesIssueThroughDeletedController() {
+        User pl = user("pl1", Role.PL);
+        Issue issue = issue(7L, "Login bug", pl);
+        IssueDetailControllerFixture fixture = controllerFixture(pl, new FakeCommentRepository(), issue);
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                fixture.issueController(),
+                fixture.issueStateController(),
+                fixture.assignmentController(),
+                fixture.deletedIssueController(),
+                view);
+        presenter.loadIssue(issue.id());
+
+        boolean deleted = presenter.deleteIssue(issue.id(), IssueEditRequest.softDelete("remove duplicate"));
+
+        assertTrue(deleted);
+        assertEquals(
+                IssueStatus.DELETED,
+                fixture.issueRepository().findById(issue.id()).orElseThrow().status());
+        assertEquals(" ", view.message());
+    }
+
+    @Test
+    @DisplayName("shows delete errors without replacing current detail")
+    void showsDeleteErrorsWithoutReplacingCurrentDetail() {
+        User reporter = user("dev1", Role.DEV);
+        Issue issue = issue(7L, "Login bug", reporter);
+        IssueDetailControllerFixture fixture = controllerFixture(reporter, new FakeCommentRepository(), issue);
+        RecordingIssueDetailView view = new RecordingIssueDetailView();
+        IssueDetailPresenter presenter = new IssueDetailPresenter(
+                fixture.issueController(),
+                fixture.issueStateController(),
+                fixture.assignmentController(),
+                fixture.deletedIssueController(),
+                view);
+        presenter.loadIssue(issue.id());
+
+        boolean deleted = presenter.deleteIssue(issue.id(), IssueEditRequest.softDelete("remove duplicate"));
+
+        assertEquals(false, deleted);
+        assertEquals("Login bug", view.detail().title());
+        assertEquals("Only PL can manage deleted issues.", view.message());
+    }
+
+    @Test
     @DisplayName("adds a comment through issue controller and reloads detail")
     void addsCommentAndReloadsDetail() {
         User reporter = user("dev1", Role.DEV);
@@ -398,6 +492,7 @@ class IssueDetailPresenterTest {
             }
         }
         InMemoryIssueRepository issueRepository = new InMemoryIssueRepository(issues);
+        FakeDeletedIssueRepository deletedIssues = new FakeDeletedIssueRepository(issueRepository);
         FakeIssueDependencyRepository dependencies = new FakeIssueDependencyRepository();
         PermissionPolicy permissionPolicy = new PermissionPolicy();
         AuthenticationService authentication = new AuthenticationService(
@@ -440,10 +535,20 @@ class IssueDetailPresenterTest {
                                 new InMemoryAssignmentRecommendationRepository(extraUsers.toArray(User[]::new)),
                                 new KNNAssignmentRecommendation()),
                         () -> NOW));
+        DeletedIssueController deletedIssueController = new DeletedIssueController(
+                authentication,
+                new DeletedIssueService(
+                        issueRepository,
+                        deletedIssues,
+                        users,
+                        permissionPolicy,
+                        () -> NOW));
         return new IssueDetailControllerFixture(
+                issueRepository,
                 issueController,
                 issueStateController,
                 assignmentController,
+                deletedIssueController,
                 dependencies);
     }
 
@@ -495,9 +600,11 @@ class IssueDetailPresenterTest {
     }
 
     private record IssueDetailControllerFixture(
+            InMemoryIssueRepository issueRepository,
             IssueController issueController,
             IssueStateController issueStateController,
             AssignmentController assignmentController,
+            DeletedIssueController deletedIssueController,
             FakeIssueDependencyRepository dependencyRepository) {
     }
 

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditContextTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditContextTest.java
@@ -1,0 +1,30 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.marcellokim.issuetracker.domain.Priority;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing issue edit context")
+class IssueEditContextTest {
+
+    @Test
+    @DisplayName("keeps existing issue text as loaded")
+    void keepsExistingIssueText() {
+        IssueEditContext context = new IssueEditContext(" Login bug ", "", Priority.MAJOR);
+
+        assertEquals(" Login bug ", context.title());
+        assertEquals("", context.description());
+        assertEquals(Priority.MAJOR, context.priority());
+    }
+
+    @Test
+    @DisplayName("requires loaded fields to be present")
+    void requiresLoadedFields() {
+        assertThrows(NullPointerException.class, () -> new IssueEditContext(null, "", Priority.MAJOR));
+        assertThrows(NullPointerException.class, () -> new IssueEditContext("title", null, Priority.MAJOR));
+        assertThrows(NullPointerException.class, () -> new IssueEditContext("title", "", null));
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditDialogsTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditDialogsTest.java
@@ -1,0 +1,125 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.domain.Priority;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.imageio.ImageIO;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing issue edit dialogs")
+class IssueEditDialogsTest {
+
+    @Test
+    @DisplayName("renders issue update form snapshot")
+    void rendersIssueUpdateFormSnapshot() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            IssueEditDialogs.UpdateForm form =
+                    IssueEditDialogs.updateForm(new IssueEditContext(
+                            "Login bug",
+                            "Login fails with valid credentials.",
+                            Priority.CRITICAL));
+            assertEquals(
+                    "Edit issue",
+                    SwingComponentTestSupport.find(form.panel(), "issueEditDialogTitle", JLabel.class).getText());
+            assertEquals(
+                    "Login bug",
+                    SwingComponentTestSupport.find(form.panel(), "issueEditTitleField", JTextField.class).getText());
+            form.panel().setSize(560, 300);
+            layoutRecursively(form.panel());
+
+            BufferedImage image = render(form.panel(), Path.of("build/reports/ui/issue-edit-dialog.png"), 560, 300);
+            assertTrue(hasRenderedContent(image));
+        });
+    }
+
+    @Test
+    @DisplayName("renders priority change form snapshot")
+    void rendersPriorityChangeFormSnapshot() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            IssueEditDialogs.PriorityForm form = IssueEditDialogs.priorityForm(Priority.CRITICAL);
+            assertEquals(
+                    "Change priority",
+                    SwingComponentTestSupport.find(form.panel(), "priorityDialogTitle", JLabel.class).getText());
+            assertEquals(
+                    Priority.CRITICAL,
+                    SwingComponentTestSupport.find(form.panel(), "priorityComboBox", JComboBox.class)
+                            .getSelectedItem());
+            form.panel().setSize(420, 160);
+            layoutRecursively(form.panel());
+
+            BufferedImage image = render(
+                    form.panel(),
+                    Path.of("build/reports/ui/issue-priority-dialog.png"),
+                    420,
+                    160);
+            assertTrue(hasRenderedContent(image));
+        });
+    }
+
+    @Test
+    @DisplayName("renders soft delete form snapshot")
+    void rendersSoftDeleteFormSnapshot() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            IssueEditDialogs.DeleteForm form = IssueEditDialogs.deleteForm();
+            assertEquals(
+                    "Delete issue",
+                    SwingComponentTestSupport.find(form.panel(), "issueDeleteDialogTitle", JLabel.class).getText());
+            assertEquals(
+                    "",
+                    SwingComponentTestSupport.find(form.panel(), "issueDeleteCommentArea", JTextArea.class).getText());
+            form.panel().setSize(560, 260);
+            layoutRecursively(form.panel());
+
+            BufferedImage image = render(form.panel(), Path.of("build/reports/ui/issue-delete-dialog.png"), 560, 260);
+            assertTrue(hasRenderedContent(image));
+        });
+    }
+
+    private static void layoutRecursively(Container container) {
+        container.doLayout();
+        for (java.awt.Component child : container.getComponents()) {
+            if (child instanceof Container nested) {
+                layoutRecursively(nested);
+            }
+        }
+    }
+
+    private static BufferedImage render(Container panel, Path output, int width, int height)
+            throws java.io.IOException {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            panel.printAll(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        Files.createDirectories(output.getParent());
+        ImageIO.write(image, "png", output.toFile());
+        return image;
+    }
+
+    private static boolean hasRenderedContent(BufferedImage image) {
+        int white = Color.WHITE.getRGB();
+        int contentPixels = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                if (image.getRGB(x, y) != white) {
+                    contentPixels++;
+                }
+            }
+        }
+        return contentPixels > 1_000;
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditRequestTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditRequestTest.java
@@ -1,0 +1,50 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.marcellokim.issuetracker.domain.Priority;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing issue edit request")
+class IssueEditRequestTest {
+
+    @Test
+    @DisplayName("validates title and description for issue update")
+    void validatesIssueUpdate() {
+        IssueEditRequest request = IssueEditRequest.update(" Login bug ", " Updated description ");
+
+        assertEquals(IssueEditMode.UPDATE, request.mode());
+        assertEquals("Login bug", request.title());
+        assertEquals("Updated description", request.description());
+        assertNull(request.priority());
+        assertNull(request.comment());
+
+        assertThrows(IllegalArgumentException.class, () -> IssueEditRequest.update(" ", "description"));
+        assertThrows(IllegalArgumentException.class, () -> IssueEditRequest.update("title", " "));
+    }
+
+    @Test
+    @DisplayName("validates priority change")
+    void validatesPriorityChange() {
+        IssueEditRequest request = IssueEditRequest.changePriority(Priority.MINOR);
+
+        assertEquals(IssueEditMode.CHANGE_PRIORITY, request.mode());
+        assertEquals(Priority.MINOR, request.priority());
+
+        assertThrows(NullPointerException.class, () -> IssueEditRequest.changePriority(null));
+    }
+
+    @Test
+    @DisplayName("validates soft delete comment")
+    void validatesSoftDeleteComment() {
+        IssueEditRequest request = IssueEditRequest.softDelete(" remove duplicate ");
+
+        assertEquals(IssueEditMode.SOFT_DELETE, request.mode());
+        assertEquals("remove duplicate", request.comment());
+
+        assertThrows(IllegalArgumentException.class, () -> IssueEditRequest.softDelete(" "));
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -10,6 +10,7 @@ import com.github.marcellokim.issuetracker.controller.AccountController;
 import com.github.marcellokim.issuetracker.controller.AssignmentController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.controller.DeletedIssueController;
 import com.github.marcellokim.issuetracker.controller.IssueController;
 import com.github.marcellokim.issuetracker.controller.IssueStateController;
 import com.github.marcellokim.issuetracker.controller.ProjectController;
@@ -35,6 +36,7 @@ import com.github.marcellokim.issuetracker.service.AssignmentRecommendationServi
 import com.github.marcellokim.issuetracker.service.AssignmentService;
 import com.github.marcellokim.issuetracker.service.AuthenticationService;
 import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
+import com.github.marcellokim.issuetracker.service.DeletedIssueService;
 import com.github.marcellokim.issuetracker.service.IssueService;
 import com.github.marcellokim.issuetracker.service.IssueStateService;
 import com.github.marcellokim.issuetracker.service.IssueWorkflowService;
@@ -43,6 +45,7 @@ import com.github.marcellokim.issuetracker.service.PasswordHashing;
 import com.github.marcellokim.issuetracker.service.PermissionPolicy;
 import com.github.marcellokim.issuetracker.service.ProjectService;
 import com.github.marcellokim.issuetracker.service.StatisticsService;
+import com.github.marcellokim.issuetracker.support.FakeDeletedIssueRepository;
 import com.github.marcellokim.issuetracker.support.FakeIssueDependencyRepository;
 import com.github.marcellokim.issuetracker.support.FakeIssueHistoryRepository;
 import com.github.marcellokim.issuetracker.support.FakeStatisticsRepository;
@@ -805,6 +808,111 @@ class SwingAppPanelTest {
     }
 
     @Test
+    @DisplayName("issue detail edit actions update issue and priority")
+    void issueDetailEditActionsUpdateIssueAndPriority() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        User pl = user("pl1", Role.PL);
+        Issue issue = issue(7L, 7L, "Login bug", Priority.CRITICAL, pl);
+        AtomicReference<IssueEditMode> promptedMode = new AtomicReference<>();
+        IssueEditPrompt editPrompt = (parent, mode, context) -> {
+            promptedMode.set(mode);
+            return switch (mode) {
+                case UPDATE -> {
+                    assertEquals("Login bug", context.title());
+                    assertEquals(Priority.CRITICAL, context.priority());
+                    yield Optional.of(IssueEditRequest.update("Edited bug", "Edited through Swing"));
+                }
+                case CHANGE_PRIORITY -> {
+                    assertEquals("Edited bug", context.title());
+                    assertEquals(Priority.CRITICAL, context.priority());
+                    yield Optional.of(IssueEditRequest.changePriority(Priority.MINOR));
+                }
+                case SOFT_DELETE -> Optional.empty();
+            };
+        };
+        SwingAppPanel panel = loginProjectUser(
+                passwordHashing,
+                titles,
+                List.of(projectSnapshot(7L, "Alpha", 3, 1)),
+                List.of(issue),
+                List.of(),
+                IssueStatusChangeDialogs::prompt,
+                IssueAssignmentDialogs::prompt,
+                IssueCommentDialogs::prompt,
+                IssueDependencyDialogs::prompt,
+                editPrompt,
+                pl);
+
+        openFirstIssueDetail(panel, "[ISSUE-7] Login bug");
+        awaitButtonEnabled(panel, "issueActionButton_UPDATE_ISSUE");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "issueActionButton_UPDATE_ISSUE", JButton.class).doClick());
+        awaitIssueDetailTitle(panel, "[ISSUE-7] Edited bug");
+
+        awaitButtonEnabled(panel, "issueActionButton_CHANGE_PRIORITY");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "issueActionButton_CHANGE_PRIORITY", JButton.class).doClick());
+        awaitIssueDetailState(panel, "NEW / MINOR");
+
+        assertEquals(IssueEditMode.CHANGE_PRIORITY, promptedMode.get());
+        SwingComponentTestSupport.onEdt(() -> {
+            assertEquals(
+                    "[ISSUE-7] Edited bug",
+                    SwingComponentTestSupport.find(panel, "issueDetailTitle", JLabel.class).getText());
+            assertEquals(
+                    "NEW / MINOR",
+                    SwingComponentTestSupport.find(panel, "issueDetailState", JLabel.class).getText());
+        });
+    }
+
+    @Test
+    @DisplayName("issue detail soft delete cancel stays on detail and confirm returns to issue list")
+    void issueDetailSoftDeleteCancelStaysOnDetailAndConfirmReturnsToIssueList() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        User pl = user("pl1", Role.PL);
+        Issue issue = issue(7L, 7L, "Login bug", Priority.CRITICAL, pl);
+        AtomicBoolean deleteConfirmed = new AtomicBoolean(false);
+        IssueEditPrompt editPrompt = (parent, mode, context) -> {
+            if (mode != IssueEditMode.SOFT_DELETE) {
+                return Optional.empty();
+            }
+            return deleteConfirmed.get()
+                    ? Optional.of(IssueEditRequest.softDelete("remove duplicate"))
+                    : Optional.empty();
+        };
+        SwingAppPanel panel = loginProjectUser(
+                passwordHashing,
+                titles,
+                List.of(projectSnapshot(7L, "Alpha", 3, 1)),
+                List.of(issue),
+                List.of(),
+                IssueStatusChangeDialogs::prompt,
+                IssueAssignmentDialogs::prompt,
+                IssueCommentDialogs::prompt,
+                IssueDependencyDialogs::prompt,
+                editPrompt,
+                pl);
+
+        openFirstIssueDetail(panel, "[ISSUE-7] Login bug");
+        awaitButtonEnabled(panel, "issueActionButton_SOFT_DELETE");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "issueActionButton_SOFT_DELETE", JButton.class).doClick());
+        SwingComponentTestSupport.onEdt(() -> assertEquals(
+                "[ISSUE-7] Login bug",
+                SwingComponentTestSupport.find(panel, "issueDetailTitle", JLabel.class).getText()));
+
+        deleteConfirmed.set(true);
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "issueActionButton_SOFT_DELETE", JButton.class).doClick());
+        awaitIssueRows(panel, 0);
+        SwingComponentTestSupport.onEdt(() -> assertEquals(
+                "Alpha",
+                SwingComponentTestSupport.find(panel, "issueListTitle", JLabel.class).getText()));
+    }
+
+    @Test
     @DisplayName("project list logout returns to login")
     void projectListLogoutReturnsToLogin() throws Exception {
         var passwordHashing = new RecordingPasswordHashing();
@@ -867,6 +975,30 @@ class SwingAppPanelTest {
                 List.of(),
                 prompts,
                 recommendationRepository,
+                users);
+    }
+
+    private static SwingAppPanel loginProjectUser(
+            RecordingPasswordHashing passwordHashing,
+            RecordingTitleUpdater titles,
+            List<DashboardProjectSnapshot> projects,
+            List<Issue> issues,
+            List<Comment> comments,
+            IssueStatusChangePrompt statusChangePrompt,
+            IssueAssignmentPrompt assignmentPrompt,
+            IssueCommentPrompt commentPrompt,
+            IssueDependencyPrompt dependencyPrompt,
+            IssueEditPrompt editPrompt,
+            User... users) throws Exception {
+        return loginProjectUser(
+                passwordHashing,
+                titles,
+                projects,
+                issues,
+                comments,
+                new SwingPromptSupport(statusChangePrompt, assignmentPrompt, commentPrompt, dependencyPrompt),
+                new InMemoryAssignmentRecommendationRepository(users),
+                editPrompt,
                 users);
     }
 
@@ -952,6 +1084,7 @@ class SwingAppPanelTest {
                 comments,
                 new SwingPromptSupport(statusChangePrompt, assignmentPrompt, commentPrompt, dependencyPrompt),
                 new InMemoryAssignmentRecommendationRepository(users),
+                IssueEditDialogs::prompt,
                 users);
     }
 
@@ -963,6 +1096,28 @@ class SwingAppPanelTest {
             List<Comment> comments,
             SwingPromptSupport prompts,
             AssignmentRecommendationRepository recommendationRepository,
+            User... users) throws Exception {
+        return loginProjectUser(
+                passwordHashing,
+                titles,
+                projects,
+                issues,
+                comments,
+                prompts,
+                recommendationRepository,
+                IssueEditDialogs::prompt,
+                users);
+    }
+
+    private static SwingAppPanel loginProjectUser(
+            RecordingPasswordHashing passwordHashing,
+            RecordingTitleUpdater titles,
+            List<DashboardProjectSnapshot> projects,
+            List<Issue> issues,
+            List<Comment> comments,
+            SwingPromptSupport prompts,
+            AssignmentRecommendationRepository recommendationRepository,
+            IssueEditPrompt editPrompt,
             User... users) throws Exception {
         var panelRef = new AtomicReference<SwingAppPanel>();
         var workerDone = new CountDownLatch(1);
@@ -984,7 +1139,9 @@ class SwingAppPanelTest {
                             controllers.assignmentController(),
                             prompts.assignmentPrompt(),
                             prompts.commentPrompt(),
-                            prompts.dependencyPrompt()),
+                            prompts.dependencyPrompt(),
+                            controllers.deletedIssueController(),
+                            editPrompt),
                     titles::update);
             panelRef.set(panel);
             User user = users[0];
@@ -1010,6 +1167,26 @@ class SwingAppPanelTest {
         assertNotNull(panel);
         awaitProjectListRows(panel, projects.size());
         return panel;
+    }
+
+    private static void openFirstIssueDetail(SwingAppPanel panel, String expectedTitle) throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable projects = SwingComponentTestSupport.find(panel, "projectListTable", JTable.class);
+            projects.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openProjectIssuesButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openProjectIssuesButton", JButton.class).doClick());
+        awaitIssueRows(panel, 1);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable issues = SwingComponentTestSupport.find(panel, "issueListTable", JTable.class);
+            issues.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openIssueDetailButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick());
+        awaitIssueDetailTitle(panel, expectedTitle);
     }
 
     private static SwingWorker<?, ?> loginWorker(SwingAppPanel panel) throws ReflectiveOperationException {
@@ -1281,6 +1458,7 @@ class SwingAppPanelTest {
             }
         });
         var issueRepository = new InMemoryIssueRepository(issues.toArray(Issue[]::new));
+        var deletedIssueRepository = new FakeDeletedIssueRepository(issueRepository);
         var dependencyRepository = new FakeIssueDependencyRepository();
         var commentRepository = new FakeCommentRepository(comments);
         var historyRepository = new FakeIssueHistoryRepository();
@@ -1305,6 +1483,14 @@ class SwingAppPanelTest {
                         new AssignmentRecommendationService(
                                 recommendationRepository,
                                 new KNNAssignmentRecommendation()),
+                        () -> NOW));
+        DeletedIssueController deletedIssueController = new DeletedIssueController(
+                service,
+                new DeletedIssueService(
+                        issueRepository,
+                        deletedIssueRepository,
+                        repository,
+                        permissionPolicy,
                         () -> NOW));
         return new SwingControllerFixture(
                 new AuthenticationController(service),
@@ -1352,7 +1538,8 @@ class SwingAppPanelTest {
                         service,
                         new StatisticsService(permissionPolicy, statisticsRepository, repository)),
                 issueStateController,
-                assignmentController);
+                assignmentController,
+                deletedIssueController);
     }
 
     private static User user(String loginId, Role role) {
@@ -1429,7 +1616,8 @@ class SwingAppPanelTest {
             IssueController issueController,
             StatisticsController statisticsController,
             IssueStateController issueStateController,
-            AssignmentController assignmentController) {
+            AssignmentController assignmentController,
+            DeletedIssueController deletedIssueController) {
 
         SwingControllers swingControllers() {
             return new SwingControllers(


### PR DESCRIPTION
## 요약
Closes #214

Swing 이슈 상세 화면에서 이슈 수정, 우선순위 변경, 소프트 삭제 action을 실제 controller 흐름에 연결합니다.

## 변경 분류
- `type:feat`
- `type:test`
- `area:ui`

## purpose
Swing 이슈 상세 화면의 `UPDATE_ISSUE`, `CHANGE_PRIORITY`, `SOFT_DELETE` action이 placeholder에 머물지 않고 기존 application/controller 계약을 통해 실행되도록 합니다.

## non-goals
- Swing UI에서 reporter/PL/status 권한 정책을 직접 계산하지 않음
- 삭제 이슈 목록, 복구, 영구 삭제 화면은 포함하지 않음
- 삭제 보관 한도나 purge 정책을 UI에서 처리하지 않음

## diff map
- 핵심 변경: `IssueEditRequest`, `IssueEditDialogs`, `IssueDetailPresenter`, `SwingAppPanel`
- 연결 변경: `SwingAppFrame`에서 `DeletedIssueController` 주입
- 테스트 변경: edit/delete request, dialog snapshot, presenter, app flow 테스트 추가

## verification evidence
- `git diff --check origin/dev...HEAD && git diff --check`
- `./gradlew check --console=plain`
- Swing dialog screenshot 확인: `build/reports/ui/issue-edit-dialog.png`, `build/reports/ui/issue-priority-dialog.png`, `build/reports/ui/issue-delete-dialog.png`

## 과제 요구사항 영향
- Swing UI가 기존 backend/application controller를 재사용하는 방식으로 동작합니다.
- 삭제 정책과 수정/우선순위 정책은 UI가 재구현하지 않고 기존 서비스 계층 검증을 따릅니다.

## 문서 및 증빙
- 별도 문서 변경 없음
- UI snapshot 테스트로 dialog 렌더링 증빙 추가

## reviewer focus areas
- `SOFT_DELETE` 성공 후 issue list로 돌아가는 navigation이 `SwingAppPanel`에서 일관되게 처리되는지
- edit/delete prompt가 기존 `IssueController`/`DeletedIssueController` 정책에만 위임하는지
- 최신 Swing controller 묶음 구조와 constructor 주입이 일관되는지

## risk / rollback
- 위험은 Swing 상세 action routing과 controller 주입부에 한정됩니다.
- 문제가 생기면 이 PR만 되돌리면 앞선 Swing 화면 흐름에는 영향이 남지 않습니다.
