### PR TITLE
feat: Swing 삭제 이슈 관리 구현

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentDeletedIssueView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/CurrentDeletedIssueView.java
@@ -1,0 +1,31 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.swing.SwingWorker;
+
+final class CurrentDeletedIssueView implements DeletedIssueView {
+
+    private final DeletedIssuePanel delegate;
+    private final CurrentViewGate gate;
+
+    CurrentDeletedIssueView(
+            DeletedIssuePanel delegate,
+            SwingWorker<?, ?> worker,
+            Supplier<? extends SwingWorker<?, ?>> currentWorker) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.gate = new CurrentViewGate(worker, currentWorker);
+    }
+
+    @Override
+    public void showDeletedIssues(int maxRetentionLimit, List<IssueSummary> issues) {
+        gate.update(() -> delegate.showDeletedIssues(maxRetentionLimit, issues));
+    }
+
+    @Override
+    public void showMessage(String message, boolean error) {
+        gate.update(() -> delegate.showMessage(message, error));
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssueDialogs.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssueDialogs.java
@@ -1,0 +1,93 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.util.Objects;
+import java.util.Optional;
+import javax.swing.Box;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+
+final class DeletedIssueDialogs {
+
+    private static final int COMMENT_ROWS = 5;
+    private static final int COMMENT_COLUMNS = 36;
+    private static final String RESTORE_DIALOG_TITLE = "Restore deleted issue";
+    private static final String PURGE_DIALOG_TITLE = "Purge deleted issue";
+
+    private DeletedIssueDialogs() {
+    }
+
+    static JPanel restoreCommentForm(IssueSummary issue) {
+        return restoreForm(issue).panel();
+    }
+
+    private static RestoreForm restoreForm(IssueSummary issue) {
+        Objects.requireNonNull(issue, "issue");
+        JPanel panel = SwingPanelSections.dialogFormPanel("Restore " + issue.issueId(), "deletedIssueRestoreTitle");
+        JPanel fields = SwingPanelSections.verticalFieldPanel();
+
+        JLabel commentLabel = SwingPanelSections.fieldLabel("Restore reason");
+        commentLabel.setName("deletedIssueRestoreCommentLabel");
+        JTextArea commentArea = new JTextArea(COMMENT_ROWS, COMMENT_COLUMNS);
+        commentArea.setName("deletedIssueRestoreCommentArea");
+        commentArea.setLineWrap(true);
+        commentArea.setWrapStyleWord(true);
+
+        fields.add(commentLabel);
+        fields.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
+        fields.add(new JScrollPane(commentArea));
+        panel.add(fields, BorderLayout.CENTER);
+        return new RestoreForm(panel, commentArea);
+    }
+
+    static final class JOptionPaneDeletedIssuePrompt implements DeletedIssuePrompt {
+
+        @Override
+        public Optional<String> requestRestoreComment(Component parent, IssueSummary issue) {
+            return promptRestore(parent, issue);
+        }
+
+        @Override
+        public boolean confirmPurge(Component parent, IssueSummary issue) {
+            int result = JOptionPane.showConfirmDialog(
+                    parent,
+                    "Permanently purge " + issue.issueId() + "?",
+                    PURGE_DIALOG_TITLE,
+                    JOptionPane.OK_CANCEL_OPTION,
+                    JOptionPane.WARNING_MESSAGE);
+            return result == JOptionPane.OK_OPTION;
+        }
+
+        private static Optional<String> promptRestore(Component parent, IssueSummary issue) {
+            RestoreForm form = restoreForm(issue);
+            while (true) {
+                int result = JOptionPane.showConfirmDialog(
+                        parent,
+                        form.panel(),
+                        RESTORE_DIALOG_TITLE,
+                        JOptionPane.OK_CANCEL_OPTION,
+                        JOptionPane.PLAIN_MESSAGE);
+                if (result != JOptionPane.OK_OPTION) {
+                    return Optional.empty();
+                }
+                String comment = form.commentArea().getText();
+                if (comment != null && !comment.isBlank()) {
+                    return Optional.of(comment.trim());
+                }
+                JOptionPane.showMessageDialog(
+                        parent,
+                        "Restore reason must not be blank.",
+                        RESTORE_DIALOG_TITLE,
+                        JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    private record RestoreForm(JPanel panel, JTextArea commentArea) {
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssuePanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssuePanel.java
@@ -1,0 +1,242 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellRenderer;
+
+final class DeletedIssuePanel extends JPanel implements DeletedIssueView {
+
+    private static final long serialVersionUID = 1L;
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    private static final String DEFAULT_ERROR_MESSAGE = "Deleted issue management failed. Please try again.";
+    private static final String[] ISSUE_COLUMNS = {"ID", "Issue", "Status", "Priority", "Title", "Reporter", "Updated"};
+    private static final int[] ISSUE_COLUMN_WIDTHS = {64, 96, 100, 92, 320, 112, 144};
+    private static final Color SELECTION_BACKGROUND = new Color(219, 234, 254);
+
+    private final transient DeletedIssueActions actions;
+    private final JLabel messageLabel = new JLabel(" ");
+    private final JLabel countLabel = new JLabel("Deleted issues 0/0");
+    private final DefaultTableModel issueTableModel = SwingPanelSections.readOnlyTableModel(ISSUE_COLUMNS);
+    private final JTable issueTable = table();
+    private final JButton restoreButton = new JButton("Restore selected");
+    private final JButton purgeButton = new JButton("Purge selected");
+    private final List<IssueSummary> issues = new ArrayList<>();
+    private boolean busy;
+
+    DeletedIssuePanel(UserResult user, DeletedIssueActions actions) {
+        Objects.requireNonNull(user, "user");
+        this.actions = Objects.requireNonNull(actions, "actions");
+
+        setName("deletedIssuePanel");
+        setLayout(new BorderLayout(SwingStyles.SECTION_GAP, SwingStyles.SECTION_GAP));
+        setBackground(SwingStyles.BACKGROUND);
+        setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING,
+                SwingStyles.OUTER_PADDING));
+
+        add(topSection(user), BorderLayout.NORTH);
+        add(tableSection(), BorderLayout.CENTER);
+        add(actionBar(), BorderLayout.SOUTH);
+        updateActionState();
+    }
+
+    @Override
+    public void showDeletedIssues(int maxRetentionLimit, List<IssueSummary> issues) {
+        Objects.requireNonNull(issues, "issues");
+        List<IssueSummary> snapshot = List.copyOf(issues);
+        List<Object[]> rows = issueRows(snapshot);
+        SwingPanelSections.runOnEdt(() -> {
+            Long selectedIssueId = selectedIssue().map(IssueSummary::id).orElse(null);
+            this.issues.clear();
+            this.issues.addAll(snapshot);
+            countLabel.setText("Deleted issues " + snapshot.size() + "/" + maxRetentionLimit);
+            replaceRows(rows);
+            restoreSelection(selectedIssueId);
+            updateActionState();
+        });
+    }
+
+    @Override
+    public void showMessage(String message, boolean error) {
+        SwingPanelSections.runOnEdt(() -> SwingPanelSections.updateMessage(
+                messageLabel,
+                message,
+                error,
+                DEFAULT_ERROR_MESSAGE));
+    }
+
+    void setBusy(boolean busy) {
+        SwingPanelSections.runOnEdt(() -> {
+            this.busy = busy;
+            issueTable.setEnabled(!busy);
+            updateActionState();
+        });
+    }
+
+    private JPanel topSection(UserResult user) {
+        JPanel panel = new JPanel(new BorderLayout(0, SwingStyles.SECTION_GAP));
+        panel.setOpaque(false);
+        panel.add(SwingPanelSections.managementHeader(
+                new SwingPanelSections.HeaderLabels(
+                        "Deleted issue management",
+                        "deletedIssueTitle",
+                        "deletedIssueUser",
+                        "deletedIssueMessage",
+                        "deletedIssueBackButton",
+                        "deletedIssueLogoutButton"),
+                user,
+                messageLabel,
+                new SwingPanelSections.NavigationActions(actions.onBack(), actions.onLogout())), BorderLayout.NORTH);
+        return panel;
+    }
+
+    private JPanel tableSection() {
+        JPanel section = new JPanel(new BorderLayout(0, SwingStyles.ROW_GAP));
+        section.setBackground(SwingStyles.SURFACE);
+        section.setBorder(SwingStyles.surfaceBorder());
+
+        JPanel heading = new JPanel(new BorderLayout());
+        heading.setOpaque(false);
+        JLabel title = new JLabel("Deleted issues");
+        SwingStyles.applySectionTitle(title);
+        countLabel.setName("deletedIssueCount");
+        SwingStyles.applyMuted(countLabel);
+        heading.add(title, BorderLayout.WEST);
+        heading.add(countLabel, BorderLayout.EAST);
+        section.add(heading, BorderLayout.NORTH);
+
+        JScrollPane scrollPane = new JScrollPane(issueTable);
+        scrollPane.setColumnHeaderView(issueTable.getTableHeader());
+        section.add(scrollPane, BorderLayout.CENTER);
+        return section;
+    }
+
+    private JPanel actionBar() {
+        JPanel panel = new JPanel();
+        panel.setBackground(SwingStyles.SURFACE);
+        panel.setBorder(SwingStyles.surfaceBorder());
+
+        restoreButton.setName("restoreDeletedIssueButton");
+        restoreButton.addActionListener(event -> selectedIssue()
+                .ifPresent(issue -> actions.onRestore().accept(this, issue)));
+        panel.add(restoreButton);
+
+        purgeButton.setName("purgeDeletedIssueButton");
+        purgeButton.addActionListener(event -> selectedIssue()
+                .ifPresent(issue -> actions.onPurge().accept(this, issue)));
+        panel.add(purgeButton);
+        return panel;
+    }
+
+    private JTable table() {
+        JTable table = new JTable(issueTableModel) {
+            @Override
+            public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
+                return SwingPanelSections.stripedTableCell(
+                        this,
+                        super.prepareRenderer(renderer, row, column),
+                        row,
+                        SELECTION_BACKGROUND);
+            }
+        };
+        SwingPanelSections.configureReadOnlyTable(table, "deletedIssueTable", SELECTION_BACKGROUND);
+        table.getSelectionModel().addListSelectionListener(event -> {
+            if (!event.getValueIsAdjusting()) {
+                updateActionState();
+            }
+        });
+        SwingPanelSections.applyColumnWidths(table, ISSUE_COLUMN_WIDTHS);
+        return table;
+    }
+
+    private Optional<IssueSummary> selectedIssue() {
+        int selectedRow = issueTable.getSelectedRow();
+        if (selectedRow < 0) {
+            return Optional.empty();
+        }
+        int modelRow = issueTable.convertRowIndexToModel(selectedRow);
+        if (modelRow < 0 || modelRow >= issues.size()) {
+            return Optional.empty();
+        }
+        return Optional.of(issues.get(modelRow));
+    }
+
+    private void replaceRows(List<Object[]> rows) {
+        issueTableModel.setRowCount(0);
+        for (Object[] row : rows) {
+            issueTableModel.addRow(row);
+        }
+    }
+
+    private void restoreSelection(Long selectedIssueId) {
+        if (selectedIssueId == null) {
+            return;
+        }
+        for (int row = 0; row < issues.size(); row++) {
+            if (selectedIssueId == issues.get(row).id()) {
+                int viewRow = issueTable.convertRowIndexToView(row);
+                if (viewRow >= 0) {
+                    issueTable.setRowSelectionInterval(viewRow, viewRow);
+                }
+                return;
+            }
+        }
+    }
+
+    private void updateActionState() {
+        boolean enabled = !busy && selectedIssue().isPresent();
+        restoreButton.setEnabled(enabled);
+        purgeButton.setEnabled(enabled);
+    }
+
+    private static List<Object[]> issueRows(List<IssueSummary> issues) {
+        return issues.stream()
+                .map(issue -> new Object[]{
+                        issue.id(),
+                        issue.issueId(),
+                        issue.status(),
+                        issue.priority(),
+                        issue.title(),
+                        issue.reporterId(),
+                        DATE_TIME_FORMATTER.format(issue.updatedAt())
+                })
+                .toList();
+    }
+
+    @FunctionalInterface
+    interface PanelIssueConsumer {
+
+        void accept(DeletedIssuePanel panel, IssueSummary issue);
+    }
+
+    record DeletedIssueActions(
+            PanelIssueConsumer onRestore,
+            PanelIssueConsumer onPurge,
+            Runnable onBack,
+            Runnable onLogout) {
+
+        DeletedIssueActions {
+            Objects.requireNonNull(onRestore, "onRestore");
+            Objects.requireNonNull(onPurge, "onPurge");
+            Objects.requireNonNull(onBack, "onBack");
+            Objects.requireNonNull(onLogout, "onLogout");
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssuePresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssuePresenter.java
@@ -1,0 +1,69 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.controller.DeletedIssueController;
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import java.util.List;
+import java.util.Objects;
+
+final class DeletedIssuePresenter {
+
+    private final DeletedIssueController deletedIssueController;
+    private final DeletedIssueView view;
+
+    DeletedIssuePresenter(DeletedIssueController deletedIssueController, DeletedIssueView view) {
+        this.deletedIssueController = Objects.requireNonNull(deletedIssueController, "deletedIssueController");
+        this.view = Objects.requireNonNull(view, "view");
+    }
+
+    void loadDeletedIssues(long projectId) {
+        try {
+            DeletedIssueSnapshot snapshot = fetchDeletedIssues(projectId);
+            view.showDeletedIssues(snapshot.maxRetentionLimit(), snapshot.issues());
+            view.showMessage(summaryMessage(snapshot), false);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    void restoreIssue(long projectId, long issueId, String comment) {
+        try {
+            deletedIssueController.restoreIssue(issueId, comment);
+            refreshDeletedIssues(projectId);
+            view.showMessage("Issue restored.", false);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    void purgeDeletedIssue(long projectId, long issueId) {
+        try {
+            deletedIssueController.purgeDeletedIssue(issueId);
+            refreshDeletedIssues(projectId);
+            view.showMessage("Deleted issue purged.", false);
+        } catch (RuntimeException exception) {
+            view.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    private void refreshDeletedIssues(long projectId) {
+        DeletedIssueSnapshot snapshot = fetchDeletedIssues(projectId);
+        view.showDeletedIssues(snapshot.maxRetentionLimit(), snapshot.issues());
+    }
+
+    private DeletedIssueSnapshot fetchDeletedIssues(long projectId) {
+        List<IssueSummary> issues = deletedIssueController.viewDeletedIssues(projectId);
+        int maxRetentionLimit = deletedIssueController.getMaxRetentionLimit();
+        return new DeletedIssueSnapshot(maxRetentionLimit, issues);
+    }
+
+    private static String summaryMessage(DeletedIssueSnapshot snapshot) {
+        return "Deleted issues " + snapshot.issues().size() + "/" + snapshot.maxRetentionLimit();
+    }
+
+    private record DeletedIssueSnapshot(int maxRetentionLimit, List<IssueSummary> issues) {
+
+        private DeletedIssueSnapshot {
+            issues = List.copyOf(issues);
+        }
+    }
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssuePrompt.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssuePrompt.java
@@ -1,0 +1,12 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import java.awt.Component;
+import java.util.Optional;
+
+interface DeletedIssuePrompt {
+
+    Optional<String> requestRestoreComment(Component parent, IssueSummary issue);
+
+    boolean confirmPurge(Component parent, IssueSummary issue);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssueView.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssueView.java
@@ -1,0 +1,11 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import java.util.List;
+
+interface DeletedIssueView {
+
+    void showDeletedIssues(int maxRetentionLimit, List<IssueSummary> issues);
+
+    void showMessage(String message, boolean error);
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditDialogs.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueEditDialogs.java
@@ -5,12 +5,8 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.util.Optional;
-import javax.swing.BorderFactory;
 import javax.swing.Box;
-import javax.swing.BoxLayout;
 import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -44,18 +40,18 @@ final class IssueEditDialogs {
         descriptionArea.setName("issueEditDescriptionArea");
         descriptionArea.setLineWrap(true);
         descriptionArea.setWrapStyleWord(true);
-        JScrollPane descriptionPane = aligned(new JScrollPane(descriptionArea));
+        JScrollPane descriptionPane = SwingPanelSections.aligned(new JScrollPane(descriptionArea));
 
-        JPanel fields = verticalFields();
-        fields.add(fieldLabel("Title"));
+        JPanel fields = SwingPanelSections.verticalFieldPanel();
+        fields.add(SwingPanelSections.fieldLabel("Title"));
         fields.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
         fields.add(titleField);
         fields.add(Box.createVerticalStrut(SwingStyles.SECTION_GAP));
-        fields.add(fieldLabel("Description"));
+        fields.add(SwingPanelSections.fieldLabel("Description"));
         fields.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
         fields.add(descriptionPane);
 
-        JPanel panel = formPanel(EDIT_ISSUE_TITLE, "issueEditDialogTitle");
+        JPanel panel = SwingPanelSections.dialogFormPanel(EDIT_ISSUE_TITLE, "issueEditDialogTitle");
         panel.add(fields, BorderLayout.CENTER);
         return new UpdateForm(panel, titleField, descriptionArea);
     }
@@ -67,12 +63,12 @@ final class IssueEditDialogs {
         priorityBox.setMaximumSize(new Dimension(Integer.MAX_VALUE, SwingStyles.FIELD_HEIGHT));
         priorityBox.setAlignmentX(Component.LEFT_ALIGNMENT);
 
-        JPanel fields = verticalFields();
-        fields.add(fieldLabel("Priority"));
+        JPanel fields = SwingPanelSections.verticalFieldPanel();
+        fields.add(SwingPanelSections.fieldLabel("Priority"));
         fields.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
         fields.add(priorityBox);
 
-        JPanel panel = formPanel("Change priority", "priorityDialogTitle");
+        JPanel panel = SwingPanelSections.dialogFormPanel("Change priority", "priorityDialogTitle");
         panel.add(fields, BorderLayout.CENTER);
         return new PriorityForm(panel, priorityBox);
     }
@@ -82,11 +78,11 @@ final class IssueEditDialogs {
         commentArea.setName("issueDeleteCommentArea");
         commentArea.setLineWrap(true);
         commentArea.setWrapStyleWord(true);
-        JScrollPane commentPane = aligned(new JScrollPane(commentArea));
+        JScrollPane commentPane = SwingPanelSections.aligned(new JScrollPane(commentArea));
 
-        JPanel panel = formPanel(DELETE_ISSUE_TITLE, "issueDeleteDialogTitle");
-        JPanel fields = verticalFields();
-        fields.add(fieldLabel("Comment"));
+        JPanel panel = SwingPanelSections.dialogFormPanel(DELETE_ISSUE_TITLE, "issueDeleteDialogTitle");
+        JPanel fields = SwingPanelSections.verticalFieldPanel();
+        fields.add(SwingPanelSections.fieldLabel("Comment"));
         fields.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
         fields.add(commentPane);
         panel.add(fields, BorderLayout.CENTER);
@@ -151,38 +147,6 @@ final class IssueEditDialogs {
                         JOptionPane.ERROR_MESSAGE);
             }
         }
-    }
-
-    private static JPanel formPanel(String titleText, String titleName) {
-        JPanel panel = new JPanel(new BorderLayout(SwingStyles.ROW_GAP, SwingStyles.ROW_GAP));
-        panel.setBorder(BorderFactory.createEmptyBorder(
-                SwingStyles.ROW_GAP,
-                SwingStyles.ROW_GAP,
-                SwingStyles.ROW_GAP,
-                SwingStyles.ROW_GAP));
-        JLabel title = new JLabel(titleText);
-        title.setName(titleName);
-        SwingStyles.applySectionTitle(title);
-        panel.add(title, BorderLayout.NORTH);
-        return panel;
-    }
-
-    private static JPanel verticalFields() {
-        JPanel fields = new JPanel();
-        fields.setLayout(new BoxLayout(fields, BoxLayout.Y_AXIS));
-        fields.setAlignmentX(Component.LEFT_ALIGNMENT);
-        return fields;
-    }
-
-    private static JLabel fieldLabel(String text) {
-        JLabel label = new JLabel(text);
-        label.setAlignmentX(Component.LEFT_ALIGNMENT);
-        return label;
-    }
-
-    private static <T extends JComponent> T aligned(T component) {
-        component.setAlignmentX(Component.LEFT_ALIGNMENT);
-        return component;
     }
 
     record UpdateForm(JPanel panel, JTextField titleField, JTextArea descriptionArea) {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanel.java
@@ -2,6 +2,7 @@ package com.github.marcellokim.issuetracker.ui.swing;
 
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Role;
 import com.github.marcellokim.issuetracker.service.IssueSummary;
 import com.github.marcellokim.issuetracker.service.ProjectResult;
 import com.github.marcellokim.issuetracker.service.UserResult;
@@ -54,9 +55,11 @@ final class IssueListPanel extends JPanel implements IssueListView {
     private final transient IssueTableRows issueRows = new IssueTableRows(issueTableModel);
     private final JTable issueTable = table();
     private final JButton searchButton = new JButton("Search");
-    private final JButton registerButton = new JButton("Register issue");
-    private final JButton openButton = new JButton("Open detail");
+    private final JButton registerButton = new JButton("Register");
+    private final JButton openButton = new JButton("Open");
+    private final JButton deletedIssuesButton = new JButton("Deleted");
     private final JButton statisticsButton = new JButton("Statistics");
+    private final boolean canManageDeletedIssues;
     private boolean busy;
     private boolean registerAllowed;
 
@@ -68,6 +71,7 @@ final class IssueListPanel extends JPanel implements IssueListView {
         this.dialogs = Objects.requireNonNull(dialogs, "dialogs");
         this.actions = Objects.requireNonNull(actions, "actions");
         this.userLabel = new JLabel(user.name() + " (" + user.role() + ")");
+        this.canManageDeletedIssues = user.role() == Role.PL;
 
         setName("issueListPanel");
         setLayout(new BorderLayout(SwingStyles.SECTION_GAP, SwingStyles.SECTION_GAP));
@@ -195,7 +199,7 @@ final class IssueListPanel extends JPanel implements IssueListView {
         panel.setBorder(SwingStyles.surfaceBorder());
 
         searchField.setName("issueSearchField");
-        searchField.setColumns(18);
+        searchField.setColumns(8);
         panel.add(searchField);
 
         statusFilter.setName("issueStatusFilter");
@@ -217,6 +221,11 @@ final class IssueListPanel extends JPanel implements IssueListView {
         openButton.addActionListener(event -> selectedIssue()
                 .ifPresent(issue -> actions.onOpenIssue().accept(issue.id())));
         panel.add(openButton);
+
+        deletedIssuesButton.setName("deletedIssuesButton");
+        deletedIssuesButton.setVisible(canManageDeletedIssues);
+        deletedIssuesButton.addActionListener(event -> actions.onDeletedIssues().run());
+        panel.add(deletedIssuesButton);
 
         statisticsButton.setName("statisticsButton");
         statisticsButton.addActionListener(event -> actions.onStatistics().run());
@@ -292,6 +301,7 @@ final class IssueListPanel extends JPanel implements IssueListView {
         boolean enabled = !busy;
         registerButton.setEnabled(enabled && registerAllowed);
         openButton.setEnabled(enabled && selectedIssue().isPresent());
+        deletedIssuesButton.setEnabled(enabled && canManageDeletedIssues);
         statisticsButton.setEnabled(enabled);
     }
 
@@ -309,6 +319,7 @@ final class IssueListPanel extends JPanel implements IssueListView {
             PanelConsumer<IssueSearchRequest> onSearch,
             PanelConsumer<IssueRegisterRequest> onRegister,
             LongConsumer onOpenIssue,
+            Runnable onDeletedIssues,
             Runnable onStatistics,
             Runnable onBack,
             Runnable onLogout) {
@@ -317,6 +328,7 @@ final class IssueListPanel extends JPanel implements IssueListView {
             Objects.requireNonNull(onSearch, "onSearch");
             Objects.requireNonNull(onRegister, "onRegister");
             Objects.requireNonNull(onOpenIssue, "onOpenIssue");
+            Objects.requireNonNull(onDeletedIssues, "onDeletedIssues");
             Objects.requireNonNull(onStatistics, "onStatistics");
             Objects.requireNonNull(onBack, "onBack");
             Objects.requireNonNull(onLogout, "onLogout");

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -4,11 +4,13 @@ import com.github.marcellokim.issuetracker.controller.AccountController;
 import com.github.marcellokim.issuetracker.controller.AssignmentController;
 import com.github.marcellokim.issuetracker.controller.AuthenticationController;
 import com.github.marcellokim.issuetracker.controller.DashboardController;
+import com.github.marcellokim.issuetracker.controller.DeletedIssueController;
 import com.github.marcellokim.issuetracker.controller.IssueController;
 import com.github.marcellokim.issuetracker.controller.ProjectController;
 import com.github.marcellokim.issuetracker.controller.StatisticsController;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.service.AssignmentOptionsResult;
+import com.github.marcellokim.issuetracker.service.IssueSummary;
 import com.github.marcellokim.issuetracker.service.UserResult;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
@@ -35,6 +37,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     private final transient SwingControllers controllers;
     private final transient IssueActionSupport issueActionSupport;
+    private final transient DeletedIssuePrompt deletedIssuePrompt;
     private final transient Consumer<String> titleUpdater;
     private final CardLayout cardLayout = new CardLayout();
     private final LoginPanel loginPanel = new LoginPanel();
@@ -49,6 +52,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private final transient AtomicReference<SwingWorker<Void, Void>> issueListWorker = new AtomicReference<>();
     private final transient AtomicReference<SwingWorker<Void, Void>> issueDetailWorker = new AtomicReference<>();
     private final transient AtomicReference<SwingWorker<Void, Void>> statisticsWorker = new AtomicReference<>();
+    private final transient AtomicReference<SwingWorker<Void, Void>> deletedIssueWorker = new AtomicReference<>();
 
     SwingAppPanel(
             AuthenticationController authenticationController,
@@ -91,8 +95,21 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             SwingControllers controllers,
             IssueActionSupport issueActionSupport,
             Consumer<String> titleUpdater) {
+        this(
+                controllers,
+                issueActionSupport,
+                new DeletedIssueDialogs.JOptionPaneDeletedIssuePrompt(),
+                titleUpdater);
+    }
+
+    SwingAppPanel(
+            SwingControllers controllers,
+            IssueActionSupport issueActionSupport,
+            DeletedIssuePrompt deletedIssuePrompt,
+            Consumer<String> titleUpdater) {
         this.controllers = Objects.requireNonNull(controllers, "controllers");
         this.issueActionSupport = Objects.requireNonNull(issueActionSupport, "issueActionSupport");
+        this.deletedIssuePrompt = Objects.requireNonNull(deletedIssuePrompt, "deletedIssuePrompt");
         this.titleUpdater = Objects.requireNonNull(titleUpdater, "titleUpdater");
 
         setName("appCards");
@@ -109,14 +126,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     public void showLogin() {
         runOnEdtAndWait(() -> {
-            cancelDashboardWorker();
-            cancelAccountWorker();
-            cancelProjectWorker();
-            cancelProjectDetailWorker();
-            cancelProjectListWorker();
-            cancelIssueListWorker();
-            cancelIssueDetailWorker();
-            cancelStatisticsWorker();
+            cancelViewWorkers();
             titleUpdater.accept("Issue Tracker");
             loginPanel.showMessage(" ", false);
             loginPanel.clearPassword();
@@ -129,14 +139,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     public void showAdminDashboard(UserResult user) {
         Objects.requireNonNull(user, "user");
         SwingUtilities.invokeLater(() -> {
-            cancelDashboardWorker();
-            cancelAccountWorker();
-            cancelProjectWorker();
-            cancelProjectDetailWorker();
-            cancelProjectListWorker();
-            cancelIssueListWorker();
-            cancelIssueDetailWorker();
-            cancelStatisticsWorker();
+            cancelViewWorkers();
             titleUpdater.accept("Admin dashboard");
             AdminDashboardPanel panel = new AdminDashboardPanel(
                     user,
@@ -156,14 +159,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     public void showProjectList(UserResult user) {
         Objects.requireNonNull(user, "user");
         runOnEdtAndWait(() -> {
-            cancelDashboardWorker();
-            cancelAccountWorker();
-            cancelProjectWorker();
-            cancelProjectDetailWorker();
-            cancelProjectListWorker();
-            cancelIssueListWorker();
-            cancelIssueDetailWorker();
-            cancelStatisticsWorker();
+            cancelViewWorkers();
             titleUpdater.accept("Project list");
             ProjectListPanel panel = new ProjectListPanel(
                     user,
@@ -180,14 +176,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     }
 
     void logout() {
-        cancelDashboardWorker();
-        cancelAccountWorker();
-        cancelProjectWorker();
-        cancelProjectDetailWorker();
-        cancelProjectListWorker();
-        cancelIssueListWorker();
-        cancelIssueDetailWorker();
-        cancelStatisticsWorker();
+        cancelViewWorkers();
         controllers.authenticationController().logout();
         showLogin();
     }
@@ -246,14 +235,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     private void showAccountManagement(UserResult user) {
         SwingUtilities.invokeLater(() -> {
-            cancelDashboardWorker();
-            cancelAccountWorker();
-            cancelProjectWorker();
-            cancelProjectDetailWorker();
-            cancelProjectListWorker();
-            cancelIssueListWorker();
-            cancelIssueDetailWorker();
-            cancelStatisticsWorker();
+            cancelViewWorkers();
             titleUpdater.accept("Account management");
             AccountManagementPanel panel = new AccountManagementPanel(
                     user,
@@ -278,14 +260,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     private void showProjectManagement(UserResult user) {
         SwingUtilities.invokeLater(() -> {
-            cancelDashboardWorker();
-            cancelAccountWorker();
-            cancelProjectWorker();
-            cancelProjectDetailWorker();
-            cancelProjectListWorker();
-            cancelIssueListWorker();
-            cancelIssueDetailWorker();
-            cancelStatisticsWorker();
+            cancelViewWorkers();
             titleUpdater.accept("Project management");
             ProjectManagementPanel panel = new ProjectManagementPanel(
                     user,
@@ -317,14 +292,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     private void showProjectDetail(UserResult user, long projectId) {
         SwingUtilities.invokeLater(() -> {
-            cancelDashboardWorker();
-            cancelAccountWorker();
-            cancelProjectWorker();
-            cancelProjectDetailWorker();
-            cancelProjectListWorker();
-            cancelIssueListWorker();
-            cancelIssueDetailWorker();
-            cancelStatisticsWorker();
+            cancelViewWorkers();
             titleUpdater.accept("Project detail");
             ProjectDetailPanel panel = new ProjectDetailPanel(
                     user,
@@ -360,14 +328,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     private void showIssueList(UserResult user, long projectId) {
         SwingUtilities.invokeLater(() -> {
-            cancelDashboardWorker();
-            cancelAccountWorker();
-            cancelProjectWorker();
-            cancelProjectDetailWorker();
-            cancelProjectListWorker();
-            cancelIssueListWorker();
-            cancelIssueDetailWorker();
-            cancelStatisticsWorker();
+            cancelViewWorkers();
             titleUpdater.accept("Issue list");
             IssueListPanel panel = new IssueListPanel(
                     user,
@@ -382,6 +343,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
                                             panelRef,
                                             presenter -> presenter.registerIssue(projectId, request)),
                             issueId -> showIssueDetail(user, projectId, issueId),
+                            () -> showDeletedIssues(user, projectId),
                             () -> showStatistics(user, projectId),
                             () -> showProjectList(user),
                             this::logout));
@@ -396,14 +358,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     private void showStatistics(UserResult user, long projectId) {
         SwingUtilities.invokeLater(() -> {
-            cancelDashboardWorker();
-            cancelAccountWorker();
-            cancelProjectWorker();
-            cancelProjectDetailWorker();
-            cancelProjectListWorker();
-            cancelIssueListWorker();
-            cancelIssueDetailWorker();
-            cancelStatisticsWorker();
+            cancelViewWorkers();
             titleUpdater.accept("Statistics");
             StatisticsPanel panel = new StatisticsPanel(
                     user,
@@ -423,16 +378,50 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         });
     }
 
+    private void showDeletedIssues(UserResult user, long projectId) {
+        SwingUtilities.invokeLater(() -> {
+            cancelViewWorkers();
+            titleUpdater.accept("Deleted issues");
+            DeletedIssuePanel panel = new DeletedIssuePanel(
+                    user,
+                    new DeletedIssuePanel.DeletedIssueActions(
+                            (panelRef, issue) -> showDeletedIssueRestore(projectId, panelRef, issue),
+                            (panelRef, issue) -> showDeletedIssuePurge(projectId, panelRef, issue),
+                            () -> showIssueList(user, projectId),
+                            this::logout));
+            projectListCard.removeAll();
+            projectListCard.add(panel, BorderLayout.CENTER);
+            projectListCard.revalidate();
+            projectListCard.repaint();
+            cardLayout.show(this, PROJECT_LIST_CARD);
+            startDeletedIssueTask(panel, presenter -> presenter.loadDeletedIssues(projectId));
+        });
+    }
+
+    private void showDeletedIssueRestore(long projectId, DeletedIssuePanel panel, IssueSummary issue) {
+        try {
+            deletedIssuePrompt.requestRestoreComment(panel, issue)
+                    .ifPresent(comment -> startDeletedIssueTask(
+                            panel,
+                            presenter -> presenter.restoreIssue(projectId, issue.id(), comment)));
+        } catch (RuntimeException exception) {
+            panel.showMessage(exception.getMessage(), true);
+        }
+    }
+
+    private void showDeletedIssuePurge(long projectId, DeletedIssuePanel panel, IssueSummary issue) {
+        try {
+            if (deletedIssuePrompt.confirmPurge(panel, issue)) {
+                startDeletedIssueTask(panel, presenter -> presenter.purgeDeletedIssue(projectId, issue.id()));
+            }
+        } catch (RuntimeException exception) {
+            panel.showMessage(exception.getMessage(), true);
+        }
+    }
+
     private void showIssueDetail(UserResult user, long projectId, long issueId) {
         SwingUtilities.invokeLater(() -> {
-            cancelDashboardWorker();
-            cancelAccountWorker();
-            cancelProjectWorker();
-            cancelProjectDetailWorker();
-            cancelProjectListWorker();
-            cancelIssueListWorker();
-            cancelIssueDetailWorker();
-            cancelStatisticsWorker();
+            cancelViewWorkers();
             titleUpdater.accept("Issue detail");
             IssueDetailPanel panel = new IssueDetailPanel(
                     user,
@@ -494,14 +483,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             return;
         }
         SwingUtilities.invokeLater(() -> {
-            cancelDashboardWorker();
-            cancelAccountWorker();
-            cancelProjectWorker();
-            cancelProjectDetailWorker();
-            cancelProjectListWorker();
-            cancelIssueListWorker();
-            cancelIssueDetailWorker();
-            cancelStatisticsWorker();
+            cancelViewWorkers();
             titleUpdater.accept("Issue action");
             showPlaceholder(
                     projectListCard,
@@ -585,6 +567,18 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         DashboardLoadWorker worker = new DashboardLoadWorker(panel);
         dashboardWorker.set(worker);
         worker.execute();
+    }
+
+    private void cancelViewWorkers() {
+        cancelDashboardWorker();
+        cancelAccountWorker();
+        cancelProjectWorker();
+        cancelProjectDetailWorker();
+        cancelProjectListWorker();
+        cancelIssueListWorker();
+        cancelIssueDetailWorker();
+        cancelStatisticsWorker();
+        cancelDeletedIssueWorker();
     }
 
     private void cancelDashboardWorker() {
@@ -726,6 +720,23 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
 
     private void cancelStatisticsWorker() {
         SwingWorker<Void, Void> worker = statisticsWorker.getAndSet(null);
+        if (worker != null && !worker.isDone()) {
+            worker.cancel(true);
+        }
+    }
+
+    private void startDeletedIssueTask(DeletedIssuePanel panel, DeletedIssueTask task) {
+        Objects.requireNonNull(panel, "panel");
+        Objects.requireNonNull(task, "task");
+        cancelDeletedIssueWorker();
+        panel.setBusy(true);
+        DeletedIssueWorker worker = new DeletedIssueWorker(panel, task);
+        deletedIssueWorker.set(worker);
+        worker.execute();
+    }
+
+    private void cancelDeletedIssueWorker() {
+        SwingWorker<Void, Void> worker = deletedIssueWorker.getAndSet(null);
         if (worker != null && !worker.isDone()) {
             worker.cancel(true);
         }
@@ -1057,6 +1068,43 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         }
     }
 
+    private final class DeletedIssueWorker extends SwingWorker<Void, Void> {
+
+        private final DeletedIssuePanel panel;
+        private final DeletedIssueTask task;
+
+        private DeletedIssueWorker(DeletedIssuePanel panel, DeletedIssueTask task) {
+            this.panel = Objects.requireNonNull(panel, "panel");
+            this.task = Objects.requireNonNull(task, "task");
+        }
+
+        @Override
+        protected Void doInBackground() {
+            DeletedIssuePresenter presenter = new DeletedIssuePresenter(
+                    requireDeletedIssueController(),
+                    new CurrentDeletedIssueView(panel, this, deletedIssueWorker::get));
+            task.run(presenter);
+            return null;
+        }
+
+        @Override
+        protected void done() {
+            finishWorker(
+                    deletedIssueWorker,
+                    this,
+                    () -> panel.setBusy(false),
+                    panel::showMessage,
+                    "Deleted issue management");
+        }
+
+        private DeletedIssueController requireDeletedIssueController() {
+            if (issueActionSupport.deletedIssueController() == null) {
+                throw new IllegalStateException("Deleted issue controller is not configured.");
+            }
+            return issueActionSupport.deletedIssueController();
+        }
+    }
+
     private static void finishWorker(
             AtomicReference<SwingWorker<Void, Void>> workerRef,
             SwingWorker<Void, Void> worker,
@@ -1120,6 +1168,12 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private interface StatisticsTask {
 
         void run(StatisticsPresenter presenter);
+    }
+
+    @FunctionalInterface
+    private interface DeletedIssueTask {
+
+        void run(DeletedIssuePresenter presenter);
     }
 
     @FunctionalInterface

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingPanelSections.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingPanelSections.java
@@ -14,6 +14,7 @@ import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -110,6 +111,38 @@ final class SwingPanelSections {
             panel.add(field, constraints);
         }
         return panel;
+    }
+
+    static JPanel dialogFormPanel(String titleText, String titleName) {
+        JPanel panel = new JPanel(new BorderLayout(SwingStyles.ROW_GAP, SwingStyles.ROW_GAP));
+        panel.setBorder(BorderFactory.createEmptyBorder(
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP,
+                SwingStyles.ROW_GAP));
+        JLabel title = new JLabel(titleText);
+        title.setName(titleName);
+        SwingStyles.applySectionTitle(title);
+        panel.add(title, BorderLayout.NORTH);
+        return panel;
+    }
+
+    static JPanel verticalFieldPanel() {
+        JPanel fields = new JPanel();
+        fields.setLayout(new BoxLayout(fields, BoxLayout.Y_AXIS));
+        fields.setAlignmentX(Component.LEFT_ALIGNMENT);
+        return fields;
+    }
+
+    static JLabel fieldLabel(String text) {
+        JLabel label = new JLabel(text);
+        label.setAlignmentX(Component.LEFT_ALIGNMENT);
+        return label;
+    }
+
+    static <T extends JComponent> T aligned(T component) {
+        component.setAlignmentX(Component.LEFT_ALIGNMENT);
+        return component;
     }
 
     static void updateMessage(

--- a/src/test/java/com/github/marcellokim/issuetracker/support/FakeDeletedIssueRepository.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/support/FakeDeletedIssueRepository.java
@@ -23,6 +23,15 @@ public final class FakeDeletedIssueRepository implements DeletedIssueRepository 
         this.issueRepository = issueRepository;
     }
 
+    public FakeDeletedIssueRepository addDeletedIssue(Issue issue) {
+        if (issue.status() != IssueStatus.DELETED) {
+            throw new IllegalArgumentException("issue must be deleted");
+        }
+        deletedIssues.put(issue.id(), issue);
+        save(issue);
+        return this;
+    }
+
     @Override
     public List<Issue> findDeletedByProject(long projectId) {
         return deletedIssues.values().stream()

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssueDialogsTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssueDialogsTest.java
@@ -1,0 +1,110 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import javax.imageio.ImageIO;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing deleted issue dialogs")
+class DeletedIssueDialogsTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("builds restore comment form")
+    void buildsRestoreCommentForm() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            JPanel form = DeletedIssueDialogs.restoreCommentForm(issueSummary());
+
+            assertEquals(
+                    "Restore ISSUE-7",
+                    SwingComponentTestSupport.find(form, "deletedIssueRestoreTitle", JLabel.class).getText());
+            assertEquals(
+                    "Restore reason",
+                    SwingComponentTestSupport.find(form, "deletedIssueRestoreCommentLabel", JLabel.class).getText());
+            assertEquals(
+                    "",
+                    SwingComponentTestSupport.find(form, "deletedIssueRestoreCommentArea", JTextArea.class)
+                            .getText());
+        });
+    }
+
+    @Test
+    @DisplayName("renders restore dialog snapshot")
+    void rendersRestoreDialogSnapshot() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            JPanel form = DeletedIssueDialogs.restoreCommentForm(issueSummary());
+            form.setSize(420, 180);
+            layoutRecursively(form);
+
+            BufferedImage image = render(form, Path.of("build/reports/ui/deleted-issue-restore-dialog.png"));
+
+            assertTrue(hasRenderedContent(image));
+        });
+    }
+
+    private static IssueSummary issueSummary() {
+        return new IssueSummary(
+                7L,
+                "ISSUE-7",
+                1L,
+                IssueStatus.DELETED,
+                Priority.CRITICAL,
+                "Removed login bug",
+                "dev1",
+                null,
+                null,
+                NOW,
+                NOW);
+    }
+
+    private static void layoutRecursively(Container container) {
+        container.doLayout();
+        for (java.awt.Component child : container.getComponents()) {
+            if (child instanceof Container nested) {
+                layoutRecursively(nested);
+            }
+        }
+    }
+
+    private static BufferedImage render(JPanel panel, Path output) throws java.io.IOException {
+        BufferedImage image = new BufferedImage(420, 180, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            panel.printAll(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        Files.createDirectories(output.getParent());
+        ImageIO.write(image, "png", output.toFile());
+        return image;
+    }
+
+    private static boolean hasRenderedContent(BufferedImage image) {
+        int white = Color.WHITE.getRGB();
+        int contentPixels = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                if (image.getRGB(x, y) != white) {
+                    contentPixels++;
+                }
+            }
+        }
+        return contentPixels > 1_000;
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssuePanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssuePanelTest.java
@@ -1,0 +1,188 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import com.github.marcellokim.issuetracker.service.UserResult;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.imageio.ImageIO;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JTable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing deleted issue panel")
+class DeletedIssuePanelTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("renders deleted issue rows and selection-sensitive actions")
+    void rendersDeletedIssueRowsAndActions() throws Exception {
+        AtomicLong restoreRef = new AtomicLong();
+        AtomicLong purgeRef = new AtomicLong();
+        AtomicInteger backClicks = new AtomicInteger();
+        AtomicInteger logoutClicks = new AtomicInteger();
+
+        SwingComponentTestSupport.onEdt(() -> {
+            DeletedIssuePanel panel = panel(restoreRef, purgeRef, backClicks, logoutClicks);
+            panel.showDeletedIssues(30, List.of(
+                    issueSummary(7L, "ISSUE-7", "Removed login bug"),
+                    issueSummary(8L, "ISSUE-8", "Removed profile typo")));
+
+            JTable table = SwingComponentTestSupport.find(panel, "deletedIssueTable", JTable.class);
+            JButton restore = SwingComponentTestSupport.find(panel, "restoreDeletedIssueButton", JButton.class);
+            JButton purge = SwingComponentTestSupport.find(panel, "purgeDeletedIssueButton", JButton.class);
+
+            assertEquals("Deleted issue management", SwingComponentTestSupport.find(panel, "deletedIssueTitle",
+                    JLabel.class).getText());
+            assertEquals("Deleted issues 2/30", SwingComponentTestSupport.find(panel, "deletedIssueCount",
+                    JLabel.class).getText());
+            assertEquals(2, table.getRowCount());
+            assertEquals("ISSUE-7", table.getValueAt(0, 1));
+            assertEquals("Removed login bug", table.getValueAt(0, 4));
+            assertEquals(false, restore.isEnabled());
+            assertEquals(false, purge.isEnabled());
+
+            table.setRowSelectionInterval(1, 1);
+
+            assertEquals(true, restore.isEnabled());
+            assertEquals(true, purge.isEnabled());
+
+            restore.doClick();
+            purge.doClick();
+            SwingComponentTestSupport.find(panel, "deletedIssueBackButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "deletedIssueLogoutButton", JButton.class).doClick();
+        });
+
+        assertEquals(8L, restoreRef.get());
+        assertEquals(8L, purgeRef.get());
+        assertEquals(1, backClicks.get());
+        assertEquals(1, logoutClicks.get());
+    }
+
+    @Test
+    @DisplayName("shows fallback text for blank error messages")
+    void showsFallbackTextForBlankErrors() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            DeletedIssuePanel panel = panel(new AtomicLong(), new AtomicLong(), new AtomicInteger(), new AtomicInteger());
+
+            panel.showMessage(" ", true);
+
+            assertEquals(
+                    "Deleted issue management failed. Please try again.",
+                    SwingComponentTestSupport.find(panel, "deletedIssueMessage", JLabel.class).getText());
+        });
+    }
+
+    @Test
+    @DisplayName("renders deleted issue screen snapshot")
+    void rendersDeletedIssueSnapshot() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            DeletedIssuePanel panel = panel(new AtomicLong(), new AtomicLong(), new AtomicInteger(), new AtomicInteger());
+            panel.showDeletedIssues(30, List.of(
+                    issueSummary(7L, "ISSUE-7", "Removed login bug"),
+                    issueSummary(8L, "ISSUE-8", "Removed profile typo")));
+            panel.setSize(SwingStyles.WINDOW_SIZE);
+            layoutRecursively(panel);
+
+            BufferedImage image = render(panel, Path.of("build/reports/ui/deleted-issue-panel.png"));
+
+            assertTrue(hasRenderedContent(image));
+
+            JTable table = SwingComponentTestSupport.find(panel, "deletedIssueTable", JTable.class);
+            table.setRowSelectionInterval(0, 0);
+            BufferedImage selected = render(panel, Path.of("build/reports/ui/deleted-issue-panel-selected.png"));
+
+            assertTrue(hasRenderedContent(selected));
+        });
+    }
+
+    private static DeletedIssuePanel panel(
+            AtomicLong restoreRef,
+            AtomicLong purgeRef,
+            AtomicInteger backClicks,
+            AtomicInteger logoutClicks) {
+        return new DeletedIssuePanel(
+                userResult("pl1", Role.PL),
+                new DeletedIssuePanel.DeletedIssueActions(
+                        (source, issue) -> restoreRef.set(issue.id()),
+                        (source, issue) -> purgeRef.set(issue.id()),
+                        backClicks::incrementAndGet,
+                        logoutClicks::incrementAndGet));
+    }
+
+    private static IssueSummary issueSummary(long id, String issueId, String title) {
+        return new IssueSummary(
+                id,
+                issueId,
+                1L,
+                IssueStatus.DELETED,
+                Priority.CRITICAL,
+                title,
+                "dev1",
+                null,
+                null,
+                NOW,
+                NOW);
+    }
+
+    private static UserResult userResult(String loginId, Role role) {
+        return UserResult.from(User.fromPersistence(loginId, loginId, "stored-password", role, true, NOW, NOW));
+    }
+
+    private static void layoutRecursively(Container container) {
+        container.doLayout();
+        for (java.awt.Component child : container.getComponents()) {
+            if (child instanceof Container nested) {
+                layoutRecursively(nested);
+            }
+        }
+    }
+
+    private static BufferedImage render(DeletedIssuePanel panel, Path output) throws java.io.IOException {
+        BufferedImage image = new BufferedImage(
+                SwingStyles.WINDOW_SIZE.width,
+                SwingStyles.WINDOW_SIZE.height,
+                BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            panel.printAll(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        Files.createDirectories(output.getParent());
+        ImageIO.write(image, "png", output.toFile());
+        return image;
+    }
+
+    private static boolean hasRenderedContent(BufferedImage image) {
+        int background = SwingStyles.BACKGROUND.getRGB();
+        int white = Color.WHITE.getRGB();
+        int contentPixels = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                int pixel = image.getRGB(x, y);
+                if (pixel != background && pixel != white) {
+                    contentPixels++;
+                }
+            }
+        }
+        return contentPixels > 10_000;
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssuePresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssuePresenterTest.java
@@ -1,0 +1,179 @@
+package com.github.marcellokim.issuetracker.ui.swing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.marcellokim.issuetracker.controller.AuthenticationController;
+import com.github.marcellokim.issuetracker.controller.DeletedIssueController;
+import com.github.marcellokim.issuetracker.domain.Issue;
+import com.github.marcellokim.issuetracker.domain.IssueStatus;
+import com.github.marcellokim.issuetracker.domain.Priority;
+import com.github.marcellokim.issuetracker.domain.Role;
+import com.github.marcellokim.issuetracker.domain.User;
+import com.github.marcellokim.issuetracker.service.AuthenticationService;
+import com.github.marcellokim.issuetracker.service.DeletedIssueService;
+import com.github.marcellokim.issuetracker.service.IssueSummary;
+import com.github.marcellokim.issuetracker.service.PasswordHashing;
+import com.github.marcellokim.issuetracker.service.PermissionPolicy;
+import com.github.marcellokim.issuetracker.support.FakeDeletedIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
+import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.technical.SessionStore;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Swing deleted issue presenter")
+class DeletedIssuePresenterTest {
+
+    private static final long PROJECT_ID = 1L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
+
+    @Test
+    @DisplayName("loads deleted issues after controller permission succeeds")
+    void loadsDeletedIssuesAfterPermissionSucceeds() {
+        User pl = user("pl1", Role.PL);
+        Issue deletedIssue = issue(7L, "Removed login bug", pl, IssueStatus.DELETED);
+        Fixture fixture = fixture(pl, deletedIssue);
+        RecordingDeletedIssueView view = new RecordingDeletedIssueView();
+        DeletedIssuePresenter presenter = new DeletedIssuePresenter(fixture.controller(), view);
+
+        presenter.loadDeletedIssues(PROJECT_ID);
+
+        assertEquals(30, view.maxRetentionLimit);
+        assertEquals(List.of(7L), view.issues.stream().map(IssueSummary::id).toList());
+        assertEquals("Deleted issues 1/30", view.message);
+        assertEquals(false, view.error);
+    }
+
+    @Test
+    @DisplayName("does not replace rows when permission fails")
+    void doesNotReplaceRowsWhenPermissionFails() {
+        User dev = user("dev1", Role.DEV);
+        Issue deletedIssue = issue(7L, "Removed login bug", dev, IssueStatus.DELETED);
+        Fixture fixture = fixture(dev, deletedIssue);
+        RecordingDeletedIssueView view = new RecordingDeletedIssueView();
+        DeletedIssuePresenter presenter = new DeletedIssuePresenter(fixture.controller(), view);
+
+        presenter.loadDeletedIssues(PROJECT_ID);
+
+        assertEquals(0, view.maxRetentionLimit);
+        assertEquals(List.of(), view.issues);
+        assertEquals("Only PL can manage deleted issues.", view.message);
+        assertEquals(true, view.error);
+    }
+
+    @Test
+    @DisplayName("restores and purges selected issue then refreshes list")
+    void restoresAndPurgesSelectedIssueThenRefreshesList() {
+        User pl = user("pl1", Role.PL);
+        Issue restoreTarget = issue(7L, "Removed login bug", pl, IssueStatus.DELETED);
+        Issue purgeTarget = issue(8L, "Removed profile typo", pl, IssueStatus.DELETED);
+        Fixture fixture = fixture(pl, restoreTarget, purgeTarget);
+        RecordingDeletedIssueView view = new RecordingDeletedIssueView();
+        DeletedIssuePresenter presenter = new DeletedIssuePresenter(fixture.controller(), view);
+
+        presenter.restoreIssue(PROJECT_ID, restoreTarget.id(), "Restore from Swing demo");
+
+        assertEquals(List.of(8L), view.issues.stream().map(IssueSummary::id).toList());
+        assertEquals("Issue restored.", view.message);
+        assertEquals(false, view.error);
+
+        presenter.purgeDeletedIssue(PROJECT_ID, purgeTarget.id());
+
+        assertEquals(List.of(), view.issues.stream().map(IssueSummary::id).toList());
+        assertEquals("Deleted issue purged.", view.message);
+        assertEquals(false, view.error);
+    }
+
+    private static Fixture fixture(User actor, Issue... issues) {
+        InMemoryIssueRepository issueRepository = new InMemoryIssueRepository(issues);
+        FakeDeletedIssueRepository deletedIssueRepository = new FakeDeletedIssueRepository(issueRepository);
+        for (Issue issue : issues) {
+            if (issue.status() == IssueStatus.DELETED) {
+                deletedIssueRepository.addDeletedIssue(issue);
+            }
+        }
+        InMemoryUserRepository users = new InMemoryUserRepository(actor)
+                .withProjectMembers(PROJECT_ID, actor.getLoginId());
+        AuthenticationService authentication = new AuthenticationService(
+                users,
+                new PlainPasswordHashing(),
+                new SessionStore());
+        new AuthenticationController(authentication).login(actor.getLoginId(), "password");
+        DeletedIssueController controller = new DeletedIssueController(
+                authentication,
+                new DeletedIssueService(
+                        issueRepository,
+                        deletedIssueRepository,
+                        users,
+                        new PermissionPolicy(),
+                        () -> NOW));
+        return new Fixture(controller);
+    }
+
+    private static Issue issue(long id, String title, User reporter, IssueStatus status) {
+        return Issue.fromPersistence(Issue.persistedState(PROJECT_ID, title, "Issue description", reporter)
+                .id(id)
+                .issueId("ISSUE-" + id)
+                .status(status)
+                .priority(Priority.CRITICAL)
+                .reportedDate(NOW)
+                .updatedAt(NOW));
+    }
+
+    private static User user(String loginId, Role role) {
+        return User.fromPersistence(loginId, loginId, "password", role, true, NOW, NOW);
+    }
+
+    private record Fixture(DeletedIssueController controller) {
+    }
+
+    private static final class RecordingDeletedIssueView implements DeletedIssueView {
+
+        private int maxRetentionLimit;
+        private List<IssueSummary> issues = List.of();
+        private String message;
+        private boolean error;
+
+        @Override
+        public void showDeletedIssues(int maxRetentionLimit, List<IssueSummary> issues) {
+            this.maxRetentionLimit = maxRetentionLimit;
+            this.issues = issues;
+        }
+
+        @Override
+        public void showMessage(String message, boolean error) {
+            this.message = message;
+            this.error = error;
+        }
+    }
+
+    private static final class PlainPasswordHashing implements PasswordHashing {
+
+        @Override
+        public String hash(String password) {
+            return password;
+        }
+
+        @Override
+        public boolean matches(String password, String storedCredential) {
+            return storedCredential.equals(password);
+        }
+
+        @Override
+        public boolean isHashed(String storedCredential) {
+            return true;
+        }
+
+        @Override
+        public String saltOf(String storedCredential) {
+            return "salt";
+        }
+
+        @Override
+        public String hashOf(String storedCredential) {
+            return storedCredential;
+        }
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanelTest.java
@@ -66,11 +66,12 @@ class IssueListPanelTest {
     }
 
     @Test
-    @DisplayName("publishes search, register, open, statistics, back, and logout actions")
+    @DisplayName("publishes search, register, open, deleted issue, statistics, back, and logout actions")
     void publishesActions() throws Exception {
         var searchRef = new AtomicReference<IssueSearchRequest>();
         var registerRef = new AtomicReference<IssueRegisterRequest>();
         var openRef = new AtomicLong();
+        var deletedIssueClicks = new AtomicInteger();
         var statisticsClicks = new AtomicInteger();
         var backClicks = new AtomicInteger();
         var logoutClicks = new AtomicInteger();
@@ -78,12 +79,13 @@ class IssueListPanelTest {
 
         SwingComponentTestSupport.onEdt(() -> {
             IssueListPanel panel = new IssueListPanel(
-                    userResult("dev1", Role.DEV),
+                    userResult("pl1", Role.PL),
                     dialogs,
                     new IssueListPanel.IssueListActions(
                             (source, request) -> searchRef.set(request),
                             (source, request) -> registerRef.set(request),
                             openRef::set,
+                            deletedIssueClicks::incrementAndGet,
                             statisticsClicks::incrementAndGet,
                             backClicks::incrementAndGet,
                             logoutClicks::incrementAndGet));
@@ -101,6 +103,7 @@ class IssueListPanelTest {
             JTable table = SwingComponentTestSupport.find(panel, "issueListTable", JTable.class);
             table.setRowSelectionInterval(0, 0);
             SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick();
+            SwingComponentTestSupport.find(panel, "deletedIssuesButton", JButton.class).doClick();
             SwingComponentTestSupport.find(panel, "statisticsButton", JButton.class).doClick();
             SwingComponentTestSupport.find(panel, "issueListBackButton", JButton.class).doClick();
             SwingComponentTestSupport.find(panel, "issueListLogoutButton", JButton.class).doClick();
@@ -109,6 +112,7 @@ class IssueListPanelTest {
         assertEquals(new IssueSearchRequest("login", IssueStatus.NEW, Priority.CRITICAL), searchRef.get());
         assertEquals(new IssueRegisterRequest("New issue", "New issue description", Priority.MINOR), registerRef.get());
         assertEquals(7L, openRef.get());
+        assertEquals(1, deletedIssueClicks.get());
         assertEquals(1, statisticsClicks.get());
         assertEquals(1, backClicks.get());
         assertEquals(1, logoutClicks.get());
@@ -129,6 +133,8 @@ class IssueListPanelTest {
                             (source, request) -> {
                             },
                             openRef::set,
+                            () -> {
+                            },
                             () -> {
                             },
                             () -> {
@@ -188,12 +194,31 @@ class IssueListPanelTest {
             table.setRowSelectionInterval(0, 0);
             BufferedImage selected = render(panel, Path.of("build/reports/ui/issue-list-panel-selected.png"));
             assertTrue(hasRenderedContent(selected));
+
+            IssueListPanel plPanel = panel(Role.PL, new FixedIssueDialogs());
+            plPanel.showProject(project());
+            plPanel.showIssues(List.of(
+                    issueSummary(1L, "ISSUE-1", "Login bug", IssueStatus.NEW, Priority.CRITICAL),
+                    issueSummary(2L, "ISSUE-2", "Profile typo", IssueStatus.ASSIGNED, Priority.MINOR)));
+            plPanel.setRegisterEnabled(true);
+            plPanel.setSize(SwingStyles.WINDOW_SIZE);
+            layoutRecursively(plPanel);
+
+            assertEquals(
+                    true,
+                    SwingComponentTestSupport.find(plPanel, "deletedIssuesButton", JButton.class).isVisible());
+            BufferedImage pl = render(plPanel, Path.of("build/reports/ui/issue-list-panel-pl.png"));
+            assertTrue(hasRenderedContent(pl));
         });
     }
 
     private static IssueListPanel panel(FixedIssueDialogs dialogs) {
+        return panel(Role.DEV, dialogs);
+    }
+
+    private static IssueListPanel panel(Role role, FixedIssueDialogs dialogs) {
         return new IssueListPanel(
-                userResult("dev1", Role.DEV),
+                userResult(role == Role.PL ? "pl1" : "dev1", role),
                 dialogs,
                 new IssueListPanel.IssueListActions(
                         (source, request) -> {
@@ -201,6 +226,8 @@ class IssueListPanelTest {
                         (source, request) -> {
                         },
                         issueId -> {
+                        },
+                        () -> {
                         },
                         () -> {
                         },

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -38,6 +38,7 @@ import com.github.marcellokim.issuetracker.service.AuthenticationService;
 import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
 import com.github.marcellokim.issuetracker.service.DeletedIssueService;
 import com.github.marcellokim.issuetracker.service.IssueService;
+import com.github.marcellokim.issuetracker.service.IssueSummary;
 import com.github.marcellokim.issuetracker.service.IssueStateService;
 import com.github.marcellokim.issuetracker.service.IssueWorkflowService;
 import com.github.marcellokim.issuetracker.service.KNNAssignmentRecommendation;
@@ -64,6 +65,7 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -486,6 +488,89 @@ class SwingAppPanelTest {
             SwingComponentTestSupport.find(panel, "statisticsBackButton", JButton.class).doClick();
         });
 
+        awaitIssueRows(panel, 1);
+    }
+
+    @Test
+    @DisplayName("issue list opens deleted issue management and refreshes restore and purge actions")
+    void issueListOpensDeletedIssueManagementAndRefreshesActions() throws Exception {
+        var passwordHashing = new RecordingPasswordHashing();
+        var titles = new RecordingTitleUpdater();
+        User pl = user("pl1", Role.PL);
+        Issue restoreTarget = deletedIssue(7L, 7L, "Removed login bug", Priority.CRITICAL, pl);
+        Issue purgeTarget = deletedIssue(8L, 7L, "Removed profile typo", Priority.MINOR, pl);
+        AtomicLong restorePromptIssueId = new AtomicLong();
+        AtomicLong purgePromptIssueId = new AtomicLong();
+        DeletedIssuePrompt deletedIssuePrompt = new DeletedIssuePrompt() {
+            @Override
+            public Optional<String> requestRestoreComment(java.awt.Component parent, IssueSummary issue) {
+                restorePromptIssueId.set(issue.id());
+                return Optional.of("restore from Swing");
+            }
+
+            @Override
+            public boolean confirmPurge(java.awt.Component parent, IssueSummary issue) {
+                purgePromptIssueId.set(issue.id());
+                return true;
+            }
+        };
+        SwingAppPanel panel = loginProjectUser(
+                passwordHashing,
+                titles,
+                List.of(projectSnapshot(7L, "Alpha", 3, 0)),
+                List.of(restoreTarget, purgeTarget),
+                List.of(),
+                IssueStatusChangeDialogs::prompt,
+                IssueAssignmentDialogs::prompt,
+                IssueCommentDialogs::prompt,
+                IssueDependencyDialogs::prompt,
+                deletedIssuePrompt,
+                IssueEditDialogs::prompt,
+                pl);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable projects = SwingComponentTestSupport.find(panel, "projectListTable", JTable.class);
+            projects.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "openProjectIssuesButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "openProjectIssuesButton", JButton.class).doClick());
+        awaitIssueRows(panel, 0);
+        awaitButtonEnabled(panel, "deletedIssuesButton");
+
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "deletedIssuesButton", JButton.class).doClick());
+        awaitRows(panel, "deletedIssueTable", 2);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            assertEquals(
+                    "Deleted issue management",
+                    SwingComponentTestSupport.find(panel, "deletedIssueTitle", JLabel.class).getText());
+            assertEquals(
+                    "Deleted issues 2/30",
+                    SwingComponentTestSupport.find(panel, "deletedIssueCount", JLabel.class).getText());
+            JTable deletedIssues = SwingComponentTestSupport.find(panel, "deletedIssueTable", JTable.class);
+            deletedIssues.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "restoreDeletedIssueButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "restoreDeletedIssueButton", JButton.class).doClick());
+        awaitRows(panel, "deletedIssueTable", 1);
+
+        SwingComponentTestSupport.onEdt(() -> {
+            JTable deletedIssues = SwingComponentTestSupport.find(panel, "deletedIssueTable", JTable.class);
+            deletedIssues.setRowSelectionInterval(0, 0);
+        });
+        awaitButtonEnabled(panel, "purgeDeletedIssueButton");
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "purgeDeletedIssueButton", JButton.class).doClick());
+        awaitRows(panel, "deletedIssueTable", 0);
+
+        assertEquals(restoreTarget.id(), restorePromptIssueId.get());
+        assertEquals(purgeTarget.id(), purgePromptIssueId.get());
+
+        SwingComponentTestSupport.onEdt(() ->
+                SwingComponentTestSupport.find(panel, "deletedIssueBackButton", JButton.class).doClick());
         awaitIssueRows(panel, 1);
     }
 
@@ -1094,6 +1179,32 @@ class SwingAppPanelTest {
             List<DashboardProjectSnapshot> projects,
             List<Issue> issues,
             List<Comment> comments,
+            IssueStatusChangePrompt statusChangePrompt,
+            IssueAssignmentPrompt assignmentPrompt,
+            IssueCommentPrompt commentPrompt,
+            IssueDependencyPrompt dependencyPrompt,
+            DeletedIssuePrompt deletedIssuePrompt,
+            IssueEditPrompt editPrompt,
+            User... users) throws Exception {
+        return loginProjectUser(
+                passwordHashing,
+                titles,
+                projects,
+                issues,
+                comments,
+                new SwingPromptSupport(statusChangePrompt, assignmentPrompt, commentPrompt, dependencyPrompt),
+                new InMemoryAssignmentRecommendationRepository(users),
+                deletedIssuePrompt,
+                editPrompt,
+                users);
+    }
+
+    private static SwingAppPanel loginProjectUser(
+            RecordingPasswordHashing passwordHashing,
+            RecordingTitleUpdater titles,
+            List<DashboardProjectSnapshot> projects,
+            List<Issue> issues,
+            List<Comment> comments,
             SwingPromptSupport prompts,
             AssignmentRecommendationRepository recommendationRepository,
             User... users) throws Exception {
@@ -1119,6 +1230,30 @@ class SwingAppPanelTest {
             AssignmentRecommendationRepository recommendationRepository,
             IssueEditPrompt editPrompt,
             User... users) throws Exception {
+        return loginProjectUser(
+                passwordHashing,
+                titles,
+                projects,
+                issues,
+                comments,
+                prompts,
+                recommendationRepository,
+                new DeletedIssueDialogs.JOptionPaneDeletedIssuePrompt(),
+                editPrompt,
+                users);
+    }
+
+    private static SwingAppPanel loginProjectUser(
+            RecordingPasswordHashing passwordHashing,
+            RecordingTitleUpdater titles,
+            List<DashboardProjectSnapshot> projects,
+            List<Issue> issues,
+            List<Comment> comments,
+            SwingPromptSupport prompts,
+            AssignmentRecommendationRepository recommendationRepository,
+            DeletedIssuePrompt deletedIssuePrompt,
+            IssueEditPrompt editPrompt,
+            User... users) throws Exception {
         var panelRef = new AtomicReference<SwingAppPanel>();
         var workerDone = new CountDownLatch(1);
         SwingControllerFixture controllers = controllers(
@@ -1142,6 +1277,7 @@ class SwingAppPanelTest {
                             prompts.dependencyPrompt(),
                             controllers.deletedIssueController(),
                             editPrompt),
+                    deletedIssuePrompt,
                     titles::update);
             panelRef.set(panel);
             User user = users[0];
@@ -1459,6 +1595,11 @@ class SwingAppPanelTest {
         });
         var issueRepository = new InMemoryIssueRepository(issues.toArray(Issue[]::new));
         var deletedIssueRepository = new FakeDeletedIssueRepository(issueRepository);
+        for (Issue issue : issues) {
+            if (issue.status() == IssueStatus.DELETED) {
+                deletedIssueRepository.addDeletedIssue(issue);
+            }
+        }
         var dependencyRepository = new FakeIssueDependencyRepository();
         var commentRepository = new FakeCommentRepository(comments);
         var historyRepository = new FakeIssueHistoryRepository();
@@ -1568,6 +1709,16 @@ class SwingAppPanelTest {
                 .id(id)
                 .issueId("ISSUE-" + id)
                 .priority(priority)
+                .reportedDate(NOW)
+                .updatedAt(NOW));
+    }
+
+    private static Issue deletedIssue(long id, long projectId, String title, Priority priority, User reporter) {
+        return Issue.fromPersistence(Issue.persistedState(projectId, title, "Issue description", reporter)
+                .id(id)
+                .issueId("ISSUE-" + id)
+                .priority(priority)
+                .status(IssueStatus.DELETED)
                 .reportedDate(NOW)
                 .updatedAt(NOW));
     }


### PR DESCRIPTION
## 요약
Closes #215

Swing 전체 UI에 PL 전용 삭제 이슈 관리 화면을 추가합니다. 최신 `origin/dev` 기준으로 앞선 Swing 이슈 수정/삭제 진입점과 충돌 없이 동작하도록 정리했습니다.

## 변경 분류
- `type:feat`
- `type:test`
- `area:ui`

## purpose
Swing 이슈 목록에서 PL이 삭제 이슈 관리 화면으로 진입하고, 기존 `DeletedIssueController` 계약으로 삭제 이슈 조회, restore, purge를 실행할 수 있게 합니다.

## non-goals
- Swing에서 active PL 권한, 보관 한도, FIFO purge 정책을 직접 계산하지 않음
- `purgeOverflow` 버튼이나 별도 repository 호출을 추가하지 않음
- JavaFX 화면 구조는 변경하지 않음

## diff map
- 핵심 변경: `DeletedIssuePanel`, `DeletedIssuePresenter`, `DeletedIssueDialogs`, `DeletedIssuePrompt`, `DeletedIssueView`
- 연결 변경: `IssueListPanel`의 PL용 삭제 이슈 진입 버튼, `SwingAppPanel` worker/navigation 연결
- 보조 변경: stale worker update 방지를 위한 `CurrentDeletedIssueView`
- 테스트 변경: panel/dialog/presenter snapshot 및 app flow 테스트 추가

## verification evidence
- `git diff --check origin/dev...HEAD`
- `git diff --check`
- `./gradlew test --tests '*IssueListPanelTest' --tests '*DeletedIssue*Test' --tests '*SwingAppPanelTest' --console=plain`
- `./gradlew check --console=plain`
- Swing screenshot 확인: `build/reports/ui/issue-list-panel-pl.png`, `build/reports/ui/deleted-issue-panel.png`, `build/reports/ui/deleted-issue-panel-selected.png`, `build/reports/ui/deleted-issue-restore-dialog.png`

## reviewer focus areas
- `viewDeletedIssues(projectId)`, `restoreIssue(issueId, comment)`, `purgeDeletedIssue(issueId)` 호출 경계가 UC9 정책과 맞는지
- non-PL 실패가 Swing 권한 재구현이 아니라 controller 실패 메시지로 처리되는지
- `SwingAppPanel` worker/cancel 흐름이 기존 issue list/detail/statistics 화면과 충돌하지 않는지
- PL issue list 조작부가 표준 창 크기에서 잘림 없이 표시되는지

## risk / rollback
- 위험은 Swing issue list 진입점과 deleted issue 화면 worker/navigation에 한정됩니다.
- 문제가 생기면 이 PR만 되돌리면 backend 정책과 앞선 Swing 화면에는 영향이 남지 않습니다.