### PR TITLE
refactor: Dependency DTO 양방향 분리

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueDependencyRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/JdbcIssueDependencyRepository.java
@@ -20,6 +20,8 @@ public final class JdbcIssueDependencyRepository implements IssueDependencyRepos
     private static final String FIND_BY_DEPENDENCY_ID_SQL = BASE_SELECT + " where dependency_id = ?";
     private static final String FIND_DEPENDENCIES_BLOCKING_ISSUE_SQL = BASE_SELECT
             + " where blocked_issue_id = ? order by id";
+    private static final String FIND_DEPENDENCIES_BLOCKED_BY_ISSUE_SQL = BASE_SELECT
+            + " where blocking_issue_id = ? order by id";
 
     private final DatabaseConnectionProvider connectionProvider;
     private final JdbcIssueWriteSupport writes = new JdbcIssueWriteSupport();
@@ -52,6 +54,17 @@ public final class JdbcIssueDependencyRepository implements IssueDependencyRepos
             return executeDependencyList(statement);
         } catch (SQLException exception) {
             throw new RepositoryException("Failed to list dependencies by blocked issue.", exception);
+        }
+    }
+
+    @Override
+    public List<IssueDependency> findDependenciesBlockedByIssue(long blockingIssueId) {
+        try (Connection connection = connectionProvider.getConnection();
+                PreparedStatement statement = connection.prepareStatement(FIND_DEPENDENCIES_BLOCKED_BY_ISSUE_SQL)) {
+            statement.setLong(1, blockingIssueId);
+            return executeDependencyList(statement);
+        } catch (SQLException exception) {
+            throw new RepositoryException("Failed to list dependencies by blocking issue.", exception);
         }
     }
 

--- a/src/main/java/com/github/marcellokim/issuetracker/repository/IssueDependencyRepository.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/repository/IssueDependencyRepository.java
@@ -10,6 +10,8 @@ public interface IssueDependencyRepository {
 
     List<IssueDependency> findDependenciesBlockingIssue(long blockedIssueId);
 
+    List<IssueDependency> findDependenciesBlockedByIssue(long blockingIssueId);
+
     List<IssueDependency> findByProjectId(long projectId);
 
     boolean existsByPair(long blockingIssueId, long blockedIssueId);

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueDetailResult.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueDetailResult.java
@@ -22,13 +22,15 @@ public record IssueDetailResult(
         LocalDateTime updatedAt,
         List<CommentResult> comments,
         List<HistoryResult> histories,
-        List<DependencyResult> dependencies,
+        List<DependencyResult> blockedByDependencies,
+        List<DependencyResult> blockingDependencies,
         List<String> availableActions) {
 
     public IssueDetailResult {
         comments = List.copyOf(comments);
         histories = List.copyOf(histories);
-        dependencies = List.copyOf(dependencies);
+        blockedByDependencies = List.copyOf(blockedByDependencies);
+        blockingDependencies = List.copyOf(blockingDependencies);
         availableActions = List.copyOf(availableActions);
     }
 
@@ -50,7 +52,8 @@ public record IssueDetailResult(
                 updatedAt,
                 comments,
                 histories,
-                dependencies,
+                blockedByDependencies,
+                blockingDependencies,
                 nextAvailableActions);
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
@@ -114,16 +114,20 @@ public final class IssueService {
         List<HistoryResult> histories = issueHistoryRepository.findByIssueId(issue.id()).stream()
                 .map(IssueService::toHistoryResult)
                 .toList();
-        List<IssueDependency> deps = dependencyRepository.findDependenciesBlockingIssue(issue.id());
-        List<Long> blockingIds = deps.stream()
-                .map(IssueDependency::blockingIssueId)
-                .toList();
-        Map<Long, Issue> blockingIssues = issueRepository.findAllById(blockingIds).stream()
+        List<IssueDependency> blockedByDeps = dependencyRepository.findDependenciesBlockingIssue(issue.id());
+        List<IssueDependency> blockingDeps = dependencyRepository.findDependenciesBlockedByIssue(issue.id());
+        Set<Long> relatedIssueIds = new HashSet<>();
+        blockedByDeps.forEach(dep -> relatedIssueIds.add(dep.blockingIssueId()));
+        blockingDeps.forEach(dep -> relatedIssueIds.add(dep.blockedIssueId()));
+        Map<Long, Issue> relatedIssues = issueRepository.findAllById(List.copyOf(relatedIssueIds)).stream()
                 .collect(Collectors.toMap(Issue::id, Function.identity()));
-        List<DependencyResult> dependencies = deps.stream()
-                .map(dep -> toDependencyResult(dep, blockingIssues.get(dep.blockingIssueId()), issue))
+        List<DependencyResult> blockedByResults = blockedByDeps.stream()
+                .map(dep -> toDependencyResult(dep, relatedIssues.get(dep.blockingIssueId()), issue))
                 .toList();
-        return toIssueDetailResult(issue, comments, histories, dependencies);
+        List<DependencyResult> blockingResults = blockingDeps.stream()
+                .map(dep -> toDependencyResult(dep, issue, relatedIssues.get(dep.blockedIssueId())))
+                .toList();
+        return toIssueDetailResult(issue, comments, histories, blockedByResults, blockingResults);
     }
 
     public List<IssueSummary> searchIssues(
@@ -289,7 +293,6 @@ public final class IssueService {
         Issue blockedIssue = findIssue(requiredBlockedIssueId);
         requireNotDeleted(blockingIssue);
         requireNotDeleted(blockedIssue);
-        requireDependencyAddStatus(blockedIssue);
         requireSameProjectDependency(blockingIssue, blockedIssue);
         User actor = findUser(requiredLoginId);
         permissionPolicy.assertCanManageDependency(actor, blockedIssue);
@@ -492,12 +495,6 @@ public final class IssueService {
         }
     }
 
-    private static void requireDependencyAddStatus(Issue blockedIssue) {
-        if (blockedIssue.status() == IssueStatus.RESOLVED || blockedIssue.status() == IssueStatus.CLOSED) {
-            throw new IllegalStateException("Resolved or closed issues cannot be blocked by a new dependency.");
-        }
-    }
-
     private void validateDependency(long blockingIssueId, long blockedIssueId) {
         if (blockingIssueId == blockedIssueId) {
             throw new IllegalArgumentException("Issue cannot depend on itself");
@@ -597,7 +594,8 @@ public final class IssueService {
             Issue issue,
             List<CommentResult> comments,
             List<HistoryResult> histories,
-            List<DependencyResult> dependencies) {
+            List<DependencyResult> blockedByDependencies,
+            List<DependencyResult> blockingDependencies) {
         return new IssueDetailResult(
                 issue.id(),
                 issue.projectId(),
@@ -615,7 +613,8 @@ public final class IssueService {
                 issue.updatedAt(),
                 comments,
                 histories,
-                dependencies,
+                blockedByDependencies,
+                blockingDependencies,
                 List.of());
     }
 

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueDetailScreen.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueDetailScreen.java
@@ -111,23 +111,37 @@ final class IssueDetailScreen extends VBox {
             commentList.setCellFactory(list -> new CommentCell(editableComments, deletableComments));
             commentList.setPrefHeight(200);
 
-            Label dependencyTitle = new Label("Dependencies (" + detail.dependencies().size() + ")");
-            dependencyTitle.setStyle("-fx-font-size: 14px; -fx-font-weight: bold;");
-            ListView<String> depListView = new ListView<>();
-            for (DependencyResult dep : detail.dependencies()){
-                depListView.getItems().add(String.format("%s blocks %s", dep.blockingIssueKey(), dep.blockedIssueKey()));
+            Label blockedByTitle = new Label("Blocked by (" + detail.blockedByDependencies().size() + ")");
+            blockedByTitle.setStyle("-fx-font-size: 14px; -fx-font-weight: bold;");
+            ListView<String> blockedByListView = new ListView<>();
+            for (DependencyResult dep : detail.blockedByDependencies()){
+                blockedByListView.getItems().add(String.format("%s blocks %s", dep.blockingIssueKey(), dep.blockedIssueKey()));
             }
-            depListView.setPrefHeight(Math.min(100, detail.dependencies().size() * 26 + 4));
+            blockedByListView.setPrefHeight(Math.min(80, detail.blockedByDependencies().size() * 26 + 4));
+
+            Label blockingTitle = new Label("Blocking (" + detail.blockingDependencies().size() + ")");
+            blockingTitle.setStyle("-fx-font-size: 14px; -fx-font-weight: bold;");
+            ListView<String> blockingListView = new ListView<>();
+            for (DependencyResult dep : detail.blockingDependencies()){
+                blockingListView.getItems().add(String.format("%s blocks %s", dep.blockingIssueKey(), dep.blockedIssueKey()));
+            }
+            blockingListView.setPrefHeight(Math.min(80, detail.blockingDependencies().size() * 26 + 4));
 
             Label historyTitle = new Label("History (" + detail.histories().size() + " entries)");
             historyTitle.setStyle("-fx-font-size: 12px; -fx-text-fill: #888;");
 
-            getChildren().addAll(titleLabel, statusLabel, new Separator(),
+            VBox content = new VBox(8, titleLabel, statusLabel, new Separator(),
                     descriptionLabel, new Separator(),
                     peopleBox, new Separator(),
                     new Label("Available Actions:"), actionButtons, new Separator(),
                     commentsTitle, commentList,
-                    dependencyTitle, depListView, historyTitle, messageLabel);
+                    blockedByTitle, blockedByListView,
+                    blockingTitle, blockingListView,
+                    historyTitle, messageLabel);
+            javafx.scene.control.ScrollPane scrollPane = new javafx.scene.control.ScrollPane(content);
+            scrollPane.setFitToWidth(true);
+            VBox.setVgrow(scrollPane, javafx.scene.layout.Priority.ALWAYS);
+            getChildren().add(scrollPane);
         } catch (Exception exception){
             ScreenComponents.showError(messageLabel, exception);
             getChildren().add(messageLabel);
@@ -261,18 +275,23 @@ final class IssueDetailScreen extends VBox {
             ScreenComponents.showError(messageLabel, exception);
             return;
         }
-        List<IssueSummary> candidates = projectIssues.stream()
+        Set<Long> existingBlockedByIds = currentDetail.blockedByDependencies().stream()
+                .map(DependencyResult::blockingIssueId).collect(java.util.stream.Collectors.toSet());
+        Set<Long> existingBlockingIds = currentDetail.blockingDependencies().stream()
+                .map(DependencyResult::blockedIssueId).collect(java.util.stream.Collectors.toSet());
+        List<IssueSummary> allCandidates = projectIssues.stream()
                 .filter(i -> i.id() != issueId)
                 .toList();
-        if (candidates.isEmpty()){
+        if (allCandidates.isEmpty()){
             ScreenComponents.showInfo(messageLabel, "No other issues available");
             return;
         }
-        Dialog<IssueSummary> dialog = new Dialog<>();
+        Dialog<ButtonType> dialog = new Dialog<>();
         dialog.setTitle("Add Dependency");
-        dialog.setHeaderText("This issue will be blocked by the selected issue.");
+        ComboBox<String> directionBox = new ComboBox<>();
+        directionBox.getItems().addAll("Blocked by", "Blocks");
+        directionBox.setValue("Blocked by");
         ComboBox<IssueSummary> issueBox = new ComboBox<>();
-        issueBox.getItems().addAll(candidates);
         issueBox.setConverter(new StringConverter<>(){
             @Override public String toString(IssueSummary s){
                 return s == null ? "" : String.format("[%s] %s (%s)", s.issueId(), s.title(), s.status());
@@ -280,35 +299,53 @@ final class IssueDetailScreen extends VBox {
             @Override public IssueSummary fromString(String str){ return null; }
         });
         issueBox.setMaxWidth(Double.MAX_VALUE);
-        dialog.getDialogPane().setContent(new VBox(8, new Label("Blocking Issue:"), issueBox));
+        Runnable refreshCandidates = () -> {
+            issueBox.getItems().clear();
+            issueBox.setValue(null);
+            Set<Long> excluded = "Blocked by".equals(directionBox.getValue()) ? existingBlockedByIds : existingBlockingIds;
+            allCandidates.stream().filter(i -> !excluded.contains(i.id())).forEach(issueBox.getItems()::add);
+        };
+        directionBox.valueProperty().addListener((obs, old, val) -> refreshCandidates.run());
+        refreshCandidates.run();
+        dialog.getDialogPane().setContent(new VBox(8,
+                new Label("Direction:"), directionBox,
+                new Label("Issue:"), issueBox));
         dialog.getDialogPane().setPrefWidth(500);
         Button okButton = setupDialogButtons(dialog);
         okButton.setDisable(true);
         issueBox.valueProperty().addListener((obs, old, val) -> okButton.setDisable(val == null));
-        dialog.setResultConverter(bt -> bt == ButtonType.OK ? issueBox.getValue() : null);
-        dialog.showAndWait().ifPresent(blocking -> {
+        Optional<ButtonType> result = dialog.showAndWait();
+        if (result.isPresent() && result.get() == ButtonType.OK && issueBox.getValue() != null){
             try{
-                issueController.addDependency(blocking.id(), issueId);
+                long selectedId = issueBox.getValue().id();
+                if ("Blocked by".equals(directionBox.getValue())){
+                    issueController.addDependency(selectedId, issueId);
+                } else{
+                    issueController.addDependency(issueId, selectedId);
+                }
                 reload();
             } catch (Exception exception){
                 ScreenComponents.showError(messageLabel, exception);
             }
-        });
+        }
     }
 
     private void handleRemoveDependency(){
-        if (currentDetail == null || currentDetail.dependencies().isEmpty()){
+        if (currentDetail == null
+                || (currentDetail.blockedByDependencies().isEmpty() && currentDetail.blockingDependencies().isEmpty())){
             ScreenComponents.showInfo(messageLabel, "No dependencies to remove");
             return;
         }
         Dialog<DependencyResult> dialog = new Dialog<>();
         dialog.setTitle("Remove Dependency");
         ComboBox<DependencyResult> depBox = new ComboBox<>();
-        depBox.getItems().addAll(currentDetail.dependencies());
+        depBox.getItems().addAll(currentDetail.blockedByDependencies());
+        depBox.getItems().addAll(currentDetail.blockingDependencies());
         depBox.setConverter(new StringConverter<>(){
             @Override public String toString(DependencyResult d){
                 if (d == null) return "";
-                return String.format("%s blocks %s", d.blockingIssueKey(), d.blockedIssueKey());
+                String direction = d.blockedIssueId() == issueId ? "[Blocked by] " : "[Blocking] ";
+                return direction + String.format("%s blocks %s", d.blockingIssueKey(), d.blockedIssueKey());
             }
             @Override public DependencyResult fromString(String s){ return null; }
         });

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueServiceTest.java
@@ -452,8 +452,8 @@ class IssueServiceTest {
                 assertEquals(String.valueOf(COMMENT_ID), detail.comments().getFirst().commentId());
                 assertEquals(1, detail.histories().size());
                 assertEquals(ActionType.COMMENTED, detail.histories().getFirst().actionType());
-                assertEquals(1, detail.dependencies().size());
-                assertEquals("dep-1", detail.dependencies().getFirst().dependencyId());
+                assertEquals(1, detail.blockedByDependencies().size());
+                assertEquals("dep-1", detail.blockedByDependencies().getFirst().dependencyId());
         }
 
         @Test
@@ -811,23 +811,16 @@ class IssueServiceTest {
         }
 
         @Test
-        @DisplayName("completed issue cannot be blocked")
-        void completedIssueCannotBeBlocked() {
+        @DisplayName("completed issue can still receive dependency - resolve-time check handles it")
+        void completedIssueCanReceiveDependency() {
                 var blockingIssue = persistedIssue(1L, "ISSUE-1");
                 var resolvedBlockedIssue = persistedIssue(2L, "ISSUE-2", PROJECT_ID, "Resolved blocked",
                                 IssueStatus.RESOLVED);
-                var closedBlockedIssue = persistedIssue(3L, "ISSUE-3", PROJECT_ID, "Closed blocked",
-                                IssueStatus.CLOSED);
-                var service = service(new InMemoryIssueRepository(
-                                blockingIssue,
-                                resolvedBlockedIssue,
-                                closedBlockedIssue));
-                String plLoginId = pl.getLoginId();
+                var service = service(new InMemoryIssueRepository(blockingIssue, resolvedBlockedIssue));
 
-                assertThrows(IllegalStateException.class,
-                                () -> service.addDependency(1L, 2L, plLoginId));
-                assertThrows(IllegalStateException.class,
-                                () -> service.addDependency(1L, 3L, plLoginId));
+                DependencyResult result = service.addDependency(1L, 2L, pl.getLoginId());
+                assertEquals(1L, result.blockingIssueId());
+                assertEquals(2L, result.blockedIssueId());
         }
 
         @Test

--- a/src/test/java/com/github/marcellokim/issuetracker/support/FakeIssueDependencyRepository.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/support/FakeIssueDependencyRepository.java
@@ -28,6 +28,13 @@ public final class FakeIssueDependencyRepository implements IssueDependencyRepos
     }
 
     @Override
+    public List<IssueDependency> findDependenciesBlockedByIssue(long blockingIssueId) {
+        return dependencies.values().stream()
+                .filter(d -> d.blockingIssueId() == blockingIssueId)
+                .toList();
+    }
+
+    @Override
     public List<IssueDependency> findByProjectId(long projectId) {
         return List.copyOf(dependencies.values());
     }

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanelTest.java
@@ -226,6 +226,7 @@ class IssueDetailPanelTest {
                 List.of(comment()),
                 List.of(history()),
                 List.of(dependency()),
+                List.of(),
                 actions);
     }
 

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
@@ -83,7 +83,8 @@ class IssueDetailPresenterTest {
         assertEquals(true, view.commentAction(100L).canUpdate());
         assertEquals(true, view.commentAction(100L).canDelete());
         assertEquals(false, view.commentAction(101L).canUpdate());
-        assertTrue(view.detail().dependencies().isEmpty());
+        assertTrue(view.detail().blockedByDependencies().isEmpty());
+        assertEquals(1, view.detail().blockingDependencies().size());
         assertEquals(1, view.projectDependencies().size());
         assertEquals(issue.id(), view.projectDependencies().getFirst().blockingIssueId());
         assertEquals(related.id(), view.projectDependencies().getFirst().blockedIssueId());


### PR DESCRIPTION
## 요약
- 관련 이슈: #250
- IssueDetailResult의 dependencies를 blockedByDependencies + blockingDependencies로 분리
- IssueDependencyRepository에 findDependenciesBlockedByIssue 역방향 조회 추가
- IssueService.viewIssueDetail에서 양방향 dependency 조회 후 분리 전달
- addDependency의 requireDependencyAddStatus 중복 검증 제거 (rejectUnresolvedBlockingIssues가 resolve 시점에서 보장)
- JavaFX IssueDetailScreen: Blocked by / Blocking 분리 표시, AddDependency direction 선택, RemoveDependency 양방향 목록, ScrollPane 추가

## 설계 근거
- Larman Information Expert: Service가 현재 이슈 기준으로 blocking/blocked by를 분류하여 DTO에 전달. UI는 표시만 수행.
- Design by Contract: rejectUnresolvedBlockingIssues가 resolve 시점의 유일한 correctness 체크. addDependency 시점의 status 검증은 중복이므로 제거.
- dependency 레코드는 삭제하지 않고 이력 증거로 보존 (auto-removal 미적용).

## 변경 파일
- `IssueDependencyRepository.java` — findDependenciesBlockedByIssue 인터페이스 추가
- `JdbcIssueDependencyRepository.java` — WHERE blocking_issue_id = ? 쿼리 구현
- `IssueDetailResult.java` — dependencies → blockedByDependencies + blockingDependencies
- `IssueService.java` — 양방향 조회 + requireDependencyAddStatus 제거
- `IssueDetailScreen.java` — 양방향 표시 + direction ComboBox + ScrollPane
- `FakeIssueDependencyRepository.java` — 테스트용 역방향 조회 구현
- `IssueServiceTest.java` — 검증 제거 반영
- `IssueDetailPanelTest.java` — DTO 생성자 파라미터 추가
- `IssueDetailPresenterTest.java` — blockedBy/blocking 분리 검증

## Swing 영향
- 프로덕션 코드 변경 0건 (viewProjectDependencies 별도 경로 사용)
- 테스트만 DTO 생성자 호환 수정 (2파일)

## 검증
- ./gradlew check 통과
- 행동 추적 검증: Add/Remove/View 양방향 + direction별 후보 필터링 + 방향 라벨 표시

## 관련 이슈
- Closes #250