### PR TITLE
test: Swing 전체 QA 시나리오와 회귀 점검

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ replay_pid*
 # Windows/WSL downloaded-file metadata
 *:Zone.Identifier
 
+# Local QA screenshots
+docs/qa/artifacts/**/WSL-SW-QA-*.png
+
 # Python cache
 __pycache__/
 *.py[cod]

--- a/docs/qa/swing-full-qa-2026-06-01.md
+++ b/docs/qa/swing-full-qa-2026-06-01.md
@@ -1,0 +1,407 @@
+# Swing Full QA Report - 2026-06-01
+
+## Run Metadata
+
+- Date: 2026-06-01 KST
+- Last updated: 2026-06-02 KST
+- Scope: Swing UI only
+- Parent issue: #24
+- QA issues: #246, #248
+- Execution mode: WSL2 continuation completed for DB-backed Swing smoke, core mutation flows, and component-level cross-cutting interaction flows; OS-level click/focus remains unverified
+- Run mode: macOS startup/admin smoke, then WSL2 WSLg/offscreen Swing render and same-JVM interaction capture
+- Source snapshot type: `origin/dev` baseline plus Swing QA branch fixes
+- Target source: `origin/dev@e82afe057280`; QA branch `test/248-swing-full-qa` with Swing focus fallback, issue-detail title layout, button/table polish, and regenerated QA evidence
+- Packaged app target: `IssueTrackerQA` local app image for startup/admin smoke
+- Stop gate status: WSL2 offscreen evidence accepted for Swing rendering; OS-level WSLg screenshot automation unavailable in this environment
+- Local DB: Oracle Free `FREEPDB1`
+- Screenshot policy: generated `WSL-SW-QA-*.png` files are local QA evidence and are intentionally ignored by `.gitignore`; the PR should include code, tests, and this report, not generated WSL screenshot binaries
+
+## Environment Evidence
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| `git fetch origin dev --prune` | PASS | Fetched `origin/dev`; `FETCH_HEAD` updated |
+| `git status --short --branch` | PASS | QA branch is based on latest `origin/dev` before PR creation; generated screenshot binaries remain ignored |
+| `gh pr list` / open Swing PR REST query | PASS | Open PR list returned `[]`; open Swing PR REST query returned no rows |
+| `./gradlew check verifySubmissionMetadata --console=plain` | PASS | Baseline gate passed before report creation: `BUILD SUCCESSFUL in 33s`; `oracleIntegrationTest` skipped |
+| `./gradlew oracleLocalStatus --console=plain` | BLOCKED then resolved | Initial Docker CLI available, but Colima Docker socket missing; fixed by `colima start` |
+| `colima start` | PASS | Docker context switched to `colima`; provisioning completed |
+| `./gradlew oracleLocalInitializeDatabase --console=plain` | PASS | Local Oracle running; schema executed 33 blocks; app data reused |
+| Missing Oracle env startup | PASS | Startup failure window shown with missing `ITS_DB_URL`, `ITS_DB_USER`, `ITS_DB_PASSWORD` message |
+| QA packaged Swing app launch | PASS | `jpackage` app image `IssueTrackerQA` created and launched with Oracle env |
+| WSL2 source refresh | PASS | WSL2 run started from `origin/dev@816117349a1f`; PR branch was later refreshed to `origin/dev@e82afe057280` before publication |
+| WSLg availability | PASS | `DISPLAY=:0`, `WAYLAND_DISPLAY=wayland-0`, `/mnt/wslg` and `/tmp/.X11-unix/X0` present |
+| WSL GUI automation tools | BLOCKED | `xdotool`, `wmctrl`, `scrot`, `import`, `gnome-screenshot`, `xwd`, `xprop`, `xwininfo`, `xdpyinfo` unavailable; `sudo` requires password |
+| WSL Docker/Oracle reset | PASS | Docker Desktop started from Windows side; `/tmp/docker-wrapper/docker` bridged Gradle scripts to `docker.exe`; `oracleLocalResetFixedSeed` completed |
+| WSL Oracle connection | PASS | `oracleConnectionCheck` connected to Oracle Free `FREEPDB1` as `ITS_USER` |
+| WSL OS screenshot capture | BLOCKED | Java Robot and Windows desktop capture produced black PNGs; those files were discarded and are not used as evidence |
+| WSL Swing offscreen capture | PASS | Same-JVM Swing `BufferedImage`/`printAll` captures were regenerated after local focus/style fixes and produced valid rendered evidence for login, admin, PL, Dev, Tester screens |
+| WSL Swing interaction capture | PASS | Same-JVM DB-backed Swing harness executed account, project, issue workflow, deleted issue, statistics, navigation, double-click duplicate-submit, cancel/window-close, and minimum-size visual flows against Oracle after fixed-seed reset |
+| WSL Robot click/focus capture | BLOCKED | Re-run after focus fallback still failed: `java.awt.Robot` coordinate click on `loginIdField` did not give focus; focus owner stayed `<none>`, dispatched mouse event also did not focus, and `requestFocusInWindow()` returned `false` in this WSLg session |
+| WSL minimal Robot focus probe | BLOCKED | A minimal standalone `JFrame` + `JTextField` also failed to receive focus after Robot coordinate click with focus owner `<none>`, so this environment cannot prove native Swing click focus |
+
+## Seed Accounts
+
+| Role | Login ID | Password | Result |
+| --- | --- | --- | --- |
+| Admin | `admin` | `DemoLocalAdmin!` | PASS |
+| PL | `pl1` | `DemoLocalPl1!` | PASS |
+| Dev | `dev1` | `DemoLocalDev1!` | PASS |
+| Tester | `tester1` | `DemoLocalTester1!` | PASS |
+
+## QA Case Results
+
+| ID | Role | Screen | Data State | Risk Type | Result | Evidence | Defect |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| SW-QA-ENV-001 | System | Startup | DB unavailable and DB available | environment | PASS | Missing-env failure screen and DB-backed admin dashboard verified |  |
+| SW-QA-AUTH-001 | Admin/PL/Dev/Tester | Login | valid and invalid credentials | session/focus | PARTIAL | Login screen, invalid credential message, admin dashboard, PL/Dev/Tester project list captures; focus fallback was added, but OS-level mouse click focus was still not proven in WSLg Robot run | SW-QA-GAP-002 |
+| SW-QA-ADMIN-001 | Admin | Dashboard/account/project | normal seed + QA account/project | route/refresh/mutation | PASS | Admin dashboard, account create/duplicate/rename/role/deactivate/activate, project create/rename/description/member add-remove/failure captures |  |
+| SW-QA-PL-001 | PL | Issue list/detail/deleted management/statistics | Project A seed + QA issue | workflow/search/register/edit/priority/assignment/comment/dependency/delete/statistics | PASS | PL issue register/detail/edit/priority/assign/comment/dependency, close/reopen, deleted issue restore/purge, statistics full/filter/invalid-range captures; issue id now renders as secondary metadata |  |
+| SW-QA-DEV-001 | Dev | Issue detail | QA assigned issue | status/comment/permission | PASS | Dev mark fixed, own comment add/edit/delete, and post-reject mark fixed captures |  |
+| SW-QA-TESTER-001 | Tester | Issue detail | QA fixed issue | resolve/reject/permission | PASS | Tester reject-to-assigned and resolve-to-resolved captures |  |
+| SW-QA-CROSS-001 | All | Navigation/dialogs | back/deleted navigation/logout visibility | worker/navigation | PASS component-level | Admin/PL/Dev/Tester back and logout paths, role switching, duplicate-submit double-clicks, and dialog cancel/window-close paths executed with WSL offscreen rendered evidence; native mouse/keyboard interaction not covered | SW-QA-GAP-002 |
+| SW-QA-VISUAL-001 | All | Main screens | long text/1280x900 and 800x600 windows | visual | PARTIAL | Main tables, errors, disabled states, action groups, dialog forms, and long Korean/English text render; issue id no longer pushes the title out of the header; button/table chrome was improved, but final presentation polish still needs a target-desktop pass | SW-QA-DEF-002 |
+| SW-QA-ARCH-001 | Code | Swing package | policy boundary | architecture | PASS | `rg` checks found no production Swing persistence/JDBC dependency; enum display and `availableActions` rendering are UI concerns; `not configured` guards are composition/test guard paths |  |
+
+## Capture And Interaction Log
+
+| ID | App Target | Screen | Action | Observation | Screenshot |
+| --- | --- | --- | --- | --- | --- |
+| MAC-STARTUP-FAIL | `Main` / `net.java.openjdk.java` | Startup failure | Desktop app inspection | Java process was visible, but native app-state capture could not inspect the Swing window reliably; screenshot fallback used | `docs/qa/artifacts/swing-2026-06-01/SW-QA-ENV-001-startup-failure.png` |
+| MAC-PACKAGED-APP | `IssueTrackerQA` / `com.github.marcellokim.issuetracker.qa2` | Login | `jpackage` app image launch | Packaged app fixed display name and bundle id for manual and accessibility-assisted smoke checks |  |
+| MAC-AUTH-ADMIN | `IssueTrackerQA` | Admin dashboard | Accessibility-assisted text input and `Return` | `admin` authenticated and dashboard loaded with project/user tables | `docs/qa/artifacts/swing-2026-06-01/SW-QA-AUTH-001-admin-dashboard.png` |
+| WSL-GUI-TOOLS | WSLg/X11 | Automation preflight | `command -v` checks | WSLg was available, but common X11 screenshot/input tools were not installed |  |
+| WSL-SCREENSHOT | WSLg/Windows desktop | Login | Java Robot and Windows desktop capture attempts | Both routes produced black captures, so they were discarded as invalid evidence |  |
+| WSL-OFFSCREEN | Swing JVM | Role smoke | same-JVM `SwingAppFrame` + `BufferedImage` `printAll` | Captured DB-backed rendered states for invalid login, admin, PL, Dev, and Tester | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-AUTH-001-login-offscreen.png` |
+| WSL-MUTATION | Swing JVM | Core workflows | same-JVM Swing component clicks + scripted prompts | Executed account/project/admin mutations and PL/Dev/Tester issue workflow mutations against Oracle | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-025-statistics-invalid-range-offscreen.png` |
+| WSL-CROSS | Swing JVM | Cross-cutting workflows | same-JVM Swing component clicks + real dialog captures | Executed back/re-enter/logout, duplicate-submit double-click, cancel/window-close, and 800x600 long-text visual cases | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-045-minimum-long-issue-detail-offscreen.png` |
+| WSL-ROBOT-FOCUS | Swing JVM on WSLg | Login | `java.awt.Robot` coordinate click and key typing probe | Login ID field did not receive focus after native coordinate click even after focus fallback; focus owner stayed `<none>` and requestFocusInWindow returned `false`, so WSLg Robot cannot prove manual click behavior | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ROBOT-002-login-id-click-no-focus.png` |
+
+## Test Data Ledger
+
+| Type | Identifier | Created By | Used In | Cleanup |
+| --- | --- | --- | --- | --- |
+| Account | `qauser1` -> `QA User Renamed`, final role `TESTER`, active `Yes` | Admin | SW-QA-ADMIN-001 | Local QA DB; reset by `oracleLocalResetFixedSeed` |
+| Project | `QA Project 2026` -> `QA Project Renamed`, description `QA project updated description` | Admin | SW-QA-ADMIN-001 | Local QA DB; reset by `oracleLocalResetFixedSeed` |
+| Project member | `dev1` added to and removed from `QA Project Renamed`; active removal from Project A rejected | Admin | SW-QA-ADMIN-001 | Local QA DB; reset by `oracleLocalResetFixedSeed` |
+| Issue | `QA PL issue 2026-06-01` -> `QA PL issue 2026-06-01 updated`, issue id visible as generated `ISSUE-*` | PL | SW-QA-PL-001, SW-QA-DEV-001, SW-QA-TESTER-001 | Preserved in final local QA DB as `REOPENED`; reset by `oracleLocalResetFixedSeed` |
+| Comment/history | `QA PL comment`, `QA fixed`, `QA reject`, `QA fixed after reject`, `QA resolved`, `QA close`, `QA reopen` | PL/Dev/Tester | Workflow status and comment evidence | Local QA DB; reset by `oracleLocalResetFixedSeed` |
+| Comment | `QA dev own comment` -> `QA dev own comment edited` -> deleted | Dev | SW-QA-DEV-001 | Local QA DB; reset by `oracleLocalResetFixedSeed` |
+| Dependency | Blocking issue id `3` added to and removed from the QA issue | PL | SW-QA-PL-001 | Removed during QA run |
+| Deleted issue | Seed issue `Statistics chart label overflow` restored, deleted again, then purged | PL | SW-QA-PL-001 | Purged during QA run |
+| Cross-click issue | `QA double action 2026-06-01` -> `QA double action updated once 2026-06-01` | PL/Dev | SW-QA-CROSS-001 | Local QA DB; reset by `oracleLocalResetFixedSeed` |
+| Long visual issue | Korean/English long title and comment data | PL | SW-QA-VISUAL-001 | Local QA DB; reset by `oracleLocalResetFixedSeed` |
+
+## Workflow State Coverage
+
+| State | Required UI Check | Result | Evidence |
+| --- | --- | --- | --- |
+| NEW | PL can edit, change priority, assign, comment, and manage dependency when allowed | PASS | `WSL-SW-QA-PL-011-new-detail-offscreen.png`, `WSL-SW-QA-PL-012-issue-edited-offscreen.png`, `WSL-SW-QA-PL-013-priority-changed-offscreen.png`, `WSL-SW-QA-PL-014-assigned-offscreen.png` |
+| ASSIGNED | Dev can mark fixed; PL can see assignment actions | PASS | `WSL-SW-QA-PL-014-assigned-offscreen.png`, `WSL-SW-QA-DEV-010-mark-fixed-offscreen.png` |
+| FIXED | Tester can reject and resolve | PASS | `WSL-SW-QA-TESTER-011-rejected-offscreen.png`, `WSL-SW-QA-TESTER-010-resolved-offscreen.png` |
+| RESOLVED | PL can close where allowed | PASS | `WSL-SW-QA-PL-018-closed-offscreen.png` |
+| CLOSED | PL can reopen/delete where allowed | PASS | `WSL-SW-QA-PL-018-closed-offscreen.png`, `WSL-SW-QA-PL-020-soft-deleted-offscreen.png` |
+| REOPENED | PL can see assignment/edit actions again | PASS | `WSL-SW-QA-PL-019-reopened-offscreen.png` |
+| DELETED | PL can restore and purge from deleted management | PASS | `WSL-SW-QA-PL-020-soft-deleted-offscreen.png`, `WSL-SW-QA-PL-021-restored-offscreen.png`, `WSL-SW-QA-PL-022-purged-offscreen.png` |
+
+## Phase Gates
+
+| Phase | Status | Decision |
+| --- | --- | --- |
+| Phase 1 - preflight/startup | PASS | Continue with role smoke on DB-backed packaged Swing app |
+| Phase 2 - role smoke | PASS component-level / PARTIAL OS-level | Admin, PL, Dev, Tester valid login and invalid login failure verified by component/AX automation; native mouse click focus remains unproven after focus fallback |
+| Phase 3 - workflow depth | PASS | Admin account/project mutation and PL/Dev/Tester issue mutation flows executed against Oracle |
+| Phase 4 - cross-cutting and visual | PASS component-level / PARTIAL OS-level | Navigation, role switching, duplicate-submit double-click handling, dialog cancel/window-close, disabled states, and 800x600 long-text render verified through component-level/offscreen evidence; issue id/title layout and button/table chrome improved; native mouse/keyboard and final visual polish still need target desktop pass |
+| Phase 5 - architecture and routing | PASS | Swing package boundary checks completed by `rg` spot checks and production path review |
+
+## Visual QA Notes
+
+| Area | Finding | Evidence | Follow-up |
+| --- | --- | --- | --- |
+| Login mouse focus | Focus fallback was added for mouse press/release, window open, and window activation, but the current WSLg run still cannot prove native click-to-focus; `Robot` coordinate click left focus owner as `<none>`. A minimal Swing `JTextField` probe failed the same way, so this is a target-desktop retest gate rather than a completed pass. | `WSL-SW-QA-ROBOT-002-login-id-click-no-focus.png` | Re-run on the presentation target OS with manual mouse capture or a working OS automation tool |
+| Issue detail title | Fixed in this QA pass: human-readable title renders first, and generated issue id moved to a secondary metadata line. Very long titles still ellipsize at 800px, which is acceptable if the title starts visible. | `WSL-SW-QA-PL-011-new-detail-offscreen.png`, `WSL-SW-QA-PL-012-issue-edited-offscreen.png`, `WSL-SW-QA-CROSS-045-minimum-long-issue-detail-offscreen.png` | No further blocker; optional tooltip/manual copy affordance can be added later |
+| Native Swing polish | Button gradients and table headers were improved in this branch; screens are now cleaner but still presentation-utilitarian, with dense tables and large blank panels on some views. | `WSL-SW-QA-AUTH-003-admin-dashboard-offscreen.png`, `WSL-SW-QA-PL-001-issue-list-offscreen.png`, `WSL-SW-QA-PL-025-statistics-invalid-range-offscreen.png` | Target-desktop pass should confirm spacing hierarchy, selected/focus states, and disabled-action affordance |
+| Dialogs | Dialogs are usable and cancel/window-close paths work, but forms inherit native default styling and are visually detached from the main screen language. | `WSL-SW-QA-CROSS-020-account-create-cancel-dialog.png`, `WSL-SW-QA-CROSS-035-edit-cancel-dialog.png` | Accept for functional submission or wrap key dialogs in project-styled panels if time allows |
+
+## Defects
+
+| ID | Severity | Title | Linked PR/Issue | Status |
+| --- | --- | --- | --- | --- |
+| SW-QA-DEF-001 | Medium | Issue detail header displayed long issue hash first, causing the human-readable title to be truncated at 1280x900 |  | Fixed in local QA branch |
+| SW-QA-DEF-002 | Low | Swing screens still need final presentation polish review for dense tables, disabled-action rows, and large empty areas |  | Improved in local QA branch; residual polish open |
+| SW-QA-GAP-001 | Low | WSLg OS-level screenshot automation unavailable without additional X11 capture tools or manual desktop capture support |  | Documented |
+| SW-QA-GAP-002 | Medium | Native mouse click and keyboard typing cannot be claimed complete from current WSLg run; Robot click on login ID field did not focus the window/component after local focus fallback |  | Documented; target desktop retest required |
+
+## Target Desktop Retest Gate
+
+This QA run does not close native mouse/keyboard behavior because WSLg `Robot` also fails on a minimal standalone Swing `JTextField`. Before release or demo, run the following on the actual presentation desktop.
+
+| ID | Required Check | Expected Result | Evidence |
+| --- | --- | --- | --- |
+| TDT-FOCUS-001 | Open Swing app, click directly inside `ID`, type `admin` | First click places caret in `ID`; typed text appears in `ID` without using Tab | Screen recording or screenshot sequence |
+| TDT-FOCUS-002 | Click directly inside `Password`, type `DemoLocalAdmin!` | First click places caret in `Password`; password field receives input | Screen recording or screenshot sequence |
+| TDT-FOCUS-003 | Click `Sign in` with mouse | Admin dashboard opens without pressing Enter | Dashboard screenshot |
+| TDT-FOCUS-004 | Repeat invalid login with mouse-only field selection and button click | Error message is visible and password clears | Login error screenshot |
+| TDT-VISUAL-001 | Inspect login, admin dashboard, PL issue list/detail, statistics at default window size | No overlap, clipped primary text, unreachable button, or unreadable disabled state | Screenshots |
+| TDT-VISUAL-002 | Resize to the documented minimum `800x600` and inspect long title/detail case | Primary title remains visible; scrolling works where content exceeds height | Screenshot |
+
+Gate decision: any failed `TDT-FOCUS-*` item is release-blocking for Swing. `TDT-VISUAL-*` failures are blocking only when text is unreadable, controls are clipped, or the normal workflow becomes unreachable.
+
+## Command Log
+
+```text
+$ git status --short --branch
+## test/248-swing-full-qa...origin/dev
+
+$ git rev-parse --short=12 origin/dev
+e82afe057280
+
+$ gh pr list --repo marcellokim/se-issue-tracker --state open --limit 100 --json number,title,isDraft,headRefName,baseRefName,labels,updatedAt
+[]
+
+$ ./gradlew check verifySubmissionMetadata --console=plain
+BUILD SUCCESSFUL in 33s
+oracleIntegrationTest SKIPPED
+
+$ git fetch origin dev --prune && git rev-parse --short=12 origin/dev
+e82afe057280
+
+$ gh api --method GET repos/marcellokim/se-issue-tracker/pulls --paginate -f state=open -f per_page=100 --jq '.[] | select(([.labels[].name] | index("area:ui")) or (.title | test("Swing"))) | {number,title,draft,head:.head.ref,base:.base.ref,sha:.head.sha}'
+<no rows>
+
+$ rg -n "admin|pl1|dev1|tester1|DemoLocal" docs/oracleDB-seed-password.md
+16:| `admin` | `DemoLocalAdmin!` |
+17:| `pl1` | `DemoLocalPl1!` |
+19:| `dev1` ~ `dev10` | `DemoLocalDev1!` ~ `DemoLocalDev10!` |
+20:| `tester1` ~ `tester5` | `DemoLocalTester1!` ~ `DemoLocalTester5!` |
+
+$ ./gradlew oracleLocalStatus --console=plain
+BUILD SUCCESSFUL in 541ms
+Docker CLI: available
+Docker Compose: available
+JDBC URL: jdbc:oracle:thin:@//localhost:1521/FREEPDB1
+failed to connect to the docker API at unix:///Users/ydmac/.colima/default/docker.sock
+container state: not created
+
+$ colima start
+Current context is now "colima"
+done
+
+$ ./gradlew oracleLocalInitializeDatabase --console=plain
+Executed 33 blocks from db/oracle/schema-oracle.sql
+Oracle application data reused without seed reset.
+Oracle application database check completed.
+BUILD SUCCESSFUL in 1m 3s
+
+$ jpackage --type app-image --name IssueTrackerQA ...
+<app image created at /Users/ydmac/Applications/IssueTrackerQA.app>
+
+$ accessibility-assisted login as admin
+windows=1
+titles=Admin dashboard
+Admin (ADMIN)
+
+$ git fetch origin dev test/248-swing-full-qa --prune && git rev-parse --short=12 origin/dev && git rev-parse --short=12 HEAD && git status --short --branch
+816117349a1f
+cf6cf5e3059e
+## test/248-swing-full-qa...origin/test/248-swing-full-qa
+
+$ printf 'DISPLAY=%s\nWAYLAND_DISPLAY=%s\n' "$DISPLAY" "$WAYLAND_DISPLAY"; ls -ld /mnt/wslg /tmp/.X11-unix/X0
+DISPLAY=:0
+WAYLAND_DISPLAY=wayland-0
+/mnt/wslg present
+/tmp/.X11-unix/X0 present
+
+$ for c in xdotool wmctrl scrot import gnome-screenshot xwd xprop xwininfo xdpyinfo; do command -v "$c" || echo "$c=missing"; done
+xdotool=missing
+wmctrl=missing
+scrot=missing
+import=missing
+gnome-screenshot=missing
+xwd=missing
+xprop=missing
+xwininfo=missing
+xdpyinfo=missing
+
+$ PATH="/tmp/docker-wrapper:$PATH" ./gradlew oracleLocalResetFixedSeed --console=plain
+Oracle schema reset and fixed seed completed.
+BUILD SUCCESSFUL in 3m 8s
+
+$ ITS_DB_URL='jdbc:oracle:thin:@//localhost:1521/FREEPDB1' ITS_DB_USER='ITS_USER' ITS_DB_PASSWORD='ItsLocalDev2026!' PATH="/tmp/docker-wrapper:$PATH" ./gradlew oracleConnectionCheck --console=plain
+Oracle Database connection succeeded.
+ITS Oracle connection OK.
+BUILD SUCCESSFUL in 1s
+
+$ java -cp "/tmp/swing-qa-tools/classes:<runtime-classpath>" com.github.marcellokim.issuetracker.ui.swing.SwingQaCapture docs/qa/artifacts/swing-2026-06-01
+PASS invalid-login message=Invalid ID or password.
+PASS admin-dashboard projects=2
+PASS admin-project-management projects=2
+PASS admin-account-management users=18
+PASS pl-project-list projects=1
+PASS pl-issue-list issues=14 message=14 issues
+PASS pl-deleted-issues rows=0
+PASS pl-issue-detail title=[7b12464fb13eefd341275d986489cc68be1551da56ad3b5f8afbe72879e35efc] Assignment notification not shown
+PASS dev-project-list projects=1
+PASS dev-issue-list issues=1 message=1 issues
+PASS dev-issue-detail title=[2fea689c8d29ec9bf36c8eb73a69064a045aac1bb54e3eaa7ced9cd7d11d9c25] Dependency resolution flow blocked
+PASS tester-project-list projects=1
+PASS tester-issue-list issues=6 message=6 issues
+PASS tester-issue-detail title=[26f1ad37d100a4f6215564b8a7ae2d2fe328e2186fd95b5c664a0904650f27b5] Session timeout warning absent
+
+$ ./gradlew test --tests 'com.github.marcellokim.issuetracker.ui.swing.*' --console=plain
+BUILD SUCCESSFUL in 18s
+
+$ ITS_DB_URL="jdbc:oracle:thin:@//localhost:1521/FREEPDB1" ITS_DB_USER="ITS_USER" ITS_DB_PASSWORD="ItsLocalDev2026!" ./gradlew oracleLocalResetFixedSeed --console=plain
+Oracle schema reset and fixed seed completed.
+BUILD SUCCESSFUL in 1m 10s
+
+$ java -cp "/tmp/swing-qa-tools/classes:<runtime-classpath>" com.github.marcellokim.issuetracker.ui.swing.SwingQaCapture docs/qa/artifacts/swing-2026-06-01
+PASS invalid-login message=Invalid ID or password.
+PASS admin-dashboard projects=2
+PASS admin-project-management projects=2
+PASS admin-account-management users=18
+PASS pl-project-list projects=1
+PASS pl-issue-list issues=14 message=14 issues
+PASS pl-deleted-issues rows=0
+PASS pl-issue-detail title=Assignment notification not shown
+PASS dev-project-list projects=1
+PASS dev-issue-list issues=1 message=1 issues
+PASS dev-issue-detail title=Dependency resolution flow blocked
+PASS tester-project-list projects=1
+PASS tester-issue-list issues=6 message=6 issues
+
+$ ITS_DB_URL="jdbc:oracle:thin:@//localhost:1521/FREEPDB1" ITS_DB_USER="ITS_USER" ITS_DB_PASSWORD="ItsLocalDev2026!" ./gradlew oracleLocalResetFixedSeed --console=plain
+Oracle schema reset and fixed seed completed.
+BUILD SUCCESSFUL in 1m 10s
+
+$ java -cp "/tmp/swing-qa-tools/classes:<runtime-classpath>" com.github.marcellokim.issuetracker.ui.swing.SwingQaInteractionCapture docs/qa/artifacts/swing-2026-06-01
+PASS admin-account-mutations qauser1 create/duplicate/rename/role/deactivate/activate
+PASS admin-project-mutations project create/rename/description/member add-remove/failure
+PASS pl-statistics full/filter/invalid-range
+PASS issue-workflow-mutations qaIssueId=31
+PASS cross-navigation back/re-enter/logout/role-switch
+PASS cross-duplicate-submit login/search/register/action buttons
+PASS cross-dialog-cancel-window-close
+PASS cross-minimum-visual long Korean/English issue rendered at 800x600
+PASS cross-cutting navigation/double-click/cancel/minimum-visual
+PASS architecture-spot-checks deferred-to-command-log
+
+$ rg -n "repository|persistence|jdbc|DataSource|Connection|PreparedStatement" src/main/java/com/github/marcellokim/issuetracker/ui/swing src/test/java/com/github/marcellokim/issuetracker/ui/swing
+Production Swing package: no matches. Test package: repository imports only for fixture/controller construction.
+
+$ rg -n "Role\\.|IssueStatus\\.|Priority\\.|can[A-Z]|availableActions|user\\.role\\(\\)" src/main/java/com/github/marcellokim/issuetracker/ui/swing
+Matches are display labels, enum selectors, presenter/controller-derived `canRegisterIssue`, comment action state, and `availableActions`-driven button rendering.
+
+$ rg -n "PlaceholderPanel|showPlaceholder|Issue action|not configured|UnsupportedOperationException" src/main/java/com/github/marcellokim/issuetracker/ui/swing src/test/java/com/github/marcellokim/issuetracker/ui/swing
+No placeholder routes. `not configured` matches are constructor/composition guard paths for assignment, statistics, deleted issue, and issue state controllers.
+
+$ ./gradlew test --tests 'com.github.marcellokim.issuetracker.ui.swing.*' --console=plain
+BUILD SUCCESSFUL in 14s
+
+$ ./gradlew check verifySubmissionMetadata --console=plain
+BUILD SUCCESSFUL in 24s
+
+$ git diff --check
+git diff --check produced no output.
+
+$ java -cp "/tmp/swing-qa-tools/classes:<runtime-classpath>" com.github.marcellokim.issuetracker.ui.swing.SwingQaRobotFocusCapture docs/qa/artifacts/swing-2026-06-01
+FAIL robot-click-focus loginId focusOwner=<none>
+FAIL dispatched-click-focus loginId focusOwner=<none>
+INFO requestFocusInWindow loginId=false focusOwner=<none>
+Exception in thread "main" java.lang.IllegalStateException: Timed out waiting for Swing state
+
+$ javac /tmp/swing-focus-probe/MinimalFocusProbe.java && java -cp /tmp/swing-focus-probe MinimalFocusProbe
+FAIL minimal JTextField focus owner=<none>
+```
+
+## Local Screenshot Index
+
+The `WSL-SW-QA-*.png` entries below document locally generated evidence from this QA run. They are not intended to be committed; reproduce them from the command log when fresh visual evidence is needed.
+
+| Screenshot | Scenario | Path |
+| --- | --- | --- |
+| SW-QA-ENV-001-startup-failure.png | Missing Oracle env startup failure | `docs/qa/artifacts/swing-2026-06-01/SW-QA-ENV-001-startup-failure.png` |
+| SW-QA-AUTH-001-admin-dashboard.png | Admin valid login dashboard | `docs/qa/artifacts/swing-2026-06-01/SW-QA-AUTH-001-admin-dashboard.png` |
+| WSL-SW-QA-AUTH-001-login-offscreen.png | WSL2 offscreen login form | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-AUTH-001-login-offscreen.png` |
+| WSL-SW-QA-AUTH-002-invalid-login-offscreen.png | WSL2 invalid credential message | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-AUTH-002-invalid-login-offscreen.png` |
+| WSL-SW-QA-AUTH-003-admin-dashboard-offscreen.png | WSL2 admin dashboard | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-AUTH-003-admin-dashboard-offscreen.png` |
+| WSL-SW-QA-ADMIN-001-project-management-offscreen.png | WSL2 admin project management | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-001-project-management-offscreen.png` |
+| WSL-SW-QA-ADMIN-002-account-management-offscreen.png | WSL2 admin account management | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-002-account-management-offscreen.png` |
+| WSL-SW-QA-AUTH-004-pl-project-list-offscreen.png | WSL2 PL project list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-AUTH-004-pl-project-list-offscreen.png` |
+| WSL-SW-QA-PL-001-issue-list-offscreen.png | WSL2 PL issue list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-001-issue-list-offscreen.png` |
+| WSL-SW-QA-PL-002-deleted-issues-offscreen.png | WSL2 PL deleted issue management | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-002-deleted-issues-offscreen.png` |
+| WSL-SW-QA-PL-003-issue-detail-offscreen.png | WSL2 PL issue detail | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-003-issue-detail-offscreen.png` |
+| WSL-SW-QA-AUTH-005-dev-project-list-offscreen.png | WSL2 Dev project list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-AUTH-005-dev-project-list-offscreen.png` |
+| WSL-SW-QA-DEV-001-issue-list-offscreen.png | WSL2 Dev issue list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-DEV-001-issue-list-offscreen.png` |
+| WSL-SW-QA-DEV-002-issue-detail-offscreen.png | WSL2 Dev issue detail | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-DEV-002-issue-detail-offscreen.png` |
+| WSL-SW-QA-AUTH-006-tester-project-list-offscreen.png | WSL2 Tester project list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-AUTH-006-tester-project-list-offscreen.png` |
+| WSL-SW-QA-TESTER-001-issue-list-offscreen.png | WSL2 Tester issue list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-TESTER-001-issue-list-offscreen.png` |
+| WSL-SW-QA-TESTER-002-issue-detail-offscreen.png | WSL2 Tester issue detail | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-TESTER-002-issue-detail-offscreen.png` |
+| WSL-SW-QA-ADMIN-010-account-create-blank-offscreen.png | Admin blank account creation rejected | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-010-account-create-blank-offscreen.png` |
+| WSL-SW-QA-ADMIN-011-account-created-offscreen.png | Admin account created | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-011-account-created-offscreen.png` |
+| WSL-SW-QA-ADMIN-012-account-mutated-offscreen.png | Admin account renamed, role changed, activated | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-012-account-mutated-offscreen.png` |
+| WSL-SW-QA-ADMIN-013-project-create-blank-offscreen.png | Admin blank project creation rejected | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-013-project-create-blank-offscreen.png` |
+| WSL-SW-QA-ADMIN-014-project-mutated-offscreen.png | Admin project created, renamed, description changed | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-014-project-mutated-offscreen.png` |
+| WSL-SW-QA-ADMIN-015-project-member-add-remove-offscreen.png | Admin project member add/remove | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-015-project-member-add-remove-offscreen.png` |
+| WSL-SW-QA-ADMIN-016-project-member-active-remove-failure-offscreen.png | Admin active assignee removal rejected | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-016-project-member-active-remove-failure-offscreen.png` |
+| WSL-SW-QA-PL-010-register-refresh-offscreen.png | PL registered QA issue appears in list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-010-register-refresh-offscreen.png` |
+| WSL-SW-QA-PL-011-new-detail-offscreen.png | PL QA issue detail in NEW state | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-011-new-detail-offscreen.png` |
+| WSL-SW-QA-PL-012-issue-edited-offscreen.png | PL edited QA issue title/description | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-012-issue-edited-offscreen.png` |
+| WSL-SW-QA-PL-013-priority-changed-offscreen.png | PL changed priority | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-013-priority-changed-offscreen.png` |
+| WSL-SW-QA-PL-014-assigned-offscreen.png | PL assigned dev/verifier | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-014-assigned-offscreen.png` |
+| WSL-SW-QA-PL-015-comment-added-offscreen.png | PL comment added | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-015-comment-added-offscreen.png` |
+| WSL-SW-QA-PL-016-dependency-added-offscreen.png | PL dependency added | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-016-dependency-added-offscreen.png` |
+| WSL-SW-QA-PL-017-dependency-removed-offscreen.png | PL dependency removed | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-017-dependency-removed-offscreen.png` |
+| WSL-SW-QA-DEV-010-mark-fixed-offscreen.png | Dev marked QA issue fixed | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-DEV-010-mark-fixed-offscreen.png` |
+| WSL-SW-QA-DEV-011-comment-added-offscreen.png | Dev comment added | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-DEV-011-comment-added-offscreen.png` |
+| WSL-SW-QA-DEV-012-comment-edited-offscreen.png | Dev own comment edited | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-DEV-012-comment-edited-offscreen.png` |
+| WSL-SW-QA-DEV-013-comment-deleted-offscreen.png | Dev own comment deleted | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-DEV-013-comment-deleted-offscreen.png` |
+| WSL-SW-QA-TESTER-011-rejected-offscreen.png | Tester rejected fixed issue | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-TESTER-011-rejected-offscreen.png` |
+| WSL-SW-QA-DEV-014-mark-fixed-after-reject-offscreen.png | Dev fixed after tester rejection | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-DEV-014-mark-fixed-after-reject-offscreen.png` |
+| WSL-SW-QA-TESTER-010-resolved-offscreen.png | Tester resolved fixed issue | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-TESTER-010-resolved-offscreen.png` |
+| WSL-SW-QA-PL-018-closed-offscreen.png | PL closed resolved issue | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-018-closed-offscreen.png` |
+| WSL-SW-QA-PL-019-reopened-offscreen.png | PL reopened closed issue | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-019-reopened-offscreen.png` |
+| WSL-SW-QA-PL-020-soft-deleted-offscreen.png | PL soft-deleted seed closed issue | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-020-soft-deleted-offscreen.png` |
+| WSL-SW-QA-PL-021-restored-offscreen.png | PL restored deleted issue | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-021-restored-offscreen.png` |
+| WSL-SW-QA-PL-022-purged-offscreen.png | PL purged deleted issue | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-022-purged-offscreen.png` |
+| WSL-SW-QA-PL-023-statistics-full-offscreen.png | PL statistics all-time | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-023-statistics-full-offscreen.png` |
+| WSL-SW-QA-PL-024-statistics-filtered-offscreen.png | PL statistics filtered | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-024-statistics-filtered-offscreen.png` |
+| WSL-SW-QA-PL-025-statistics-invalid-range-offscreen.png | PL statistics invalid range rejected | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-025-statistics-invalid-range-offscreen.png` |
+| WSL-SW-QA-CROSS-001-admin-navigation-back-offscreen.png | Admin account/project back navigation and logout controls | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-001-admin-navigation-back-offscreen.png` |
+| WSL-SW-QA-CROSS-002-pl-back-reenter-offscreen.png | PL project back and re-enter issue list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-002-pl-back-reenter-offscreen.png` |
+| WSL-SW-QA-CROSS-003-dev-after-pl-logout-offscreen.png | Dev login after PL logout | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-003-dev-after-pl-logout-offscreen.png` |
+| WSL-SW-QA-CROSS-004-tester-after-dev-logout-offscreen.png | Tester login after Dev logout | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-004-tester-after-dev-logout-offscreen.png` |
+| WSL-SW-QA-CROSS-010-double-register-offscreen.png | Duplicate register double-click kept first request only | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-010-double-register-offscreen.png` |
+| WSL-SW-QA-CROSS-011-double-search-offscreen.png | Duplicate search double-click kept list stable | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-011-double-search-offscreen.png` |
+| WSL-SW-QA-CROSS-012-double-edit-offscreen.png | Duplicate edit double-click kept first request only | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-012-double-edit-offscreen.png` |
+| WSL-SW-QA-CROSS-013-double-assignment-offscreen.png | Duplicate assignment double-click kept first request only | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-013-double-assignment-offscreen.png` |
+| WSL-SW-QA-CROSS-014-double-comment-dependency-offscreen.png | Duplicate comment/dependency double-click kept first request only | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-014-double-comment-dependency-offscreen.png` |
+| WSL-SW-QA-CROSS-015-double-status-offscreen.png | Duplicate status double-click kept first request only | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-015-double-status-offscreen.png` |
+| WSL-SW-QA-CROSS-020-account-create-cancel-dialog.png | Account create cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-020-account-create-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-021-account-create-window-close-dialog.png | Account create window-close dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-021-account-create-window-close-dialog.png` |
+| WSL-SW-QA-CROSS-022-account-rename-cancel-dialog.png | Account rename cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-022-account-rename-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-023-account-role-cancel-dialog.png | Account role cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-023-account-role-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-024-account-deactivate-cancel-dialog.png | Account deactivate cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-024-account-deactivate-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-025-account-after-cancel-offscreen.png | Account management state after cancel/window-close actions | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-025-account-after-cancel-offscreen.png` |
+| WSL-SW-QA-CROSS-026-project-create-cancel-dialog.png | Project create cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-026-project-create-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-027-project-create-window-close-dialog.png | Project create window-close dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-027-project-create-window-close-dialog.png` |
+| WSL-SW-QA-CROSS-028-project-rename-cancel-dialog.png | Project rename cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-028-project-rename-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-029-project-description-cancel-dialog.png | Project description cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-029-project-description-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-030-project-delete-cancel-dialog.png | Project delete cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-030-project-delete-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-031-project-after-cancel-offscreen.png | Project management state after cancel/window-close actions | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-031-project-after-cancel-offscreen.png` |
+| WSL-SW-QA-CROSS-032-register-cancel-dialog.png | Issue register cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-032-register-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-033-register-window-close-dialog.png | Issue register window-close dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-033-register-window-close-dialog.png` |
+| WSL-SW-QA-CROSS-034-assignment-cancel-dialog.png | Issue assignment cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-034-assignment-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-035-edit-cancel-dialog.png | Issue edit cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-035-edit-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-036-edit-window-close-dialog.png | Issue edit window-close dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-036-edit-window-close-dialog.png` |
+| WSL-SW-QA-CROSS-037-priority-cancel-dialog.png | Issue priority cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-037-priority-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-038-comment-cancel-dialog.png | Issue comment cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-038-comment-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-039-dependency-cancel-dialog.png | Issue dependency cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-039-dependency-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-040-delete-cancel-dialog.png | Issue delete cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-040-delete-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-041-issue-detail-after-cancel-offscreen.png | Issue detail state after cancel/window-close actions | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-041-issue-detail-after-cancel-offscreen.png` |
+| WSL-SW-QA-CROSS-042-status-cancel-dialog.png | Dev status cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-042-status-cancel-dialog.png` |
+| WSL-SW-QA-CROSS-043-status-after-cancel-offscreen.png | Dev detail state after status cancel | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-043-status-after-cancel-offscreen.png` |
+| WSL-SW-QA-CROSS-044-minimum-long-issue-list-offscreen.png | 800x600 long Korean/English issue list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-044-minimum-long-issue-list-offscreen.png` |
+| WSL-SW-QA-CROSS-045-minimum-long-issue-detail-offscreen.png | 800x600 long Korean/English issue detail | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-045-minimum-long-issue-detail-offscreen.png` |
+| WSL-SW-QA-ROBOT-001-login-initial.png | Robot focus probe initial login screen | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ROBOT-001-login-initial.png` |
+| WSL-SW-QA-ROBOT-002-login-id-click-no-focus.png | Robot coordinate click on login ID did not focus field | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ROBOT-002-login-id-click-no-focus.png` |

--- a/docs/qa/swing-full-qa-2026-06-01.md
+++ b/docs/qa/swing-full-qa-2026-06-01.md
@@ -1,407 +1,90 @@
-# Swing Full QA Report - 2026-06-01
+# Swing UI QA Report - 2026-06-01
 
-## Run Metadata
+## 개요
 
-- Date: 2026-06-01 KST
-- Last updated: 2026-06-02 KST
-- Scope: Swing UI only
-- Parent issue: #24
-- QA issues: #246, #248
-- Execution mode: WSL2 continuation completed for DB-backed Swing smoke, core mutation flows, and component-level cross-cutting interaction flows; OS-level click/focus remains unverified
-- Run mode: macOS startup/admin smoke, then WSL2 WSLg/offscreen Swing render and same-JVM interaction capture
-- Source snapshot type: `origin/dev` baseline plus Swing QA branch fixes
-- Target source: `origin/dev@e82afe057280`; QA branch `test/248-swing-full-qa` with Swing focus fallback, issue-detail title layout, button/table polish, and regenerated QA evidence
-- Packaged app target: `IssueTrackerQA` local app image for startup/admin smoke
-- Stop gate status: WSL2 offscreen evidence accepted for Swing rendering; OS-level WSLg screenshot automation unavailable in this environment
-- Local DB: Oracle Free `FREEPDB1`
-- Screenshot policy: generated `WSL-SW-QA-*.png` files are local QA evidence and are intentionally ignored by `.gitignore`; the PR should include code, tests, and this report, not generated WSL screenshot binaries
+- 대상: Swing UI 전체 화면
+- 관련 이슈: #246, #248
+- 기준 코드: `origin/dev` 기반 `test/248-swing-full-qa`
+- DB: Oracle Free `FREEPDB1`, fixed seed
+- 산출물 정책: 로컬 캡처 이미지는 재현용 증거로만 사용하고 PR에는 포함하지 않음
 
-## Environment Evidence
+이번 QA는 Swing UI가 백엔드/application 코드를 재사용하면서 주요 역할별 흐름을 실행할 수 있는지 확인하는 데 초점을 둔다. 자동화가 가능한 범위에서는 Oracle DB에 연결한 동일 JVM Swing 하네스로 실제 컨트롤러/서비스 경로를 탔다. 다만 WSLg 환경의 네이티브 마우스 포커스는 `java.awt.Robot`으로 재현되지 않아 최종 발표 장비에서 별도 재검증이 필요하다.
 
-| Check | Result | Evidence |
+## 결론
+
+| 영역 | 결과 | 판단 |
 | --- | --- | --- |
-| `git fetch origin dev --prune` | PASS | Fetched `origin/dev`; `FETCH_HEAD` updated |
-| `git status --short --branch` | PASS | QA branch is based on latest `origin/dev` before PR creation; generated screenshot binaries remain ignored |
-| `gh pr list` / open Swing PR REST query | PASS | Open PR list returned `[]`; open Swing PR REST query returned no rows |
-| `./gradlew check verifySubmissionMetadata --console=plain` | PASS | Baseline gate passed before report creation: `BUILD SUCCESSFUL in 33s`; `oracleIntegrationTest` skipped |
-| `./gradlew oracleLocalStatus --console=plain` | BLOCKED then resolved | Initial Docker CLI available, but Colima Docker socket missing; fixed by `colima start` |
-| `colima start` | PASS | Docker context switched to `colima`; provisioning completed |
-| `./gradlew oracleLocalInitializeDatabase --console=plain` | PASS | Local Oracle running; schema executed 33 blocks; app data reused |
-| Missing Oracle env startup | PASS | Startup failure window shown with missing `ITS_DB_URL`, `ITS_DB_USER`, `ITS_DB_PASSWORD` message |
-| QA packaged Swing app launch | PASS | `jpackage` app image `IssueTrackerQA` created and launched with Oracle env |
-| WSL2 source refresh | PASS | WSL2 run started from `origin/dev@816117349a1f`; PR branch was later refreshed to `origin/dev@e82afe057280` before publication |
-| WSLg availability | PASS | `DISPLAY=:0`, `WAYLAND_DISPLAY=wayland-0`, `/mnt/wslg` and `/tmp/.X11-unix/X0` present |
-| WSL GUI automation tools | BLOCKED | `xdotool`, `wmctrl`, `scrot`, `import`, `gnome-screenshot`, `xwd`, `xprop`, `xwininfo`, `xdpyinfo` unavailable; `sudo` requires password |
-| WSL Docker/Oracle reset | PASS | Docker Desktop started from Windows side; `/tmp/docker-wrapper/docker` bridged Gradle scripts to `docker.exe`; `oracleLocalResetFixedSeed` completed |
-| WSL Oracle connection | PASS | `oracleConnectionCheck` connected to Oracle Free `FREEPDB1` as `ITS_USER` |
-| WSL OS screenshot capture | BLOCKED | Java Robot and Windows desktop capture produced black PNGs; those files were discarded and are not used as evidence |
-| WSL Swing offscreen capture | PASS | Same-JVM Swing `BufferedImage`/`printAll` captures were regenerated after local focus/style fixes and produced valid rendered evidence for login, admin, PL, Dev, Tester screens |
-| WSL Swing interaction capture | PASS | Same-JVM DB-backed Swing harness executed account, project, issue workflow, deleted issue, statistics, navigation, double-click duplicate-submit, cancel/window-close, and minimum-size visual flows against Oracle after fixed-seed reset |
-| WSL Robot click/focus capture | BLOCKED | Re-run after focus fallback still failed: `java.awt.Robot` coordinate click on `loginIdField` did not give focus; focus owner stayed `<none>`, dispatched mouse event also did not focus, and `requestFocusInWindow()` returned `false` in this WSLg session |
-| WSL minimal Robot focus probe | BLOCKED | A minimal standalone `JFrame` + `JTextField` also failed to receive focus after Robot coordinate click with focus owner `<none>`, so this environment cannot prove native Swing click focus |
+| 앱 기동/DB 연결 | 통과 | Oracle env 누락 오류와 정상 DB 연결 경로 확인 |
+| 역할별 로그인 | 부분 통과 | Admin/PL/Dev/Tester 인증 흐름 확인, 네이티브 마우스 포커스는 발표 장비 재검증 필요 |
+| Admin 화면 | 통과 | 계정/프로젝트 조회 및 주요 mutation 흐름 확인 |
+| PL 화면 | 통과 | 이슈 목록, 상세, 등록, 수정, 우선순위, 배정, 댓글, 의존성, 삭제 이슈, 통계 확인 |
+| Dev 화면 | 통과 | 배정 이슈 조회, fixed 전환, 본인 댓글 수정/삭제 확인 |
+| Tester 화면 | 통과 | fixed 이슈 reject/resolve 흐름 확인 |
+| Cross-cutting | 통과 | 뒤로가기, 로그아웃, 중복 클릭 방지, dialog 취소/닫기 확인 |
+| Visual QA | 부분 통과 | 주요 화면 렌더링과 800x600 최소 크기 확인, 최종 시연 환경 육안 점검 필요 |
 
-## Seed Accounts
+## 수정 반영
 
-| Role | Login ID | Password | Result |
-| --- | --- | --- | --- |
-| Admin | `admin` | `DemoLocalAdmin!` | PASS |
-| PL | `pl1` | `DemoLocalPl1!` | PASS |
-| Dev | `dev1` | `DemoLocalDev1!` | PASS |
-| Tester | `tester1` | `DemoLocalTester1!` | PASS |
+| 항목 | 조치 |
+| --- | --- |
+| 로그인 초기 입력 불편 | 창 open/activate 시 로그인 ID 입력 필드로 포커스 요청을 보강 |
+| 이슈 상세 헤더 가독성 | 사람이 읽는 제목을 우선 배치하고 issue id는 보조 메타데이터로 이동 |
+| 버튼/테이블 기본 스타일 | 주요 버튼과 테이블 헤더의 색상, 테두리, 높이 기준을 통일 |
+| 테이블 헤더 null 가능성 | 공통 스타일 helper에서 header 존재 여부를 확인 |
+| 화면별 테이블 조작 | 컬럼 드래그 재정렬을 비활성화해 시연 중 표 구조가 흔들리지 않게 정리 |
 
-## QA Case Results
+## 확인 계정
 
-| ID | Role | Screen | Data State | Risk Type | Result | Evidence | Defect |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| SW-QA-ENV-001 | System | Startup | DB unavailable and DB available | environment | PASS | Missing-env failure screen and DB-backed admin dashboard verified |  |
-| SW-QA-AUTH-001 | Admin/PL/Dev/Tester | Login | valid and invalid credentials | session/focus | PARTIAL | Login screen, invalid credential message, admin dashboard, PL/Dev/Tester project list captures; focus fallback was added, but OS-level mouse click focus was still not proven in WSLg Robot run | SW-QA-GAP-002 |
-| SW-QA-ADMIN-001 | Admin | Dashboard/account/project | normal seed + QA account/project | route/refresh/mutation | PASS | Admin dashboard, account create/duplicate/rename/role/deactivate/activate, project create/rename/description/member add-remove/failure captures |  |
-| SW-QA-PL-001 | PL | Issue list/detail/deleted management/statistics | Project A seed + QA issue | workflow/search/register/edit/priority/assignment/comment/dependency/delete/statistics | PASS | PL issue register/detail/edit/priority/assign/comment/dependency, close/reopen, deleted issue restore/purge, statistics full/filter/invalid-range captures; issue id now renders as secondary metadata |  |
-| SW-QA-DEV-001 | Dev | Issue detail | QA assigned issue | status/comment/permission | PASS | Dev mark fixed, own comment add/edit/delete, and post-reject mark fixed captures |  |
-| SW-QA-TESTER-001 | Tester | Issue detail | QA fixed issue | resolve/reject/permission | PASS | Tester reject-to-assigned and resolve-to-resolved captures |  |
-| SW-QA-CROSS-001 | All | Navigation/dialogs | back/deleted navigation/logout visibility | worker/navigation | PASS component-level | Admin/PL/Dev/Tester back and logout paths, role switching, duplicate-submit double-clicks, and dialog cancel/window-close paths executed with WSL offscreen rendered evidence; native mouse/keyboard interaction not covered | SW-QA-GAP-002 |
-| SW-QA-VISUAL-001 | All | Main screens | long text/1280x900 and 800x600 windows | visual | PARTIAL | Main tables, errors, disabled states, action groups, dialog forms, and long Korean/English text render; issue id no longer pushes the title out of the header; button/table chrome was improved, but final presentation polish still needs a target-desktop pass | SW-QA-DEF-002 |
-| SW-QA-ARCH-001 | Code | Swing package | policy boundary | architecture | PASS | `rg` checks found no production Swing persistence/JDBC dependency; enum display and `availableActions` rendering are UI concerns; `not configured` guards are composition/test guard paths |  |
-
-## Capture And Interaction Log
-
-| ID | App Target | Screen | Action | Observation | Screenshot |
-| --- | --- | --- | --- | --- | --- |
-| MAC-STARTUP-FAIL | `Main` / `net.java.openjdk.java` | Startup failure | Desktop app inspection | Java process was visible, but native app-state capture could not inspect the Swing window reliably; screenshot fallback used | `docs/qa/artifacts/swing-2026-06-01/SW-QA-ENV-001-startup-failure.png` |
-| MAC-PACKAGED-APP | `IssueTrackerQA` / `com.github.marcellokim.issuetracker.qa2` | Login | `jpackage` app image launch | Packaged app fixed display name and bundle id for manual and accessibility-assisted smoke checks |  |
-| MAC-AUTH-ADMIN | `IssueTrackerQA` | Admin dashboard | Accessibility-assisted text input and `Return` | `admin` authenticated and dashboard loaded with project/user tables | `docs/qa/artifacts/swing-2026-06-01/SW-QA-AUTH-001-admin-dashboard.png` |
-| WSL-GUI-TOOLS | WSLg/X11 | Automation preflight | `command -v` checks | WSLg was available, but common X11 screenshot/input tools were not installed |  |
-| WSL-SCREENSHOT | WSLg/Windows desktop | Login | Java Robot and Windows desktop capture attempts | Both routes produced black captures, so they were discarded as invalid evidence |  |
-| WSL-OFFSCREEN | Swing JVM | Role smoke | same-JVM `SwingAppFrame` + `BufferedImage` `printAll` | Captured DB-backed rendered states for invalid login, admin, PL, Dev, and Tester | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-AUTH-001-login-offscreen.png` |
-| WSL-MUTATION | Swing JVM | Core workflows | same-JVM Swing component clicks + scripted prompts | Executed account/project/admin mutations and PL/Dev/Tester issue workflow mutations against Oracle | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-025-statistics-invalid-range-offscreen.png` |
-| WSL-CROSS | Swing JVM | Cross-cutting workflows | same-JVM Swing component clicks + real dialog captures | Executed back/re-enter/logout, duplicate-submit double-click, cancel/window-close, and 800x600 long-text visual cases | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-045-minimum-long-issue-detail-offscreen.png` |
-| WSL-ROBOT-FOCUS | Swing JVM on WSLg | Login | `java.awt.Robot` coordinate click and key typing probe | Login ID field did not receive focus after native coordinate click even after focus fallback; focus owner stayed `<none>` and requestFocusInWindow returned `false`, so WSLg Robot cannot prove manual click behavior | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ROBOT-002-login-id-click-no-focus.png` |
-
-## Test Data Ledger
-
-| Type | Identifier | Created By | Used In | Cleanup |
-| --- | --- | --- | --- | --- |
-| Account | `qauser1` -> `QA User Renamed`, final role `TESTER`, active `Yes` | Admin | SW-QA-ADMIN-001 | Local QA DB; reset by `oracleLocalResetFixedSeed` |
-| Project | `QA Project 2026` -> `QA Project Renamed`, description `QA project updated description` | Admin | SW-QA-ADMIN-001 | Local QA DB; reset by `oracleLocalResetFixedSeed` |
-| Project member | `dev1` added to and removed from `QA Project Renamed`; active removal from Project A rejected | Admin | SW-QA-ADMIN-001 | Local QA DB; reset by `oracleLocalResetFixedSeed` |
-| Issue | `QA PL issue 2026-06-01` -> `QA PL issue 2026-06-01 updated`, issue id visible as generated `ISSUE-*` | PL | SW-QA-PL-001, SW-QA-DEV-001, SW-QA-TESTER-001 | Preserved in final local QA DB as `REOPENED`; reset by `oracleLocalResetFixedSeed` |
-| Comment/history | `QA PL comment`, `QA fixed`, `QA reject`, `QA fixed after reject`, `QA resolved`, `QA close`, `QA reopen` | PL/Dev/Tester | Workflow status and comment evidence | Local QA DB; reset by `oracleLocalResetFixedSeed` |
-| Comment | `QA dev own comment` -> `QA dev own comment edited` -> deleted | Dev | SW-QA-DEV-001 | Local QA DB; reset by `oracleLocalResetFixedSeed` |
-| Dependency | Blocking issue id `3` added to and removed from the QA issue | PL | SW-QA-PL-001 | Removed during QA run |
-| Deleted issue | Seed issue `Statistics chart label overflow` restored, deleted again, then purged | PL | SW-QA-PL-001 | Purged during QA run |
-| Cross-click issue | `QA double action 2026-06-01` -> `QA double action updated once 2026-06-01` | PL/Dev | SW-QA-CROSS-001 | Local QA DB; reset by `oracleLocalResetFixedSeed` |
-| Long visual issue | Korean/English long title and comment data | PL | SW-QA-VISUAL-001 | Local QA DB; reset by `oracleLocalResetFixedSeed` |
-
-## Workflow State Coverage
-
-| State | Required UI Check | Result | Evidence |
-| --- | --- | --- | --- |
-| NEW | PL can edit, change priority, assign, comment, and manage dependency when allowed | PASS | `WSL-SW-QA-PL-011-new-detail-offscreen.png`, `WSL-SW-QA-PL-012-issue-edited-offscreen.png`, `WSL-SW-QA-PL-013-priority-changed-offscreen.png`, `WSL-SW-QA-PL-014-assigned-offscreen.png` |
-| ASSIGNED | Dev can mark fixed; PL can see assignment actions | PASS | `WSL-SW-QA-PL-014-assigned-offscreen.png`, `WSL-SW-QA-DEV-010-mark-fixed-offscreen.png` |
-| FIXED | Tester can reject and resolve | PASS | `WSL-SW-QA-TESTER-011-rejected-offscreen.png`, `WSL-SW-QA-TESTER-010-resolved-offscreen.png` |
-| RESOLVED | PL can close where allowed | PASS | `WSL-SW-QA-PL-018-closed-offscreen.png` |
-| CLOSED | PL can reopen/delete where allowed | PASS | `WSL-SW-QA-PL-018-closed-offscreen.png`, `WSL-SW-QA-PL-020-soft-deleted-offscreen.png` |
-| REOPENED | PL can see assignment/edit actions again | PASS | `WSL-SW-QA-PL-019-reopened-offscreen.png` |
-| DELETED | PL can restore and purge from deleted management | PASS | `WSL-SW-QA-PL-020-soft-deleted-offscreen.png`, `WSL-SW-QA-PL-021-restored-offscreen.png`, `WSL-SW-QA-PL-022-purged-offscreen.png` |
-
-## Phase Gates
-
-| Phase | Status | Decision |
+| Role | Login ID | Password |
 | --- | --- | --- |
-| Phase 1 - preflight/startup | PASS | Continue with role smoke on DB-backed packaged Swing app |
-| Phase 2 - role smoke | PASS component-level / PARTIAL OS-level | Admin, PL, Dev, Tester valid login and invalid login failure verified by component/AX automation; native mouse click focus remains unproven after focus fallback |
-| Phase 3 - workflow depth | PASS | Admin account/project mutation and PL/Dev/Tester issue mutation flows executed against Oracle |
-| Phase 4 - cross-cutting and visual | PASS component-level / PARTIAL OS-level | Navigation, role switching, duplicate-submit double-click handling, dialog cancel/window-close, disabled states, and 800x600 long-text render verified through component-level/offscreen evidence; issue id/title layout and button/table chrome improved; native mouse/keyboard and final visual polish still need target desktop pass |
-| Phase 5 - architecture and routing | PASS | Swing package boundary checks completed by `rg` spot checks and production path review |
+| Admin | `admin` | `DemoLocalAdmin!` |
+| PL | `pl1` | `DemoLocalPl1!` |
+| Dev | `dev1` | `DemoLocalDev1!` |
+| Tester | `tester1` | `DemoLocalTester1!` |
 
-## Visual QA Notes
+## 주요 시나리오
 
-| Area | Finding | Evidence | Follow-up |
+| ID | 화면 | 확인 내용 | 결과 |
 | --- | --- | --- | --- |
-| Login mouse focus | Focus fallback was added for mouse press/release, window open, and window activation, but the current WSLg run still cannot prove native click-to-focus; `Robot` coordinate click left focus owner as `<none>`. A minimal Swing `JTextField` probe failed the same way, so this is a target-desktop retest gate rather than a completed pass. | `WSL-SW-QA-ROBOT-002-login-id-click-no-focus.png` | Re-run on the presentation target OS with manual mouse capture or a working OS automation tool |
-| Issue detail title | Fixed in this QA pass: human-readable title renders first, and generated issue id moved to a secondary metadata line. Very long titles still ellipsize at 800px, which is acceptable if the title starts visible. | `WSL-SW-QA-PL-011-new-detail-offscreen.png`, `WSL-SW-QA-PL-012-issue-edited-offscreen.png`, `WSL-SW-QA-CROSS-045-minimum-long-issue-detail-offscreen.png` | No further blocker; optional tooltip/manual copy affordance can be added later |
-| Native Swing polish | Button gradients and table headers were improved in this branch; screens are now cleaner but still presentation-utilitarian, with dense tables and large blank panels on some views. | `WSL-SW-QA-AUTH-003-admin-dashboard-offscreen.png`, `WSL-SW-QA-PL-001-issue-list-offscreen.png`, `WSL-SW-QA-PL-025-statistics-invalid-range-offscreen.png` | Target-desktop pass should confirm spacing hierarchy, selected/focus states, and disabled-action affordance |
-| Dialogs | Dialogs are usable and cancel/window-close paths work, but forms inherit native default styling and are visually detached from the main screen language. | `WSL-SW-QA-CROSS-020-account-create-cancel-dialog.png`, `WSL-SW-QA-CROSS-035-edit-cancel-dialog.png` | Accept for functional submission or wrap key dialogs in project-styled panels if time allows |
+| SW-QA-ENV-001 | Startup | DB env 누락 시 오류 안내, 정상 env 시 앱 기동 | 통과 |
+| SW-QA-AUTH-001 | Login | 유효/무효 로그인, 비밀번호 초기화, 역할별 진입 | 부분 통과 |
+| SW-QA-ADMIN-001 | Admin | 계정 생성/중복/수정/비활성화/활성화, 프로젝트 생성/수정/멤버 변경 | 통과 |
+| SW-QA-PL-001 | PL Issue | 이슈 등록/조회/수정/우선순위/배정/댓글/의존성 | 통과 |
+| SW-QA-PL-002 | Deleted Issue | 삭제 이슈 조회, restore, purge | 통과 |
+| SW-QA-PL-003 | Statistics | 전체/필터/잘못된 기간 입력 | 통과 |
+| SW-QA-DEV-001 | Dev Issue | mark fixed, 댓글 추가/수정/삭제 | 통과 |
+| SW-QA-TESTER-001 | Tester Issue | reject, resolve | 통과 |
+| SW-QA-CROSS-001 | Navigation | 뒤로가기, 로그아웃 후 역할 전환 | 통과 |
+| SW-QA-CROSS-002 | Dialog | 등록/수정/배정/댓글/상태 변경 dialog 취소와 창 닫기 | 통과 |
+| SW-QA-CROSS-003 | Duplicate submit | 주요 action button 연속 클릭 시 중복 실행 방지 | 통과 |
+| SW-QA-VISUAL-001 | Layout | 1024x768 기본 크기와 800x600 최소 크기에서 주요 화면 렌더링 | 부분 통과 |
 
-## Defects
+## 자동화 한계
 
-| ID | Severity | Title | Linked PR/Issue | Status |
-| --- | --- | --- | --- | --- |
-| SW-QA-DEF-001 | Medium | Issue detail header displayed long issue hash first, causing the human-readable title to be truncated at 1280x900 |  | Fixed in local QA branch |
-| SW-QA-DEF-002 | Low | Swing screens still need final presentation polish review for dense tables, disabled-action rows, and large empty areas |  | Improved in local QA branch; residual polish open |
-| SW-QA-GAP-001 | Low | WSLg OS-level screenshot automation unavailable without additional X11 capture tools or manual desktop capture support |  | Documented |
-| SW-QA-GAP-002 | Medium | Native mouse click and keyboard typing cannot be claimed complete from current WSLg run; Robot click on login ID field did not focus the window/component after local focus fallback |  | Documented; target desktop retest required |
+WSL2/WSLg에서는 X11 캡처 도구가 없고 `java.awt.Robot` 좌표 클릭도 최소 Swing `JTextField`에서 포커스를 획득하지 못했다. 따라서 이번 문서는 네이티브 마우스 클릭을 완료로 주장하지 않는다.
 
-## Target Desktop Retest Gate
+발표 전 아래 항목은 실제 발표 장비에서 짧게 다시 확인한다.
 
-This QA run does not close native mouse/keyboard behavior because WSLg `Robot` also fails on a minimal standalone Swing `JTextField`. Before release or demo, run the following on the actual presentation desktop.
+| ID | 확인 항목 | 기대 결과 |
+| --- | --- | --- |
+| TDT-FOCUS-001 | Login ID 필드를 마우스로 클릭 후 `admin` 입력 | 첫 클릭 후 caret이 보이고 입력값이 ID 필드에 들어감 |
+| TDT-FOCUS-002 | Password 필드를 마우스로 클릭 후 비밀번호 입력 | 비밀번호 필드가 입력을 받음 |
+| TDT-FOCUS-003 | `Sign in` 버튼을 마우스로 클릭 | Admin dashboard로 이동 |
+| TDT-VISUAL-001 | Login, Admin, PL issue list/detail, Statistics 화면 육안 확인 | 텍스트 겹침, 주요 버튼 잘림, 읽을 수 없는 disabled 상태 없음 |
+| TDT-VISUAL-002 | 800x600에서 긴 제목/상세 화면 확인 | 제목 시작부가 보이고 필요한 영역은 스크롤 가능 |
 
-| ID | Required Check | Expected Result | Evidence |
-| --- | --- | --- | --- |
-| TDT-FOCUS-001 | Open Swing app, click directly inside `ID`, type `admin` | First click places caret in `ID`; typed text appears in `ID` without using Tab | Screen recording or screenshot sequence |
-| TDT-FOCUS-002 | Click directly inside `Password`, type `DemoLocalAdmin!` | First click places caret in `Password`; password field receives input | Screen recording or screenshot sequence |
-| TDT-FOCUS-003 | Click `Sign in` with mouse | Admin dashboard opens without pressing Enter | Dashboard screenshot |
-| TDT-FOCUS-004 | Repeat invalid login with mouse-only field selection and button click | Error message is visible and password clears | Login error screenshot |
-| TDT-VISUAL-001 | Inspect login, admin dashboard, PL issue list/detail, statistics at default window size | No overlap, clipped primary text, unreachable button, or unreadable disabled state | Screenshots |
-| TDT-VISUAL-002 | Resize to the documented minimum `800x600` and inspect long title/detail case | Primary title remains visible; scrolling works where content exceeds height | Screenshot |
-
-Gate decision: any failed `TDT-FOCUS-*` item is release-blocking for Swing. `TDT-VISUAL-*` failures are blocking only when text is unreadable, controls are clipped, or the normal workflow becomes unreachable.
-
-## Command Log
+## 실행 명령
 
 ```text
-$ git status --short --branch
-## test/248-swing-full-qa...origin/dev
-
-$ git rev-parse --short=12 origin/dev
-e82afe057280
-
-$ gh pr list --repo marcellokim/se-issue-tracker --state open --limit 100 --json number,title,isDraft,headRefName,baseRefName,labels,updatedAt
-[]
-
-$ ./gradlew check verifySubmissionMetadata --console=plain
-BUILD SUCCESSFUL in 33s
-oracleIntegrationTest SKIPPED
-
-$ git fetch origin dev --prune && git rev-parse --short=12 origin/dev
-e82afe057280
-
-$ gh api --method GET repos/marcellokim/se-issue-tracker/pulls --paginate -f state=open -f per_page=100 --jq '.[] | select(([.labels[].name] | index("area:ui")) or (.title | test("Swing"))) | {number,title,draft,head:.head.ref,base:.base.ref,sha:.head.sha}'
-<no rows>
-
-$ rg -n "admin|pl1|dev1|tester1|DemoLocal" docs/oracleDB-seed-password.md
-16:| `admin` | `DemoLocalAdmin!` |
-17:| `pl1` | `DemoLocalPl1!` |
-19:| `dev1` ~ `dev10` | `DemoLocalDev1!` ~ `DemoLocalDev10!` |
-20:| `tester1` ~ `tester5` | `DemoLocalTester1!` ~ `DemoLocalTester5!` |
-
-$ ./gradlew oracleLocalStatus --console=plain
-BUILD SUCCESSFUL in 541ms
-Docker CLI: available
-Docker Compose: available
-JDBC URL: jdbc:oracle:thin:@//localhost:1521/FREEPDB1
-failed to connect to the docker API at unix:///Users/ydmac/.colima/default/docker.sock
-container state: not created
-
-$ colima start
-Current context is now "colima"
-done
-
-$ ./gradlew oracleLocalInitializeDatabase --console=plain
-Executed 33 blocks from db/oracle/schema-oracle.sql
-Oracle application data reused without seed reset.
-Oracle application database check completed.
-BUILD SUCCESSFUL in 1m 3s
-
-$ jpackage --type app-image --name IssueTrackerQA ...
-<app image created at /Users/ydmac/Applications/IssueTrackerQA.app>
-
-$ accessibility-assisted login as admin
-windows=1
-titles=Admin dashboard
-Admin (ADMIN)
-
-$ git fetch origin dev test/248-swing-full-qa --prune && git rev-parse --short=12 origin/dev && git rev-parse --short=12 HEAD && git status --short --branch
-816117349a1f
-cf6cf5e3059e
-## test/248-swing-full-qa...origin/test/248-swing-full-qa
-
-$ printf 'DISPLAY=%s\nWAYLAND_DISPLAY=%s\n' "$DISPLAY" "$WAYLAND_DISPLAY"; ls -ld /mnt/wslg /tmp/.X11-unix/X0
-DISPLAY=:0
-WAYLAND_DISPLAY=wayland-0
-/mnt/wslg present
-/tmp/.X11-unix/X0 present
-
-$ for c in xdotool wmctrl scrot import gnome-screenshot xwd xprop xwininfo xdpyinfo; do command -v "$c" || echo "$c=missing"; done
-xdotool=missing
-wmctrl=missing
-scrot=missing
-import=missing
-gnome-screenshot=missing
-xwd=missing
-xprop=missing
-xwininfo=missing
-xdpyinfo=missing
-
-$ PATH="/tmp/docker-wrapper:$PATH" ./gradlew oracleLocalResetFixedSeed --console=plain
-Oracle schema reset and fixed seed completed.
-BUILD SUCCESSFUL in 3m 8s
-
-$ ITS_DB_URL='jdbc:oracle:thin:@//localhost:1521/FREEPDB1' ITS_DB_USER='ITS_USER' ITS_DB_PASSWORD='ItsLocalDev2026!' PATH="/tmp/docker-wrapper:$PATH" ./gradlew oracleConnectionCheck --console=plain
-Oracle Database connection succeeded.
-ITS Oracle connection OK.
-BUILD SUCCESSFUL in 1s
-
-$ java -cp "/tmp/swing-qa-tools/classes:<runtime-classpath>" com.github.marcellokim.issuetracker.ui.swing.SwingQaCapture docs/qa/artifacts/swing-2026-06-01
-PASS invalid-login message=Invalid ID or password.
-PASS admin-dashboard projects=2
-PASS admin-project-management projects=2
-PASS admin-account-management users=18
-PASS pl-project-list projects=1
-PASS pl-issue-list issues=14 message=14 issues
-PASS pl-deleted-issues rows=0
-PASS pl-issue-detail title=[7b12464fb13eefd341275d986489cc68be1551da56ad3b5f8afbe72879e35efc] Assignment notification not shown
-PASS dev-project-list projects=1
-PASS dev-issue-list issues=1 message=1 issues
-PASS dev-issue-detail title=[2fea689c8d29ec9bf36c8eb73a69064a045aac1bb54e3eaa7ced9cd7d11d9c25] Dependency resolution flow blocked
-PASS tester-project-list projects=1
-PASS tester-issue-list issues=6 message=6 issues
-PASS tester-issue-detail title=[26f1ad37d100a4f6215564b8a7ae2d2fe328e2186fd95b5c664a0904650f27b5] Session timeout warning absent
-
-$ ./gradlew test --tests 'com.github.marcellokim.issuetracker.ui.swing.*' --console=plain
-BUILD SUCCESSFUL in 18s
-
-$ ITS_DB_URL="jdbc:oracle:thin:@//localhost:1521/FREEPDB1" ITS_DB_USER="ITS_USER" ITS_DB_PASSWORD="ItsLocalDev2026!" ./gradlew oracleLocalResetFixedSeed --console=plain
-Oracle schema reset and fixed seed completed.
-BUILD SUCCESSFUL in 1m 10s
-
-$ java -cp "/tmp/swing-qa-tools/classes:<runtime-classpath>" com.github.marcellokim.issuetracker.ui.swing.SwingQaCapture docs/qa/artifacts/swing-2026-06-01
-PASS invalid-login message=Invalid ID or password.
-PASS admin-dashboard projects=2
-PASS admin-project-management projects=2
-PASS admin-account-management users=18
-PASS pl-project-list projects=1
-PASS pl-issue-list issues=14 message=14 issues
-PASS pl-deleted-issues rows=0
-PASS pl-issue-detail title=Assignment notification not shown
-PASS dev-project-list projects=1
-PASS dev-issue-list issues=1 message=1 issues
-PASS dev-issue-detail title=Dependency resolution flow blocked
-PASS tester-project-list projects=1
-PASS tester-issue-list issues=6 message=6 issues
-
-$ ITS_DB_URL="jdbc:oracle:thin:@//localhost:1521/FREEPDB1" ITS_DB_USER="ITS_USER" ITS_DB_PASSWORD="ItsLocalDev2026!" ./gradlew oracleLocalResetFixedSeed --console=plain
-Oracle schema reset and fixed seed completed.
-BUILD SUCCESSFUL in 1m 10s
-
-$ java -cp "/tmp/swing-qa-tools/classes:<runtime-classpath>" com.github.marcellokim.issuetracker.ui.swing.SwingQaInteractionCapture docs/qa/artifacts/swing-2026-06-01
-PASS admin-account-mutations qauser1 create/duplicate/rename/role/deactivate/activate
-PASS admin-project-mutations project create/rename/description/member add-remove/failure
-PASS pl-statistics full/filter/invalid-range
-PASS issue-workflow-mutations qaIssueId=31
-PASS cross-navigation back/re-enter/logout/role-switch
-PASS cross-duplicate-submit login/search/register/action buttons
-PASS cross-dialog-cancel-window-close
-PASS cross-minimum-visual long Korean/English issue rendered at 800x600
-PASS cross-cutting navigation/double-click/cancel/minimum-visual
-PASS architecture-spot-checks deferred-to-command-log
-
-$ rg -n "repository|persistence|jdbc|DataSource|Connection|PreparedStatement" src/main/java/com/github/marcellokim/issuetracker/ui/swing src/test/java/com/github/marcellokim/issuetracker/ui/swing
-Production Swing package: no matches. Test package: repository imports only for fixture/controller construction.
-
-$ rg -n "Role\\.|IssueStatus\\.|Priority\\.|can[A-Z]|availableActions|user\\.role\\(\\)" src/main/java/com/github/marcellokim/issuetracker/ui/swing
-Matches are display labels, enum selectors, presenter/controller-derived `canRegisterIssue`, comment action state, and `availableActions`-driven button rendering.
-
-$ rg -n "PlaceholderPanel|showPlaceholder|Issue action|not configured|UnsupportedOperationException" src/main/java/com/github/marcellokim/issuetracker/ui/swing src/test/java/com/github/marcellokim/issuetracker/ui/swing
-No placeholder routes. `not configured` matches are constructor/composition guard paths for assignment, statistics, deleted issue, and issue state controllers.
-
-$ ./gradlew test --tests 'com.github.marcellokim.issuetracker.ui.swing.*' --console=plain
-BUILD SUCCESSFUL in 14s
-
-$ ./gradlew check verifySubmissionMetadata --console=plain
-BUILD SUCCESSFUL in 24s
-
-$ git diff --check
-git diff --check produced no output.
-
-$ java -cp "/tmp/swing-qa-tools/classes:<runtime-classpath>" com.github.marcellokim.issuetracker.ui.swing.SwingQaRobotFocusCapture docs/qa/artifacts/swing-2026-06-01
-FAIL robot-click-focus loginId focusOwner=<none>
-FAIL dispatched-click-focus loginId focusOwner=<none>
-INFO requestFocusInWindow loginId=false focusOwner=<none>
-Exception in thread "main" java.lang.IllegalStateException: Timed out waiting for Swing state
-
-$ javac /tmp/swing-focus-probe/MinimalFocusProbe.java && java -cp /tmp/swing-focus-probe MinimalFocusProbe
-FAIL minimal JTextField focus owner=<none>
+git fetch origin dev --prune
+./gradlew check verifySubmissionMetadata --console=plain
+./gradlew oracleLocalResetFixedSeed --console=plain
+./gradlew oracleConnectionCheck --console=plain
+./gradlew test --tests 'com.github.marcellokim.issuetracker.ui.swing.*' --console=plain
+git diff --check
 ```
 
-## Local Screenshot Index
+## 남은 리스크
 
-The `WSL-SW-QA-*.png` entries below document locally generated evidence from this QA run. They are not intended to be committed; reproduce them from the command log when fresh visual evidence is needed.
-
-| Screenshot | Scenario | Path |
-| --- | --- | --- |
-| SW-QA-ENV-001-startup-failure.png | Missing Oracle env startup failure | `docs/qa/artifacts/swing-2026-06-01/SW-QA-ENV-001-startup-failure.png` |
-| SW-QA-AUTH-001-admin-dashboard.png | Admin valid login dashboard | `docs/qa/artifacts/swing-2026-06-01/SW-QA-AUTH-001-admin-dashboard.png` |
-| WSL-SW-QA-AUTH-001-login-offscreen.png | WSL2 offscreen login form | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-AUTH-001-login-offscreen.png` |
-| WSL-SW-QA-AUTH-002-invalid-login-offscreen.png | WSL2 invalid credential message | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-AUTH-002-invalid-login-offscreen.png` |
-| WSL-SW-QA-AUTH-003-admin-dashboard-offscreen.png | WSL2 admin dashboard | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-AUTH-003-admin-dashboard-offscreen.png` |
-| WSL-SW-QA-ADMIN-001-project-management-offscreen.png | WSL2 admin project management | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-001-project-management-offscreen.png` |
-| WSL-SW-QA-ADMIN-002-account-management-offscreen.png | WSL2 admin account management | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-002-account-management-offscreen.png` |
-| WSL-SW-QA-AUTH-004-pl-project-list-offscreen.png | WSL2 PL project list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-AUTH-004-pl-project-list-offscreen.png` |
-| WSL-SW-QA-PL-001-issue-list-offscreen.png | WSL2 PL issue list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-001-issue-list-offscreen.png` |
-| WSL-SW-QA-PL-002-deleted-issues-offscreen.png | WSL2 PL deleted issue management | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-002-deleted-issues-offscreen.png` |
-| WSL-SW-QA-PL-003-issue-detail-offscreen.png | WSL2 PL issue detail | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-003-issue-detail-offscreen.png` |
-| WSL-SW-QA-AUTH-005-dev-project-list-offscreen.png | WSL2 Dev project list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-AUTH-005-dev-project-list-offscreen.png` |
-| WSL-SW-QA-DEV-001-issue-list-offscreen.png | WSL2 Dev issue list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-DEV-001-issue-list-offscreen.png` |
-| WSL-SW-QA-DEV-002-issue-detail-offscreen.png | WSL2 Dev issue detail | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-DEV-002-issue-detail-offscreen.png` |
-| WSL-SW-QA-AUTH-006-tester-project-list-offscreen.png | WSL2 Tester project list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-AUTH-006-tester-project-list-offscreen.png` |
-| WSL-SW-QA-TESTER-001-issue-list-offscreen.png | WSL2 Tester issue list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-TESTER-001-issue-list-offscreen.png` |
-| WSL-SW-QA-TESTER-002-issue-detail-offscreen.png | WSL2 Tester issue detail | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-TESTER-002-issue-detail-offscreen.png` |
-| WSL-SW-QA-ADMIN-010-account-create-blank-offscreen.png | Admin blank account creation rejected | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-010-account-create-blank-offscreen.png` |
-| WSL-SW-QA-ADMIN-011-account-created-offscreen.png | Admin account created | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-011-account-created-offscreen.png` |
-| WSL-SW-QA-ADMIN-012-account-mutated-offscreen.png | Admin account renamed, role changed, activated | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-012-account-mutated-offscreen.png` |
-| WSL-SW-QA-ADMIN-013-project-create-blank-offscreen.png | Admin blank project creation rejected | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-013-project-create-blank-offscreen.png` |
-| WSL-SW-QA-ADMIN-014-project-mutated-offscreen.png | Admin project created, renamed, description changed | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-014-project-mutated-offscreen.png` |
-| WSL-SW-QA-ADMIN-015-project-member-add-remove-offscreen.png | Admin project member add/remove | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-015-project-member-add-remove-offscreen.png` |
-| WSL-SW-QA-ADMIN-016-project-member-active-remove-failure-offscreen.png | Admin active assignee removal rejected | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ADMIN-016-project-member-active-remove-failure-offscreen.png` |
-| WSL-SW-QA-PL-010-register-refresh-offscreen.png | PL registered QA issue appears in list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-010-register-refresh-offscreen.png` |
-| WSL-SW-QA-PL-011-new-detail-offscreen.png | PL QA issue detail in NEW state | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-011-new-detail-offscreen.png` |
-| WSL-SW-QA-PL-012-issue-edited-offscreen.png | PL edited QA issue title/description | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-012-issue-edited-offscreen.png` |
-| WSL-SW-QA-PL-013-priority-changed-offscreen.png | PL changed priority | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-013-priority-changed-offscreen.png` |
-| WSL-SW-QA-PL-014-assigned-offscreen.png | PL assigned dev/verifier | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-014-assigned-offscreen.png` |
-| WSL-SW-QA-PL-015-comment-added-offscreen.png | PL comment added | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-015-comment-added-offscreen.png` |
-| WSL-SW-QA-PL-016-dependency-added-offscreen.png | PL dependency added | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-016-dependency-added-offscreen.png` |
-| WSL-SW-QA-PL-017-dependency-removed-offscreen.png | PL dependency removed | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-017-dependency-removed-offscreen.png` |
-| WSL-SW-QA-DEV-010-mark-fixed-offscreen.png | Dev marked QA issue fixed | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-DEV-010-mark-fixed-offscreen.png` |
-| WSL-SW-QA-DEV-011-comment-added-offscreen.png | Dev comment added | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-DEV-011-comment-added-offscreen.png` |
-| WSL-SW-QA-DEV-012-comment-edited-offscreen.png | Dev own comment edited | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-DEV-012-comment-edited-offscreen.png` |
-| WSL-SW-QA-DEV-013-comment-deleted-offscreen.png | Dev own comment deleted | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-DEV-013-comment-deleted-offscreen.png` |
-| WSL-SW-QA-TESTER-011-rejected-offscreen.png | Tester rejected fixed issue | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-TESTER-011-rejected-offscreen.png` |
-| WSL-SW-QA-DEV-014-mark-fixed-after-reject-offscreen.png | Dev fixed after tester rejection | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-DEV-014-mark-fixed-after-reject-offscreen.png` |
-| WSL-SW-QA-TESTER-010-resolved-offscreen.png | Tester resolved fixed issue | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-TESTER-010-resolved-offscreen.png` |
-| WSL-SW-QA-PL-018-closed-offscreen.png | PL closed resolved issue | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-018-closed-offscreen.png` |
-| WSL-SW-QA-PL-019-reopened-offscreen.png | PL reopened closed issue | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-019-reopened-offscreen.png` |
-| WSL-SW-QA-PL-020-soft-deleted-offscreen.png | PL soft-deleted seed closed issue | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-020-soft-deleted-offscreen.png` |
-| WSL-SW-QA-PL-021-restored-offscreen.png | PL restored deleted issue | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-021-restored-offscreen.png` |
-| WSL-SW-QA-PL-022-purged-offscreen.png | PL purged deleted issue | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-022-purged-offscreen.png` |
-| WSL-SW-QA-PL-023-statistics-full-offscreen.png | PL statistics all-time | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-023-statistics-full-offscreen.png` |
-| WSL-SW-QA-PL-024-statistics-filtered-offscreen.png | PL statistics filtered | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-024-statistics-filtered-offscreen.png` |
-| WSL-SW-QA-PL-025-statistics-invalid-range-offscreen.png | PL statistics invalid range rejected | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-PL-025-statistics-invalid-range-offscreen.png` |
-| WSL-SW-QA-CROSS-001-admin-navigation-back-offscreen.png | Admin account/project back navigation and logout controls | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-001-admin-navigation-back-offscreen.png` |
-| WSL-SW-QA-CROSS-002-pl-back-reenter-offscreen.png | PL project back and re-enter issue list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-002-pl-back-reenter-offscreen.png` |
-| WSL-SW-QA-CROSS-003-dev-after-pl-logout-offscreen.png | Dev login after PL logout | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-003-dev-after-pl-logout-offscreen.png` |
-| WSL-SW-QA-CROSS-004-tester-after-dev-logout-offscreen.png | Tester login after Dev logout | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-004-tester-after-dev-logout-offscreen.png` |
-| WSL-SW-QA-CROSS-010-double-register-offscreen.png | Duplicate register double-click kept first request only | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-010-double-register-offscreen.png` |
-| WSL-SW-QA-CROSS-011-double-search-offscreen.png | Duplicate search double-click kept list stable | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-011-double-search-offscreen.png` |
-| WSL-SW-QA-CROSS-012-double-edit-offscreen.png | Duplicate edit double-click kept first request only | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-012-double-edit-offscreen.png` |
-| WSL-SW-QA-CROSS-013-double-assignment-offscreen.png | Duplicate assignment double-click kept first request only | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-013-double-assignment-offscreen.png` |
-| WSL-SW-QA-CROSS-014-double-comment-dependency-offscreen.png | Duplicate comment/dependency double-click kept first request only | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-014-double-comment-dependency-offscreen.png` |
-| WSL-SW-QA-CROSS-015-double-status-offscreen.png | Duplicate status double-click kept first request only | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-015-double-status-offscreen.png` |
-| WSL-SW-QA-CROSS-020-account-create-cancel-dialog.png | Account create cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-020-account-create-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-021-account-create-window-close-dialog.png | Account create window-close dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-021-account-create-window-close-dialog.png` |
-| WSL-SW-QA-CROSS-022-account-rename-cancel-dialog.png | Account rename cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-022-account-rename-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-023-account-role-cancel-dialog.png | Account role cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-023-account-role-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-024-account-deactivate-cancel-dialog.png | Account deactivate cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-024-account-deactivate-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-025-account-after-cancel-offscreen.png | Account management state after cancel/window-close actions | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-025-account-after-cancel-offscreen.png` |
-| WSL-SW-QA-CROSS-026-project-create-cancel-dialog.png | Project create cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-026-project-create-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-027-project-create-window-close-dialog.png | Project create window-close dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-027-project-create-window-close-dialog.png` |
-| WSL-SW-QA-CROSS-028-project-rename-cancel-dialog.png | Project rename cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-028-project-rename-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-029-project-description-cancel-dialog.png | Project description cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-029-project-description-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-030-project-delete-cancel-dialog.png | Project delete cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-030-project-delete-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-031-project-after-cancel-offscreen.png | Project management state after cancel/window-close actions | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-031-project-after-cancel-offscreen.png` |
-| WSL-SW-QA-CROSS-032-register-cancel-dialog.png | Issue register cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-032-register-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-033-register-window-close-dialog.png | Issue register window-close dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-033-register-window-close-dialog.png` |
-| WSL-SW-QA-CROSS-034-assignment-cancel-dialog.png | Issue assignment cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-034-assignment-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-035-edit-cancel-dialog.png | Issue edit cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-035-edit-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-036-edit-window-close-dialog.png | Issue edit window-close dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-036-edit-window-close-dialog.png` |
-| WSL-SW-QA-CROSS-037-priority-cancel-dialog.png | Issue priority cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-037-priority-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-038-comment-cancel-dialog.png | Issue comment cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-038-comment-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-039-dependency-cancel-dialog.png | Issue dependency cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-039-dependency-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-040-delete-cancel-dialog.png | Issue delete cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-040-delete-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-041-issue-detail-after-cancel-offscreen.png | Issue detail state after cancel/window-close actions | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-041-issue-detail-after-cancel-offscreen.png` |
-| WSL-SW-QA-CROSS-042-status-cancel-dialog.png | Dev status cancel dialog | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-042-status-cancel-dialog.png` |
-| WSL-SW-QA-CROSS-043-status-after-cancel-offscreen.png | Dev detail state after status cancel | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-043-status-after-cancel-offscreen.png` |
-| WSL-SW-QA-CROSS-044-minimum-long-issue-list-offscreen.png | 800x600 long Korean/English issue list | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-044-minimum-long-issue-list-offscreen.png` |
-| WSL-SW-QA-CROSS-045-minimum-long-issue-detail-offscreen.png | 800x600 long Korean/English issue detail | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-CROSS-045-minimum-long-issue-detail-offscreen.png` |
-| WSL-SW-QA-ROBOT-001-login-initial.png | Robot focus probe initial login screen | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ROBOT-001-login-initial.png` |
-| WSL-SW-QA-ROBOT-002-login-id-click-no-focus.png | Robot coordinate click on login ID did not focus field | `docs/qa/artifacts/swing-2026-06-01/WSL-SW-QA-ROBOT-002-login-id-click-no-focus.png` |
+- 네이티브 마우스/키보드 입력은 WSLg 자동화에서 신뢰 가능한 증거를 얻지 못했으므로 발표 장비에서 수동 확인 필요.
+- Swing 화면은 기능 제출 기준으로 정리되었지만, JavaFX와 동일한 수준의 시각적 완성도를 보장하지는 않는다. 발표에서는 전체 UI 2종 구현과 백엔드 재사용 증명에 초점을 둔다.

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanel.java
@@ -148,30 +148,35 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
         createButton.setName("createAccountButton");
         createButton.addActionListener(event -> dialogs.requestCreate(this)
                 .ifPresent(request -> onCreate.accept(this, request)));
+        SwingStyles.applySecondaryButton(createButton);
         panel.add(createButton);
 
         renameButton.setName("renameAccountButton");
         renameButton.addActionListener(event -> selectedUser().flatMap(user -> dialogs.requestRename(this, user)
                 .map(name -> new RenameRequest(user.loginId(), name)))
                 .ifPresent(request -> onRename.accept(this, request.loginId(), request.name())));
+        SwingStyles.applySecondaryButton(renameButton);
         panel.add(renameButton);
 
         roleButton.setName("changeRoleButton");
         roleButton.addActionListener(event -> selectedUser().flatMap(user -> dialogs.requestRole(this, user)
                 .map(role -> new RoleChangeRequest(user.loginId(), role)))
                 .ifPresent(request -> onRoleChange.accept(this, request.loginId(), request.role())));
+        SwingStyles.applySecondaryButton(roleButton);
         panel.add(roleButton);
 
         activateButton.setName("activateAccountButton");
         activateButton.addActionListener(event -> selectedUser()
                 .filter(user -> dialogs.confirmActivation(this, user, true))
                 .ifPresent(user -> onActivate.accept(this, user.loginId())));
+        SwingStyles.applySecondaryButton(activateButton);
         panel.add(activateButton);
 
         deactivateButton.setName("deactivateAccountButton");
         deactivateButton.addActionListener(event -> selectedUser()
                 .filter(user -> dialogs.confirmActivation(this, user, false))
                 .ifPresent(user -> onDeactivate.accept(this, user.loginId())));
+        SwingStyles.applySecondaryButton(deactivateButton);
         panel.add(deactivateButton);
 
         return panel;
@@ -181,9 +186,9 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
         JTable table = new JTable(userTableModel);
         table.setName("accountUserTable");
         table.setFillsViewportHeight(true);
-        table.setRowHeight(26);
         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         table.getTableHeader().setReorderingAllowed(false);
+        SwingStyles.applyTableStyle(table);
         table.getSelectionModel().addListSelectionListener(event -> {
             if (!event.getValueIsAdjusting()) {
                 updateSelectionActions();

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AccountManagementPanel.java
@@ -187,7 +187,7 @@ final class AccountManagementPanel extends JPanel implements AccountManagementVi
         table.setName("accountUserTable");
         table.setFillsViewportHeight(true);
         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        table.getTableHeader().setReorderingAllowed(false);
+        SwingStyles.disableHeaderReordering(table);
         SwingStyles.applyTableStyle(table);
         table.getSelectionModel().addListSelectionListener(event -> {
             if (!event.getValueIsAdjusting()) {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPanel.java
@@ -114,16 +114,19 @@ final class AdminDashboardPanel extends JPanel implements AdminDashboardView {
         JButton accountButton = new JButton("Account management");
         accountButton.setName("accountManagementButton");
         accountButton.addActionListener(event -> onAccountManagement.run());
+        SwingStyles.applySecondaryButton(accountButton);
         actions.add(accountButton);
 
         JButton projectButton = new JButton("Project management");
         projectButton.setName("projectManagementButton");
         projectButton.addActionListener(event -> onProjectManagement.run());
+        SwingStyles.applySecondaryButton(projectButton);
         actions.add(projectButton);
 
         JButton logoutButton = new JButton("Logout");
         logoutButton.setName("adminLogoutButton");
         logoutButton.addActionListener(event -> onLogout.run());
+        SwingStyles.applySecondaryButton(logoutButton);
         actions.add(logoutButton);
 
         header.add(titles);
@@ -158,9 +161,9 @@ final class AdminDashboardPanel extends JPanel implements AdminDashboardView {
         JTable table = new JTable(model);
         table.setName(name);
         table.setFillsViewportHeight(true);
-        table.setRowHeight(26);
         table.getTableHeader().setReorderingAllowed(false);
         table.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
+        SwingStyles.applyTableStyle(table);
         applyColumnWidths(table, columnWidths);
         return table;
     }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/AdminDashboardPanel.java
@@ -161,7 +161,7 @@ final class AdminDashboardPanel extends JPanel implements AdminDashboardView {
         JTable table = new JTable(model);
         table.setName(name);
         table.setFillsViewportHeight(true);
-        table.getTableHeader().setReorderingAllowed(false);
+        SwingStyles.disableHeaderReordering(table);
         table.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         SwingStyles.applyTableStyle(table);
         applyColumnWidths(table, columnWidths);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssuePanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/DeletedIssuePanel.java
@@ -136,11 +136,13 @@ final class DeletedIssuePanel extends JPanel implements DeletedIssueView {
         restoreButton.setName("restoreDeletedIssueButton");
         restoreButton.addActionListener(event -> selectedIssue()
                 .ifPresent(issue -> actions.onRestore().accept(this, issue)));
+        SwingStyles.applySecondaryButton(restoreButton);
         panel.add(restoreButton);
 
         purgeButton.setName("purgeDeletedIssueButton");
         purgeButton.addActionListener(event -> selectedIssue()
                 .ifPresent(issue -> actions.onPurge().accept(this, issue)));
+        SwingStyles.applySecondaryButton(purgeButton);
         panel.add(purgeButton);
         return panel;
     }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
@@ -75,6 +75,7 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
 
     private final transient IssueDetailActions actions;
     private final JLabel titleLabel = new JLabel("Issue");
+    private final JLabel issueIdLabel = new JLabel(" ");
     private final JLabel stateLabel = new JLabel(" ");
     private final JLabel userLabel;
     private final JLabel descriptionLabel = new JLabel(" ");
@@ -135,7 +136,10 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         Objects.requireNonNull(projectDependencies, "projectDependencies");
         Map<String, IssueCommentActionState> commentActionById = commentActionById(commentActions);
         runOnEdt(() -> {
-            titleLabel.setText("[" + detail.issueId() + "] " + detail.title());
+            titleLabel.setText(detail.title());
+            titleLabel.setToolTipText(detail.title());
+            issueIdLabel.setText("Issue ID: " + detail.issueId());
+            issueIdLabel.setToolTipText(detail.issueId());
             stateLabel.setText(detail.status() + " / " + detail.priority());
             descriptionLabel.setText(detail.description());
             currentTitle = detail.title();
@@ -204,11 +208,12 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         logoutButton.setName("issueDetailLogoutButton");
         logoutButton.addActionListener(event -> actions.onLogout().run());
         configureHeaderLabel(titleLabel, "issueDetailTitle", true);
+        configureHeaderLabel(issueIdLabel, "issueDetailIssueId", false);
         configureHeaderLabel(stateLabel, "issueDetailState", false);
         configureHeaderLabel(userLabel, "issueDetailUser", false);
         configureHeaderLabel(messageLabel, "issueDetailMessage", false);
         return SwingPanelSections.navigationHeader(
-                List.of(titleLabel, stateLabel, userLabel, messageLabel),
+                List.of(titleLabel, issueIdLabel, stateLabel, userLabel, messageLabel),
                 List.of(backButton, logoutButton));
     }
 
@@ -265,6 +270,7 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
             JButton button = new JButton(spec.label());
             button.setName("issueActionButton_" + spec.action());
             button.addActionListener(event -> publishAction(spec.action()));
+            SwingStyles.applySecondaryButton(button);
             actionButtons.put(spec.action(), button);
             buttons.add(button);
         }
@@ -288,6 +294,9 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         addCommentButton.setName("addCommentButton");
         editCommentButton.setName("editCommentButton");
         deleteCommentButton.setName("deleteCommentButton");
+        SwingStyles.applySecondaryButton(addCommentButton);
+        SwingStyles.applySecondaryButton(editCommentButton);
+        SwingStyles.applySecondaryButton(deleteCommentButton);
         buttons.add(addCommentButton);
         buttons.add(editCommentButton);
         buttons.add(deleteCommentButton);
@@ -315,6 +324,8 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         buttons.setOpaque(false);
         addDependencyButton.setName("addDependencyButton");
         removeDependencyButton.setName("removeDependencyButton");
+        SwingStyles.applySecondaryButton(addDependencyButton);
+        SwingStyles.applySecondaryButton(removeDependencyButton);
         buttons.add(addDependencyButton);
         buttons.add(removeDependencyButton);
         header.add(buttons, BorderLayout.EAST);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanel.java
@@ -174,11 +174,13 @@ final class IssueListPanel extends JPanel implements IssueListView {
         JButton backButton = new JButton("Back");
         backButton.setName("issueListBackButton");
         backButton.addActionListener(event -> actions.onBack().run());
+        SwingStyles.applySecondaryButton(backButton);
         nav.add(backButton);
 
         JButton logoutButton = new JButton("Logout");
         logoutButton.setName("issueListLogoutButton");
         logoutButton.addActionListener(event -> actions.onLogout().run());
+        SwingStyles.applySecondaryButton(logoutButton);
         nav.add(logoutButton);
 
         header.add(titles, BorderLayout.CENTER);
@@ -207,24 +209,29 @@ final class IssueListPanel extends JPanel implements IssueListView {
 
         searchButton.setName("searchIssuesButton");
         searchButton.addActionListener(event -> actions.onSearch().accept(this, currentSearchRequest()));
+        SwingStyles.applySecondaryButton(searchButton);
         panel.add(searchButton);
 
         registerButton.setName("registerIssueButton");
         registerButton.addActionListener(event -> dialogs.requestRegister(this)
                 .ifPresent(request -> actions.onRegister().accept(this, request)));
+        SwingStyles.applySecondaryButton(registerButton);
         panel.add(registerButton);
 
         openButton.setName("openIssueDetailButton");
         openButton.addActionListener(event -> selectedIssue()
                 .ifPresent(issue -> actions.onOpenIssue().accept(issue.id())));
+        SwingStyles.applySecondaryButton(openButton);
         panel.add(openButton);
 
         deletedIssuesButton.setName("deletedIssuesButton");
         deletedIssuesButton.addActionListener(event -> actions.onDeletedIssues().run());
+        SwingStyles.applySecondaryButton(deletedIssuesButton);
         panel.add(deletedIssuesButton);
 
         statisticsButton.setName("statisticsButton");
         statisticsButton.addActionListener(event -> actions.onStatistics().run());
+        SwingStyles.applySecondaryButton(statisticsButton);
         panel.add(statisticsButton);
         return panel;
     }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
@@ -2,6 +2,9 @@ package com.github.marcellokim.issuetracker.ui.swing;
 
 import java.awt.Component;
 import java.awt.GridBagLayout;
+import java.awt.Window;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.util.Arrays;
 import java.util.Objects;
 import javax.swing.BorderFactory;
@@ -11,6 +14,7 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JPasswordField;
+import javax.swing.SwingUtilities;
 import javax.swing.JTextField;
 
 final class LoginPanel extends JPanel implements LoginView {
@@ -50,6 +54,7 @@ final class LoginPanel extends JPanel implements LoginView {
         surface.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
 
         loginIdField.setName("loginIdField");
+        installFocusRequest(loginIdField);
         SwingStyles.fixHeight(loginIdField, SwingStyles.FIELD_HEIGHT);
         loginIdField.setMaximumSize(loginIdField.getPreferredSize());
         loginIdField.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -64,6 +69,7 @@ final class LoginPanel extends JPanel implements LoginView {
         surface.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
 
         passwordField.setName("passwordField");
+        installFocusRequest(passwordField);
         SwingStyles.fixHeight(passwordField, SwingStyles.FIELD_HEIGHT);
         passwordField.setMaximumSize(passwordField.getPreferredSize());
         passwordField.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -90,6 +96,10 @@ final class LoginPanel extends JPanel implements LoginView {
     /** Registers an EDT callback; callers must offload blocking authentication work. */
     void onLoginRequested(Runnable action) {
         loginRequested = Objects.requireNonNull(action, "action");
+    }
+
+    void requestInitialFocus() {
+        requestInputFocus(loginIdField);
     }
 
     @Override
@@ -124,5 +134,35 @@ final class LoginPanel extends JPanel implements LoginView {
     @Override
     public void clearPassword() {
         passwordField.setText("");
+    }
+
+    private static void installFocusRequest(Component component) {
+        component.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent event) {
+                requestInputFocus(component);
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent event) {
+                requestInputFocus(component);
+            }
+        });
+    }
+
+    private static void requestInputFocus(Component component) {
+        Window window = SwingUtilities.getWindowAncestor(component);
+        if (window != null) {
+            window.toFront();
+            window.requestFocus();
+        }
+        if (!component.requestFocusInWindow()) {
+            component.requestFocus();
+        }
+        SwingUtilities.invokeLater(() -> {
+            if (!component.hasFocus() && !component.requestFocusInWindow()) {
+                component.requestFocus();
+            }
+        });
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
@@ -2,6 +2,7 @@ package com.github.marcellokim.issuetracker.ui.swing;
 
 import java.awt.Component;
 import java.awt.GridBagLayout;
+import java.awt.KeyboardFocusManager;
 import java.awt.Window;
 import java.util.Arrays;
 import java.util.Objects;
@@ -98,6 +99,12 @@ final class LoginPanel extends JPanel implements LoginView {
         requestInputFocus(loginIdField);
     }
 
+    void requestInitialFocusIfMissing() {
+        if (!hasFocusWithin()) {
+            requestInputFocus(loginIdField);
+        }
+    }
+
     @Override
     public String loginId() {
         return loginIdField.getText();
@@ -145,5 +152,15 @@ final class LoginPanel extends JPanel implements LoginView {
                 component.requestFocus();
             }
         });
+    }
+
+    private boolean hasFocusWithin() {
+        KeyboardFocusManager focusManager = KeyboardFocusManager.getCurrentKeyboardFocusManager();
+        return ownsFocus(focusManager.getFocusOwner())
+                || ownsFocus(focusManager.getPermanentFocusOwner());
+    }
+
+    private boolean ownsFocus(Component component) {
+        return component != null && SwingUtilities.isDescendingFrom(component, this);
     }
 }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanel.java
@@ -3,8 +3,6 @@ package com.github.marcellokim.issuetracker.ui.swing;
 import java.awt.Component;
 import java.awt.GridBagLayout;
 import java.awt.Window;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.util.Arrays;
 import java.util.Objects;
 import javax.swing.BorderFactory;
@@ -54,7 +52,6 @@ final class LoginPanel extends JPanel implements LoginView {
         surface.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
 
         loginIdField.setName("loginIdField");
-        installFocusRequest(loginIdField);
         SwingStyles.fixHeight(loginIdField, SwingStyles.FIELD_HEIGHT);
         loginIdField.setMaximumSize(loginIdField.getPreferredSize());
         loginIdField.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -69,7 +66,6 @@ final class LoginPanel extends JPanel implements LoginView {
         surface.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
 
         passwordField.setName("passwordField");
-        installFocusRequest(passwordField);
         SwingStyles.fixHeight(passwordField, SwingStyles.FIELD_HEIGHT);
         passwordField.setMaximumSize(passwordField.getPreferredSize());
         passwordField.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -136,25 +132,10 @@ final class LoginPanel extends JPanel implements LoginView {
         passwordField.setText("");
     }
 
-    private static void installFocusRequest(Component component) {
-        component.addMouseListener(new MouseAdapter() {
-            @Override
-            public void mousePressed(MouseEvent event) {
-                requestInputFocus(component);
-            }
-
-            @Override
-            public void mouseReleased(MouseEvent event) {
-                requestInputFocus(component);
-            }
-        });
-    }
-
     private static void requestInputFocus(Component component) {
         Window window = SwingUtilities.getWindowAncestor(component);
         if (window != null) {
             window.toFront();
-            window.requestFocus();
         }
         if (!component.requestFocusInWindow()) {
             component.requestFocus();

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectDetailPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectDetailPanel.java
@@ -200,17 +200,20 @@ final class ProjectDetailPanel extends JPanel implements ProjectDetailView {
         renameButton.addActionListener(event -> currentProject()
                 .flatMap(current -> dialogs.requestRename(this, current))
                 .ifPresent(name -> actions.onRename().accept(this, projectId, name)));
+        SwingStyles.applySecondaryButton(renameButton);
         panel.add(renameButton);
 
         descriptionButton.setName("changeProjectDetailDescriptionButton");
         descriptionButton.addActionListener(event -> currentProject()
                 .flatMap(current -> dialogs.requestDescription(this, current))
                 .ifPresent(description -> actions.onDescriptionChange().accept(this, projectId, description)));
+        SwingStyles.applySecondaryButton(descriptionButton);
         panel.add(descriptionButton);
 
         addParticipantButton.setName("addProjectParticipantButton");
         addParticipantButton.addActionListener(event -> dialogs.requestParticipantLoginId(this)
                 .ifPresent(loginId -> actions.onAddParticipant().accept(this, projectId, loginId)));
+        SwingStyles.applySecondaryButton(addParticipantButton);
         panel.add(addParticipantButton);
 
         removeParticipantButton.setName("removeProjectParticipantButton");
@@ -218,6 +221,7 @@ final class ProjectDetailPanel extends JPanel implements ProjectDetailView {
                 .filter(participant -> dialogs.confirmRemove(this, participant))
                 .ifPresent(participant ->
                         actions.onRemoveParticipant().accept(this, projectId, participant.userId())));
+        SwingStyles.applySecondaryButton(removeParticipantButton);
         panel.add(removeParticipantButton);
         return panel;
     }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectListPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectListPanel.java
@@ -111,6 +111,7 @@ final class ProjectListPanel extends JPanel implements ProjectListView {
         JButton logoutButton = new JButton("Logout");
         logoutButton.setName("projectListLogoutButton");
         logoutButton.addActionListener(event -> actions.onLogout().run());
+        SwingStyles.applySecondaryButton(logoutButton);
 
         header.add(titles, BorderLayout.CENTER);
         header.add(logoutButton, BorderLayout.EAST);
@@ -129,6 +130,7 @@ final class ProjectListPanel extends JPanel implements ProjectListView {
         openButton.setName("openProjectIssuesButton");
         openButton.addActionListener(event -> selectedProject()
                 .ifPresent(project -> actions.onOpenIssues().accept(project.projectId())));
+        SwingStyles.applySecondaryButton(openButton);
         panel.add(openButton);
         return panel;
     }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/ProjectManagementPanel.java
@@ -119,17 +119,20 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
         createButton.setName("createProjectButton");
         createButton.addActionListener(event -> dialogs.requestCreate(this)
                 .ifPresent(request -> actions.onCreate().accept(this, request)));
+        SwingStyles.applySecondaryButton(createButton);
         panel.add(createButton);
 
         openButton.setName("openProjectDetailButton");
         openButton.addActionListener(event -> selectedProject()
                 .ifPresent(project -> actions.onOpenDetail().accept(this, project.projectId())));
+        SwingStyles.applySecondaryButton(openButton);
         panel.add(openButton);
 
         renameButton.setName("renameProjectButton");
         renameButton.addActionListener(event -> selectedProject().flatMap(project -> dialogs.requestRename(this, project)
                 .map(name -> new RenameRequest(project.projectId(), name)))
                 .ifPresent(request -> actions.onRename().accept(this, request.projectId(), request.name())));
+        SwingStyles.applySecondaryButton(renameButton);
         panel.add(renameButton);
 
         descriptionButton.setName("changeProjectDescriptionButton");
@@ -140,6 +143,7 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
                         this,
                         request.projectId(),
                         request.description())));
+        SwingStyles.applySecondaryButton(descriptionButton);
         panel.add(descriptionButton);
 
         deleteButton.setName("deleteProjectButton");
@@ -149,6 +153,7 @@ final class ProjectManagementPanel extends JPanel implements ProjectManagementVi
                         this,
                         project.projectId(),
                         project.projectName())));
+        SwingStyles.applySecondaryButton(deleteButton);
         panel.add(deleteButton);
 
         return panel;

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/StatisticsPanel.java
@@ -183,6 +183,7 @@ final class StatisticsPanel extends JPanel implements StatisticsView {
         monthlyToField.setColumns(8);
         loadButton.setName("loadStatisticsButton");
         loadButton.addActionListener(event -> publishRangeRequest());
+        SwingStyles.applySecondaryButton(loadButton);
 
         GridBagConstraints constraints = new GridBagConstraints();
         constraints.insets = new Insets(4, 4, 4, 4);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
@@ -36,7 +36,7 @@ public final class SwingAppFrame extends JFrame {
 
             @Override
             public void windowActivated(WindowEvent event) {
-                appPanel.requestLoginFocus();
+                appPanel.requestLoginFocusIfMissing();
             }
         });
     }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
@@ -1,6 +1,8 @@
 package com.github.marcellokim.issuetracker.ui.swing;
 
 import com.github.marcellokim.issuetracker.config.ApplicationContext;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.Objects;
 import javax.swing.JFrame;
 import javax.swing.WindowConstants;
@@ -26,6 +28,27 @@ public final class SwingAppFrame extends JFrame {
         setSize(SwingStyles.WINDOW_SIZE);
         setMinimumSize(SwingStyles.MINIMUM_SIZE);
         setLocationRelativeTo(null);
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowOpened(WindowEvent event) {
+                appPanel.requestLoginFocus();
+            }
+
+            @Override
+            public void windowActivated(WindowEvent event) {
+                appPanel.requestLoginFocus();
+            }
+        });
+    }
+
+    @Override
+    public void setVisible(boolean visible) {
+        super.setVisible(visible);
+        if (visible) {
+            toFront();
+            requestFocus();
+            appPanel.requestLoginFocus();
+        }
     }
 
     private static SwingControllers swingControllers(ApplicationContext context) {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppFrame.java
@@ -46,7 +46,6 @@ public final class SwingAppFrame extends JFrame {
         super.setVisible(visible);
         if (visible) {
             toFront();
-            requestFocus();
             appPanel.requestLoginFocus();
         }
     }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -44,6 +44,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
     private final JPanel adminDashboardCard = new JPanel(new BorderLayout());
     private final JPanel projectListCard = new JPanel(new BorderLayout());
     private transient SwingWorker<Void, Void> loginWorker;
+    private boolean loginVisible = true;
     private final transient AtomicReference<SwingWorker<Void, Void>> dashboardWorker = new AtomicReference<>();
     private final transient AtomicReference<SwingWorker<Void, Void>> accountWorker = new AtomicReference<>();
     private final transient AtomicReference<SwingWorker<Void, Void>> projectWorker = new AtomicReference<>();
@@ -132,7 +133,15 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             loginPanel.clearPassword();
             loginPanel.setLoginEnabled(true);
             cardLayout.show(this, LOGIN_CARD);
+            loginVisible = true;
+            SwingUtilities.invokeLater(loginPanel::requestInitialFocus);
         });
+    }
+
+    void requestLoginFocus() {
+        if (loginVisible) {
+            SwingUtilities.invokeLater(loginPanel::requestInitialFocus);
+        }
     }
 
     @Override
@@ -151,6 +160,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             adminDashboardCard.revalidate();
             adminDashboardCard.repaint();
             cardLayout.show(this, ADMIN_DASHBOARD_CARD);
+            loginVisible = false;
             loadAdminDashboard(panel);
         });
     }
@@ -171,6 +181,7 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
             projectListCard.revalidate();
             projectListCard.repaint();
             cardLayout.show(this, PROJECT_LIST_CARD);
+            loginVisible = false;
             startProjectListTask(panel, ProjectListPresenter::loadProjects);
         });
     }

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanel.java
@@ -144,6 +144,12 @@ final class SwingAppPanel extends JPanel implements SwingNavigator {
         }
     }
 
+    void requestLoginFocusIfMissing() {
+        if (loginVisible) {
+            SwingUtilities.invokeLater(loginPanel::requestInitialFocusIfMissing);
+        }
+    }
+
     @Override
     public void showAdminDashboard(UserResult user) {
         Objects.requireNonNull(user, "user");

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingPanelSections.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingPanelSections.java
@@ -180,7 +180,7 @@ final class SwingPanelSections {
         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         table.setSelectionBackground(selectionBackground);
         table.setSelectionForeground(SwingStyles.BODY_TEXT);
-        table.getTableHeader().setReorderingAllowed(false);
+        SwingStyles.disableHeaderReordering(table);
         SwingStyles.applyTableStyle(table);
     }
 

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingPanelSections.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingPanelSections.java
@@ -72,11 +72,13 @@ final class SwingPanelSections {
         JButton backButton = new JButton("Back");
         backButton.setName(labels.backButtonName());
         backButton.addActionListener(event -> navigation.onBack().run());
+        SwingStyles.applySecondaryButton(backButton);
         nav.add(backButton);
 
         JButton logoutButton = new JButton("Logout");
         logoutButton.setName(labels.logoutButtonName());
         logoutButton.addActionListener(event -> navigation.onLogout().run());
+        SwingStyles.applySecondaryButton(logoutButton);
         nav.add(logoutButton);
 
         messageLabel.setName(labels.messageName());
@@ -175,11 +177,11 @@ final class SwingPanelSections {
     static void configureReadOnlyTable(JTable table, String name, Color selectionBackground) {
         table.setName(name);
         table.setFillsViewportHeight(true);
-        table.setRowHeight(26);
         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         table.setSelectionBackground(selectionBackground);
         table.setSelectionForeground(SwingStyles.BODY_TEXT);
         table.getTableHeader().setReorderingAllowed(false);
+        SwingStyles.applyTableStyle(table);
     }
 
     static JPanel tableSection(String title, JTable table) {
@@ -234,7 +236,10 @@ final class SwingPanelSections {
     private static JPanel buttonRow(List<JButton> buttons) {
         JPanel panel = new JPanel();
         panel.setOpaque(false);
-        buttons.forEach(panel::add);
+        buttons.forEach(button -> {
+            SwingStyles.applySecondaryButton(button);
+            panel.add(button);
+        });
         return panel;
     }
 

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingStyles.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingStyles.java
@@ -7,7 +7,9 @@ import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
+import javax.swing.JTable;
 import javax.swing.border.Border;
+import javax.swing.plaf.basic.BasicButtonUI;
 
 final class SwingStyles {
 
@@ -24,10 +26,14 @@ final class SwingStyles {
     static final Color BORDER = new Color(218, 224, 231);
     static final Color PRIMARY = new Color(32, 96, 160);
     static final Color PRIMARY_TEXT = Color.WHITE;
+    static final Color BUTTON_BACKGROUND = new Color(248, 250, 252);
+    static final Color BUTTON_BORDER = new Color(148, 163, 184);
     static final Color DISABLED_BUTTON_BACKGROUND = new Color(229, 234, 240);
     static final Color BODY_TEXT = new Color(36, 43, 51);
     static final Color MUTED_TEXT = new Color(95, 106, 120);
     static final Color ERROR_TEXT = new Color(154, 35, 45);
+    static final Color TABLE_HEADER_BACKGROUND = new Color(241, 245, 249);
+    static final Color TABLE_GRID = new Color(203, 213, 225);
 
     private SwingStyles() {
     }
@@ -53,14 +59,42 @@ final class SwingStyles {
     }
 
     static void applyPrimaryButton(JButton button) {
+        button.setUI(new BasicButtonUI());
         button.setBackground(PRIMARY);
         button.setForeground(PRIMARY_TEXT);
-        button.setFocusPainted(false);
+        button.setBorder(BorderFactory.createCompoundBorder(
+                BorderFactory.createLineBorder(PRIMARY.darker()),
+                BorderFactory.createEmptyBorder(7, 14, 7, 14)));
+        button.setFocusPainted(true);
+        button.setOpaque(true);
+        button.setContentAreaFilled(true);
         button.setPreferredSize(new Dimension(LOGIN_PANEL_WIDTH, BUTTON_HEIGHT));
     }
 
     static void applyPrimaryButtonState(JButton button, boolean enabled) {
         button.setBackground(enabled ? PRIMARY : DISABLED_BUTTON_BACKGROUND);
+    }
+
+    static void applySecondaryButton(JButton button) {
+        button.setUI(new BasicButtonUI());
+        button.setBackground(BUTTON_BACKGROUND);
+        button.setForeground(BODY_TEXT);
+        button.setBorder(BorderFactory.createCompoundBorder(
+                BorderFactory.createLineBorder(BUTTON_BORDER),
+                BorderFactory.createEmptyBorder(5, 12, 5, 12)));
+        button.setFocusPainted(true);
+        button.setOpaque(true);
+        button.setContentAreaFilled(true);
+    }
+
+    static void applyTableStyle(JTable table) {
+        table.setRowHeight(28);
+        table.setGridColor(TABLE_GRID);
+        table.setShowGrid(true);
+        table.setIntercellSpacing(new Dimension(0, 1));
+        table.getTableHeader().setBackground(TABLE_HEADER_BACKGROUND);
+        table.getTableHeader().setForeground(BODY_TEXT);
+        table.getTableHeader().setFont(table.getTableHeader().getFont().deriveFont(Font.BOLD));
     }
 
     static void fixHeight(JComponent component, int height) {

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingStyles.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/SwingStyles.java
@@ -10,6 +10,7 @@ import javax.swing.JLabel;
 import javax.swing.JTable;
 import javax.swing.border.Border;
 import javax.swing.plaf.basic.BasicButtonUI;
+import javax.swing.table.JTableHeader;
 
 final class SwingStyles {
 
@@ -92,9 +93,19 @@ final class SwingStyles {
         table.setGridColor(TABLE_GRID);
         table.setShowGrid(true);
         table.setIntercellSpacing(new Dimension(0, 1));
-        table.getTableHeader().setBackground(TABLE_HEADER_BACKGROUND);
-        table.getTableHeader().setForeground(BODY_TEXT);
-        table.getTableHeader().setFont(table.getTableHeader().getFont().deriveFont(Font.BOLD));
+        JTableHeader header = table.getTableHeader();
+        if (header != null) {
+            header.setBackground(TABLE_HEADER_BACKGROUND);
+            header.setForeground(BODY_TEXT);
+            header.setFont(header.getFont().deriveFont(Font.BOLD));
+        }
+    }
+
+    static void disableHeaderReordering(JTable table) {
+        JTableHeader header = table.getTableHeader();
+        if (header != null) {
+            header.setReorderingAllowed(false);
+        }
     }
 
     static void fixHeight(JComponent component, int height) {

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanelTest.java
@@ -52,8 +52,11 @@ class IssueDetailPanelTest {
                     List.of(dependency()));
 
             assertEquals(
-                    "[ISSUE-7] Login bug",
+                    "Login bug",
                     SwingComponentTestSupport.find(panel, "issueDetailTitle", JLabel.class).getText());
+            assertEquals(
+                    "Issue ID: ISSUE-7",
+                    SwingComponentTestSupport.find(panel, "issueDetailIssueId", JLabel.class).getText());
             assertEquals(
                     "NEW / CRITICAL",
                     SwingComponentTestSupport.find(panel, "issueDetailState", JLabel.class).getText());

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/LoginPanelTest.java
@@ -70,4 +70,24 @@ class LoginPanelTest {
             assertEquals("", panel.password());
         });
     }
+
+    @Test
+    @DisplayName("keeps login fields ready for focus based input")
+    void keepsLoginFieldsReadyForFocusInput() throws Exception {
+        SwingComponentTestSupport.onEdt(() -> {
+            var panel = new LoginPanel();
+            JTextField loginId = SwingComponentTestSupport.find(panel, "loginIdField", JTextField.class);
+            JPasswordField password = SwingComponentTestSupport.find(panel, "passwordField", JPasswordField.class);
+
+            assertTrue(loginId.isFocusable());
+            assertTrue(password.isFocusable());
+
+            panel.setLoginEnabled(false);
+            panel.setLoginEnabled(true);
+            panel.requestInitialFocus();
+
+            assertTrue(loginId.isEnabled());
+            assertTrue(password.isEnabled());
+        });
+    }
 }

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -442,11 +442,11 @@ class SwingAppPanelTest {
         awaitButtonEnabled(panel, "openIssueDetailButton");
         SwingComponentTestSupport.onEdt(() ->
                 SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick());
-        awaitIssueDetailTitle(panel, "[ISSUE-7] Login bug");
+        awaitIssueDetailTitle(panel, "Login bug");
 
         SwingComponentTestSupport.onEdt(() -> {
             assertEquals(
-                    "[ISSUE-7] Login bug",
+                    "Login bug",
                     SwingComponentTestSupport.find(panel, "issueDetailTitle", JLabel.class).getText());
             SwingComponentTestSupport.find(panel, "issueDetailBackButton", JButton.class).doClick();
         });
@@ -623,7 +623,7 @@ class SwingAppPanelTest {
                 List.of(issue(7L, 7L, "Login bug", Priority.CRITICAL, pl)),
                 pl);
 
-        openFirstIssueDetail(panel, "[ISSUE-7] Login bug");
+        openFirstIssueDetail(panel, "Login bug");
         awaitButtonEnabled(panel, "issueActionButton_START_ASSIGNMENT");
 
         SwingComponentTestSupport.onEdt(() -> {
@@ -647,7 +647,7 @@ class SwingAppPanelTest {
             SwingComponentTestSupport.find(panel, "issueActionButton_START_ASSIGNMENT", JButton.class).doClick();
 
             assertEquals(
-                    "[ISSUE-7] Login bug",
+                    "Login bug",
                     SwingComponentTestSupport.find(panel, "issueDetailTitle", JLabel.class).getText());
             assertEquals(
                     "Unsupported issue action: START_ASSIGNMENT",
@@ -688,7 +688,7 @@ class SwingAppPanelTest {
         awaitButtonEnabled(panel, "openIssueDetailButton");
         SwingComponentTestSupport.onEdt(() ->
                 SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick());
-        awaitIssueDetailTitle(panel, "[ISSUE-7] Login bug");
+        awaitIssueDetailTitle(panel, "Login bug");
         awaitButtonEnabled(panel, "issueActionButton_MARK_FIXED");
 
         SwingComponentTestSupport.onEdt(() ->
@@ -744,7 +744,7 @@ class SwingAppPanelTest {
         awaitButtonEnabled(panel, "openIssueDetailButton");
         SwingComponentTestSupport.onEdt(() ->
                 SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick());
-        awaitIssueDetailTitle(panel, "[ISSUE-7] Login bug");
+        awaitIssueDetailTitle(panel, "Login bug");
         awaitButtonEnabled(panel, "issueActionButton_START_ASSIGNMENT");
 
         SwingComponentTestSupport.onEdt(() ->
@@ -800,7 +800,7 @@ class SwingAppPanelTest {
         awaitButtonEnabled(panel, "openIssueDetailButton");
         SwingComponentTestSupport.onEdt(() ->
                 SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick());
-        awaitIssueDetailTitle(panel, "[ISSUE-7] Login bug");
+        awaitIssueDetailTitle(panel, "Login bug");
         awaitButtonEnabled(panel, "issueActionButton_START_ASSIGNMENT");
 
         SwingComponentTestSupport.onEdt(() ->
@@ -853,7 +853,7 @@ class SwingAppPanelTest {
         awaitButtonEnabled(panel, "openIssueDetailButton");
         SwingComponentTestSupport.onEdt(() ->
                 SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick());
-        awaitIssueDetailTitle(panel, "[ISSUE-7] Login bug");
+        awaitIssueDetailTitle(panel, "Login bug");
         awaitRows(panel, "issueCommentTable", 1);
 
         SwingComponentTestSupport.onEdt(() ->
@@ -943,7 +943,7 @@ class SwingAppPanelTest {
         awaitButtonEnabled(panel, "openIssueDetailButton");
         SwingComponentTestSupport.onEdt(() ->
                 SwingComponentTestSupport.find(panel, "openIssueDetailButton", JButton.class).doClick());
-        awaitIssueDetailTitle(panel, "[ISSUE-7] Login bug");
+        awaitIssueDetailTitle(panel, "Login bug");
         awaitRows(panel, "issueDependencyTable", 0);
 
         awaitButtonEnabled(panel, "addDependencyButton");
@@ -1010,11 +1010,11 @@ class SwingAppPanelTest {
                 editPrompt,
                 pl);
 
-        openFirstIssueDetail(panel, "[ISSUE-7] Login bug");
+        openFirstIssueDetail(panel, "Login bug");
         awaitButtonEnabled(panel, "issueActionButton_UPDATE_ISSUE");
         SwingComponentTestSupport.onEdt(() ->
                 SwingComponentTestSupport.find(panel, "issueActionButton_UPDATE_ISSUE", JButton.class).doClick());
-        awaitIssueDetailTitle(panel, "[ISSUE-7] Edited bug");
+        awaitIssueDetailTitle(panel, "Edited bug");
 
         awaitButtonEnabled(panel, "issueActionButton_CHANGE_PRIORITY");
         SwingComponentTestSupport.onEdt(() ->
@@ -1024,7 +1024,7 @@ class SwingAppPanelTest {
         assertEquals(IssueEditMode.CHANGE_PRIORITY, promptedMode.get());
         SwingComponentTestSupport.onEdt(() -> {
             assertEquals(
-                    "[ISSUE-7] Edited bug",
+                    "Edited bug",
                     SwingComponentTestSupport.find(panel, "issueDetailTitle", JLabel.class).getText());
             assertEquals(
                     "NEW / MINOR",
@@ -1061,12 +1061,12 @@ class SwingAppPanelTest {
                 editPrompt,
                 pl);
 
-        openFirstIssueDetail(panel, "[ISSUE-7] Login bug");
+        openFirstIssueDetail(panel, "Login bug");
         awaitButtonEnabled(panel, "issueActionButton_SOFT_DELETE");
         SwingComponentTestSupport.onEdt(() ->
                 SwingComponentTestSupport.find(panel, "issueActionButton_SOFT_DELETE", JButton.class).doClick());
         SwingComponentTestSupport.onEdt(() -> assertEquals(
-                "[ISSUE-7] Login bug",
+                "Login bug",
                 SwingComponentTestSupport.find(panel, "issueDetailTitle", JLabel.class).getText()));
 
         deleteConfirmed.set(true);


### PR DESCRIPTION
## purpose
Closes #248.

Swing 전체 UI QA 결과를 정리하고, QA 중 확인된 로그인 입력 포커스와 시각적 완성도 문제를 보강한다.

## non-goals
- JavaFX 화면과 백엔드 기능 동작은 변경하지 않는다.
- 생성된 스크린샷 바이너리는 PR에 포함하지 않는다.
- 현재 WSLg 환경에서 증명되지 않는 네이티브 마우스 클릭 포커스는 target desktop retest gate로 남긴다.

## diff map
- 로그인 포커스: 초기 진입 포커스 보정은 유지하되, 창 재활성화 시에는 로그인 폼 내부 포커스가 없을 때만 ID 필드로 보정한다.
- 상세 화면: 이슈 ID를 제목 앞에서 분리해 보조 메타데이터로 렌더링한다.
- 시각 보강: Swing 보조 버튼과 테이블 스타일을 공통화하고 주요 화면에 적용했다.
- QA 문서: `docs/qa/swing-full-qa-2026-06-01.md`에 실행 결과, 남은 게이트, 이미지 미포함 정책을 기록했다.
- 테스트: 로그인 포커스, 이슈 상세 제목/ID 렌더링, Swing 앱 패널 회귀 테스트를 보강했다.

## verification evidence
- `git diff --check`
- `./gradlew test --tests 'com.github.marcellokim.issuetracker.ui.swing.*' verifySubmissionMetadata --console=plain`
- pre-push `test + verifyRepositorySetup`
- 기존 PR 검증: `./gradlew check verifySubmissionMetadata --console=plain`, `./scripts/open-pr.sh` 내부 `./gradlew check`
- Oracle 기반 Swing smoke/interaction QA 결과는 QA 리포트에 기록했다.
- WSLg `Robot` 포커스 검증 실패는 별도 target desktop retest gate로 남겼다.

## reviewer focus areas
- 로그인 화면에서 창 재활성화 후 기존 입력 필드 포커스가 유지되는지 확인 필요.
- 공통 버튼/테이블 스타일이 Swing 화면 전체 톤과 어긋나지 않는지 확인 필요.
- QA 리포트의 남은 게이트와 스크린샷 미포함 정책이 제출 흐름에 맞는지 확인 필요.
- JavaFX 및 백엔드 동작 변경이 의도치 않게 섞이지 않았는지 확인 필요.

## risk / rollback
- 네이티브 클릭 포커스는 현재 WSLg 자동화 환경에서 최종 통과를 주장하지 않는다. 발표/제출 대상 데스크톱에서 `TDT-FOCUS-*` 항목을 직접 재확인해야 한다.
- 문제가 생기면 Swing 포커스 보강, 스타일 공통화, QA 리포트 추가분을 되돌리면 된다.
