### PR TITLE
chore: 일정 기준선과 프로젝트 계획 최신화

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## 1. 과제 제출 정보
 - **과제명**: SE 2026 Spring Term Project - 이슈관리 시스템 개발
 - **구현 언어**: Java
-- **최종 제출 마감**: 2026-06-02 21:00
+- **최종 제출 마감**: 2026-06-04 21:00 KST
 - **발표 일정**: 2026-06-03 / 2026-06-08 수업 시간
 - **GitHub 저장소**: <https://github.com/marcellokim/se-issue-tracker>
 - **GitHub 프로젝트**: <https://github.com/users/marcellokim/projects/1>
@@ -39,9 +39,11 @@
 - [x] 초기 세팅 / git hook / 라벨 동기화 / 제출 패키징 스크립트
 - [x] 사용자용 운영 가이드 및 자동화 옵션 문서
 - [x] 도메인 모델 구현
-- [ ] UI(JavaFX + Swing) 구현
-- [ ] 통계 / 추천 기능 구현
+- [x] JavaFX 전체 UI 구현
+- [x] Swing 전체 UI 구현
+- [x] 통계 / 추천 기능 구현
 - [ ] 최종 발표 자료 / 동영상 / 프로젝트 문서 PDF 완성
+- [ ] 최종 제출 패키지 freeze 및 증빙 정리
 
 ## 5. 로컬 실행 및 개발 시작
 ### 필수 환경
@@ -93,10 +95,14 @@ Windows에서 `python3` 대신 `python` 또는 `py`만 잡히는 경우에는 Gr
 ```
 
 ### 애플리케이션 실행 확인
-아직 실제 JavaFX 화면은 #23에서 구현합니다. 현재 단계에서는 Gradle 실행 골격과 JavaFX 런타임 설정이 잡혀 있는지만 확인합니다.
+기본 실행은 JavaFX UI이며, Swing UI는 별도 Gradle task로 실행합니다. Oracle DB를 사용하는 데모 실행은 [docs/local-oracle-testing.md](docs/local-oracle-testing.md)의 앱 DB 준비 절차를 먼저 따릅니다.
 
 ```bash
-./gradlew run
+# JavaFX
+./gradlew run --console=plain
+
+# Swing
+./gradlew runSwing --console=plain
 ```
 
 ### 정해진 작업 흐름

--- a/config/github/milestones.json
+++ b/config/github/milestones.json
@@ -5,14 +5,14 @@
   },
   {
     "title": "M2 - 핵심 도메인 및 영속 저장소",
-    "description": "계정, 프로젝트, 이슈, 댓글, 상태 전이, 검색, DB 기반 영속 저장소와 핵심 서비스 계층 구현 완료. 2026-05-30 재조정 기준으로 M2 잔여 open work는 M3/M4로 이동하거나 완료 정리한다."
+    "description": "계정, 프로젝트, 이슈, 댓글, 상태 전이, 검색, DB 기반 영속 저장소와 핵심 서비스 계층 구현 완료. 2026-06-02 기준 M2 기능 범위는 완료 상태이며, 남은 작업은 M3/M4의 UI 검증과 제출 패키지에서 추적한다."
   },
   {
     "title": "M3 - 다중 UI 및 데모 흐름",
-    "description": "JavaFX 실사용자 UI와 Swing Admin UI에서 공통 model/service/controller를 재사용하고 과제 데모 흐름을 실행 가능하게 만든다. 2026-05-30 재조정 기준: backend/controller/persistence는 dev 기준 준비, 남은 범위는 JavaFX core/secondary action, Swing Admin 관리 UI, 화면 증빙이며 M3 UI demo freeze 목표는 2026-06-01 KST."
+    "description": "JavaFX 전체 UI 1개와 Swing 전체 UI 1개를 각각 제공하고, 두 UI가 같은 controller/service/domain/persistence 계층을 재사용한다는 것을 데모 흐름으로 증명한다. 2026-06-02 재조정 기준: UI 구현은 dev 기준 통합 단계이며, 남은 범위는 QA evidence와 최종 발표/문서 연결이다."
   },
   {
     "title": "M4 - 검증 및 제출 패키지",
-    "description": "JUnit 테스트, Oracle/CI 검증, 최종 프로젝트 문서, 발표 자료, 데모 영상, 제출 zip, GitHub Project 증빙을 정리한다. 2026-05-30 재조정 기준: M4 내부 freeze는 2026-06-03 KST, 최종 제출은 연장 공지가 적용된 2026-06-04 21:00 KST 기준으로 관리한다."
+    "description": "JUnit 테스트, Oracle/CI 검증, 최종 프로젝트 문서, 발표 자료, 데모 영상, 제출 zip, GitHub Project 증빙을 정리한다. 2026-06-02 재조정 기준: M4 내부 freeze는 2026-06-03 KST, 최종 제출은 연장 공지가 적용된 2026-06-04 21:00 KST 기준으로 관리한다."
   }
 ]

--- a/docs/project-management-plan.md
+++ b/docs/project-management-plan.md
@@ -24,7 +24,7 @@
 
 - **M1 - 요구사항 및 설계 기준선**: 요구사항 추적, 유스케이스, 도메인 모델, SSD, Operation Contract
 - **M2 - 핵심 도메인 및 영속 저장소**: 모델, 서비스, 검색, 상태 전이, 저장소, 통계, 추천
-- **M3 - 다중 UI 및 데모 흐름**: JavaFX/Swing UI와 PDF 데모 시나리오
+- **M3 - 다중 UI 및 데모 흐름**: JavaFX 전체 UI와 Swing 전체 UI가 같은 controller/service/domain/persistence 계층을 재사용하는 데모 흐름
 - **M4 - 검증 및 제출 패키지**: 테스트, 최종 문서, 발표, 영상, 제출 zip
 
 기존의 `초기 설정`, `핵심 기능`, `UI`, `테스트`, `문서`, `데모` 마일스톤은 과거 분류용 이력이므로 닫아 두고, 앞으로 새 작업은 M1~M4 중심으로 배치합니다.
@@ -57,11 +57,11 @@
 | [#20](https://github.com/marcellokim/se-issue-tracker/issues/20) feat: 이슈 배정과 상태 변경 흐름 구현 | M2 | 기능/상태 전이 |
 | [#21](https://github.com/marcellokim/se-issue-tracker/issues/21) feat: 일/월별 이슈 통계와 추이 조회 구현 | M2 | 기능/통계 |
 | [#22](https://github.com/marcellokim/se-issue-tracker/issues/22) feat: 해결 이력 기반 담당자 추천 기능 구현 | M2 | 기능/추천 |
-| [#23](https://github.com/marcellokim/se-issue-tracker/issues/23) feat: JavaFX 메인 UI로 기본 사용자 흐름 구현 | M3 | 기능/UI |
-| [#24](https://github.com/marcellokim/se-issue-tracker/issues/24) feat: Swing 보조 UI로 모델 재사용 구조 입증 | M3 | 기능/UI |
+| [#23](https://github.com/marcellokim/se-issue-tracker/issues/23) feat: JavaFX 전체 UI 데모 흐름 parent 관리 | M3 | 기능/UI |
+| [#24](https://github.com/marcellokim/se-issue-tracker/issues/24) feat: Swing 전체 UI 데모 흐름 parent 관리 | M3 | 기능/UI |
 | [#25](https://github.com/marcellokim/se-issue-tracker/issues/25) test: 모델, 서비스, 영속 저장소 JUnit 테스트 구성 | M4 | 테스트 |
 | [#26](https://github.com/marcellokim/se-issue-tracker/issues/26) docs: 최종 프로젝트 문서, 발표 자료, 영상, 제출 패키지 준비 | M4 | 문서/제출 |
-| [#27](https://github.com/marcellokim/se-issue-tracker/issues/27) chore: GitHub Project 자동 등록과 진행 이력 캡처 준비 | M1 | 작업/자동화 |
+| [#27](https://github.com/marcellokim/se-issue-tracker/issues/27) chore: GitHub Project 진행 이력과 제출 증빙 캡처 준비 | M4 | 작업/자동화 |
 | [#39](https://github.com/marcellokim/se-issue-tracker/issues/39) docs: MVC, GRASP, Repository, Strategy 설계원칙 기준선 정리 | M1 | 문서/설계 원칙 |
 | [#43](https://github.com/marcellokim/se-issue-tracker/issues/43) feat: Tester 검증 실패 시 fixed 이슈를 assigned로 되돌리는 역전이 구현 | M2 | 기능/상태 전이 |
 | [#44](https://github.com/marcellokim/se-issue-tracker/issues/44) feat: deleted 상태와 삭제 후보 보관/FIFO 정리 정책 구현 | M2 | 기능/상태 전이/저장소 |
@@ -77,10 +77,10 @@
 3. #18, #44, #45로 DB schema, seed 데이터, soft-delete, dependency 저장 구조를 준비합니다.
 4. #19로 이슈 등록/검색/상세/코멘트 서비스를 연결합니다.
 5. #21, #22를 붙여 통계/추천 요구사항을 완성합니다.
-6. #23, #24에서 UI 두 개를 같은 서비스 계층에 연결합니다.
+6. #23, #24에서 JavaFX 전체 UI와 Swing 전체 UI를 같은 서비스 계층에 연결합니다.
 7. #25로 핵심 모델/서비스/저장소 테스트를 보강합니다.
 8. #26에서 문서/발표/영상/제출 패키지를 닫습니다.
 
 ## 자동화 메모
 
-현재 Project URL 변수는 설정되어 있지만, 사용자 계정 소유 GitHub Project에 자동 등록하려면 `ADD_TO_PROJECT_PAT` secret이 필요합니다. 이 값은 보안 정보이므로 문서나 커밋에 적지 않습니다. 설정이 끝나면 새 이슈/PR 생성 시 Project 자동 등록 워크플로우가 실제로 동작하는지 #27에서 확인합니다.
+현재 Project URL 변수는 설정되어 있지만, 사용자 계정 소유 GitHub Project 자동 등록과 보드 정렬은 `ADD_TO_PROJECT_PAT` secret 상태에 따라 달라질 수 있습니다. 이 값은 보안 정보이므로 문서나 커밋에 적지 않습니다. 제출 직전에는 #27에서 GitHub Project 진행 이력, PR/issue 상태, 마일스톤 증빙을 사람이 확인할 수 있는 형태로 캡처합니다.


### PR DESCRIPTION
## purpose
Closes #95.

현재 일정 기준선과 프로젝트 안내 문서에서 오래된 UI 구분, 제출 마감, 구현 상태 표현을 정리합니다. JavaFX 전체 UI 1개 + Swing 전체 UI 1개 기준을 README, 프로젝트 관리 계획, 마일스톤 config에 맞췄습니다.

## non-goals
- 기능 구현과 테스트 범위 변경은 포함하지 않습니다.
- 열린 #100/#101/#107 문서 PR의 산출물은 수정하지 않습니다.
- GitHub Project metadata 실패나 승인 대기 PR을 이 PR에서 해결하지 않습니다.

## diff map
- `README.md`: 최종 제출 마감, 구현 상태 체크리스트, JavaFX/Swing 실행 안내 최신화
- `docs/project-management-plan.md`: M3 설명, #23/#24/#27 기준 정리
- `config/github/milestones.json`: M2/M3/M4 설명 최신화

## verification evidence
- `git diff --check`
- `./gradlew verifySubmissionMetadata --console=plain`
- `./gradlew check --console=plain`
- pre-push `test + verifyRepositorySetup`
- GitHub live milestone description PATCH 반영 확인

## reviewer focus areas
- M3가 역할 분리 UI가 아니라 JavaFX 전체 UI + Swing 전체 UI 기준으로 설명되는지
- README의 제출 마감과 실행 명령이 현재 팀 기준과 맞는지
- #95 범위 밖의 구현/최종 PDF/traceability 내용을 건드리지 않았는지

## risk / rollback
- 문서와 config 정리 PR이라 rollback 영향은 낮습니다.
- 마감이나 발표 일정이 다시 바뀌면 README와 milestone 설명만 후속 PR로 조정하면 됩니다.