### PR TITLE
test: 모델 서비스 저장소 검증 게이트 정리

### DIFF
--- a/docs/test-gates/issue-25-model-service-persistence-gate-2026-06-02.md
+++ b/docs/test-gates/issue-25-model-service-persistence-gate-2026-06-02.md
@@ -1,0 +1,106 @@
+# Issue 25 Model, Service, Persistence Test Gate
+
+## Purpose
+
+이 문서는 #25의 모델, 서비스, 영속 저장소 테스트 gate를 제출 전 검증 증거로 연결하기 위한 2026-06-02 스냅샷이다. 최종 제출 직전에는 모든 대기 PR을 `dev`에 병합한 뒤 같은 명령을 다시 실행한다.
+
+## Scope
+
+- 기준 commit: `42db174` (`feat: 이슈 열람 정책 수정 + 검색 필터 확장 + docs 정리 (#255)`)
+- 기준 branch: `origin/dev`
+- 대상: domain, service, persistence, controller 경계 테스트와 repository/setup guard
+- 제외: Swing/JavaFX 화면 QA 증빙, 최종 PDF 본문, 제출 zip 생성
+
+## Test Inventory
+
+`src/test/java` 기준 테스트 클래스 수는 다음과 같다.
+
+| 영역 | 테스트 클래스 수 | 주요 검증 |
+|---|---:|---|
+| application smoke | 1 | 기본 entry point와 실행 인자 분기 |
+| controller | 10 | Controller가 service/use-case 경계로 요청을 위임하는지 |
+| domain | 8 | Entity, value object, 이슈 상태/이력/의존성 규칙 |
+| persistence | 7 | DB 환경, initializer, JDBC query/write support, Oracle repository integration |
+| service | 13 | 계정, 프로젝트, 이슈, 배정, 상태 전이, 추천, 통계, 권한 정책 |
+| setup | 6 | architecture boundary, workflow guard, 공개 이력 정책, repository convention |
+| technical | 3 | password hashing, session, comment id generator |
+| ui/javafx | 1 | JavaFX graph screen 단위 검증 |
+| ui/swing | 34 | Swing presenter/panel/dialog/request 단위 검증 |
+
+## Requirement Coverage
+
+| 요구 범위 | 증거 |
+|---|---|
+| #16 User/Role/Project | `UserTest`, `ProjectTest`, `AccountServiceTest`, `ProjectServiceTest` |
+| #17 Issue/Comment/History/Priority/Status | `IssueCreationTest`, `CommentTest`, `IssueHistoryTest`, `IssueWorkflowTest` |
+| #18 JDBC repository/schema/seed | `DatabaseEnvironmentTest`, `DatabaseInitializerTest`, `JdbcIssueQueriesTest`, `JdbcIssueWriteSupportTest`, `OracleRepositoryIntegrationTest` |
+| #19 register/search/detail/comment | `IssueServiceTest`, `IssueControllerTest` |
+| #20 assignment/status workflow | `AssignmentServiceTest`, `IssueStateServiceTest`, `IssueWorkflowServiceTest` |
+| #21 statistics | `StatisticsServiceTest`, `StatisticsControllerTest` |
+| #22 recommendation | `AssignmentRecommendationServiceTest`, `KNNAssignmentRecommendationTest` |
+| #43 reject fix | `IssueStateServiceTest`, `IssueWorkflowTest` |
+| #44 delete/restore/FIFO | `DeletedIssueServiceTest`, `DeletedIssueControllerTest` |
+| #45 dependency/cycle/resolve guard | `IssueDependencyTest`, `IssueServiceTest` |
+| #46 edit issue policy | `IssueEditTest`, `IssueServiceTest` |
+| #47 reopen policy | `IssueStateServiceTest`, `IssueWorkflowServiceTest` |
+
+## Local Verification
+
+### `./gradlew clean check --console=plain`
+
+Result: passed.
+
+Relevant output:
+
+```text
+> Task :auditAutomation
+> Task :test FROM-CACHE
+> Task :oracleIntegrationTest SKIPPED
+> Task :verifyRepositorySetup
+저장소 기본 구성을 확인했습니다 (41개 필수 경로 확인).
+> Task :check
+
+BUILD SUCCESSFUL in 4s
+7 actionable tasks: 3 executed, 3 from cache, 1 up-to-date
+```
+
+JUnit XML summary from `build/test-results/test`:
+
+```text
+test_classes=83
+tests=688
+failures_or_errors=0
+skipped=34
+```
+
+### `./gradlew verifySubmissionMetadata --console=plain`
+
+Result: passed.
+
+Relevant output:
+
+```text
+> Task :verifySubmissionMetadata
+README 제출 메타데이터를 확인했습니다.
+
+BUILD SUCCESSFUL
+```
+
+## Oracle Evidence
+
+Local `check` does not require Oracle and skipped `oracleIntegrationTest` because no Oracle test DB environment was configured. Oracle 검증은 두 경로 중 하나로 최종 제출 전에 다시 확보한다.
+
+| 경로 | 명령 또는 증거 |
+|---|---|
+| Local Docker | `./gradlew oracleLocalTest --console=plain` |
+| CI | `빌드와 테스트` workflow의 `Oracle 통합 테스트` job과 `oracle-통합-테스트-리포트` artifact |
+
+`.github/workflows/gradle.yml`은 일반 test report와 Oracle integration report를 각각 artifact로 업로드한다.
+
+## Final Rerun Checklist
+
+- [ ] #253, #254, #256, #257, #258, #259 병합 후 최신 `origin/dev`를 fetch한다.
+- [ ] `./gradlew clean check --console=plain`을 다시 실행한다.
+- [ ] `./gradlew verifySubmissionMetadata --console=plain`을 다시 실행한다.
+- [ ] Oracle local 또는 CI `Oracle 통합 테스트` 통과 증거를 최종 보고서/제출 패키지에 연결한다.
+- [ ] 실패가 있으면 #25를 닫지 않고 실패 test class와 원인을 별도 fix/test 이슈로 분리한다.

--- a/docs/test-gates/issue-25-model-service-persistence-gate-2026-06-02.md
+++ b/docs/test-gates/issue-25-model-service-persistence-gate-2026-06-02.md
@@ -6,7 +6,7 @@
 
 ## Scope
 
-- 기준 commit: `42db174` (`feat: 이슈 열람 정책 수정 + 검색 필터 확장 + docs 정리 (#255)`)
+- 기준 commit: `d2ec80b` (`fix: GitHub Project 항목 로딩 한계 보정 (#263)`)
 - 기준 branch: `origin/dev`
 - 대상: domain, service, persistence, controller 경계 테스트와 repository/setup guard
 - 제외: Swing/JavaFX 화면 QA 증빙, 최종 PDF 본문, 제출 zip 생성
@@ -99,7 +99,7 @@ Local `check` does not require Oracle and skipped `oracleIntegrationTest` becaus
 
 ## Final Rerun Checklist
 
-- [ ] #253, #254, #256, #257, #258, #259 병합 후 최신 `origin/dev`를 fetch한다.
+- [ ] #253, #254, #256, #257, #258, #261, #262, #265 병합 후 최신 `origin/dev`를 fetch한다.
 - [ ] `./gradlew clean check --console=plain`을 다시 실행한다.
 - [ ] `./gradlew verifySubmissionMetadata --console=plain`을 다시 실행한다.
 - [ ] Oracle local 또는 CI `Oracle 통합 테스트` 통과 증거를 최종 보고서/제출 패키지에 연결한다.


### PR DESCRIPTION
## purpose
Refs #25.

모델, 서비스, 영속 저장소 테스트 gate를 제출 전 검증 증거로 연결하기 위한 스냅샷 문서를 추가합니다. 현재 `origin/dev` 기준 테스트 인벤토리, `clean check`, `verifySubmissionMetadata`, Oracle evidence 확보 경로를 정리했습니다.

## non-goals
- #25를 이 PR만으로 최종 종료하지 않습니다. 대기 PR 병합 후 최신 `dev`에서 재실행해야 합니다.
- UI QA 증빙, 최종 PDF 본문, 제출 zip 생성은 포함하지 않습니다.
- README, package script, traceability/final-report/demo 문서는 수정하지 않습니다.

## diff map
- `docs/test-gates/issue-25-model-service-persistence-gate-2026-06-02.md`: 테스트 클래스 인벤토리, 요구 범위별 테스트 매핑, 로컬 검증 결과, Oracle 최종 증거 확보 경로, 최종 재실행 체크리스트 추가

## verification evidence
- `./gradlew clean check --console=plain`
- `./gradlew verifySubmissionMetadata --console=plain`
- `git diff --cached --check`
- `./gradlew check --console=plain`
- pre-push `test + verifyRepositorySetup`

## reviewer focus areas
- #25 완료 기준을 과장하지 않고 현재 스냅샷과 최종 재실행 조건을 분리했는지
- model/service/persistence 테스트 매핑이 현재 테스트 구조와 맞는지
- 열린 PR들과 충돌하지 않도록 새 evidence 문서만 추가한 범위가 적절한지

## risk / rollback
- 문서 추가 PR이라 rollback 영향은 낮습니다.
- 최종 제출 직전에는 모든 대기 PR 병합 후 같은 명령을 다시 실행해야 합니다.