### PR TITLE
test: Architecture boundary와 testability guard 확장

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/config/ApplicationBootstrap.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/config/ApplicationBootstrap.java
@@ -24,6 +24,7 @@ import com.github.marcellokim.issuetracker.technical.SystemClock;
 import com.github.marcellokim.issuetracker.service.DashboardSummaryService;
 import com.github.marcellokim.issuetracker.service.DeletedIssueService;
 import com.github.marcellokim.issuetracker.service.IssueService;
+import com.github.marcellokim.issuetracker.service.IssueIdProvider;
 import com.github.marcellokim.issuetracker.service.IssueStateService;
 import com.github.marcellokim.issuetracker.service.IssueWorkflowService;
 import com.github.marcellokim.issuetracker.service.PasswordHashing;
@@ -34,6 +35,7 @@ import com.github.marcellokim.issuetracker.technical.PasswordHasher;
 import com.github.marcellokim.issuetracker.technical.SessionStore;
 import com.github.marcellokim.issuetracker.service.CommentIdProvider;
 import com.github.marcellokim.issuetracker.technical.CommentIdGenerator;
+import com.github.marcellokim.issuetracker.technical.IssueIdGenerator;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -57,6 +59,7 @@ public final class ApplicationBootstrap {
                 var dashboardSummaries = repositories.dashboardSummaries();
                 PermissionPolicy permissionPolicy = new PermissionPolicy();
                 Clock clock = new SystemClock();
+                IssueIdProvider issueIdProvider = new IssueIdGenerator();
                 CommentIdProvider commentIdProvider = new CommentIdGenerator();
                 AuthenticationService authenticationService = authenticationService(users);
                 AccountService accountService = new AccountService(
@@ -74,6 +77,7 @@ public final class ApplicationBootstrap {
                                 issueHistory,
                                 users,
                                 permissionPolicy,
+                                issueIdProvider,
                                 clock);
                 AssignmentService assignmentService = new AssignmentService(
                                 issues,

--- a/src/main/java/com/github/marcellokim/issuetracker/domain/Issue.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/domain/Issue.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 
 public class Issue {
 
@@ -15,8 +14,6 @@ public class Issue {
     private static final String COMMENT_DELETED_MESSAGE = "comment deleted";
     private static final String CHANGED_BY_REQUIRED = "changedBy must not be null";
     private static final String CHANGED_DATE_REQUIRED = "changedDate must not be null";
-    private static final String ISSUE_ID_PREFIX = "ISSUE-";
-
     private final long id;
     private final long projectId;
     private final String issueId;
@@ -49,7 +46,7 @@ public class Issue {
         Objects.requireNonNull(state, "state must not be null");
         this.id = persisted ? requirePositive(state.id, "id") : requireZero(state.id, "id");
         this.projectId = requirePositive(state.projectId, "projectId");
-        this.issueId = persisted ? requireText(state.issueId, "issueId") : issueIdOrNew(state.issueId);
+        this.issueId = requireText(state.issueId, "issueId");
         this.title = requireText(state.title, "title");
         this.description = requireText(state.description, "description");
         this.reportedDate = Objects.requireNonNull(state.reportedDate, "reportedDate must not be null");
@@ -568,17 +565,6 @@ public class Issue {
             throw new IllegalArgumentException(fieldName + " must be zero before persistence");
         }
         return value;
-    }
-
-    private static String newIssueId() {
-        return ISSUE_ID_PREFIX + UUID.randomUUID().toString();
-    }
-
-    private static String issueIdOrNew(String issueId) {
-        if (issueId == null || issueId.isBlank()) {
-            return newIssueId();
-        }
-        return requireText(issueId, "issueId");
     }
 
     private static String loginIdOrNull(User user) {

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueIdProvider.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueIdProvider.java
@@ -1,0 +1,6 @@
+package com.github.marcellokim.issuetracker.service;
+
+public interface IssueIdProvider {
+
+    String nextIssueId();
+}

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
@@ -46,6 +46,7 @@ public final class IssueService {
     private final IssueHistoryRepository issueHistoryRepository;
     private final UserRepository userRepository;
     private final PermissionPolicy permissionPolicy;
+    private final IssueIdProvider issueIdProvider;
     private final Clock clock;
 
     public IssueService(
@@ -56,6 +57,7 @@ public final class IssueService {
             IssueHistoryRepository issueHistoryRepository,
             UserRepository userRepository,
             PermissionPolicy permissionPolicy,
+            IssueIdProvider issueIdProvider,
             Clock clock) {
         this.projectRepository = Objects.requireNonNull(projectRepository, "projectRepository");
         this.issueRepository = Objects.requireNonNull(issueRepository, "issueRepository");
@@ -64,6 +66,7 @@ public final class IssueService {
         this.issueHistoryRepository = Objects.requireNonNull(issueHistoryRepository, "issueHistoryRepository");
         this.userRepository = Objects.requireNonNull(userRepository, "userRepository");
         this.permissionPolicy = Objects.requireNonNull(permissionPolicy, "permissionPolicy");
+        this.issueIdProvider = Objects.requireNonNull(issueIdProvider, "issueIdProvider");
         this.clock = Objects.requireNonNull(clock, "clock");
     }
 
@@ -83,6 +86,7 @@ public final class IssueService {
         LocalDateTime now = now();
         Issue issue = Issue.create(
                 Issue.persistedState(project.getId(), requiredTitle, requiredDescription, reporter)
+                        .issueId(issueIdProvider.nextIssueId())
                         .priority(priority != null ? priority : Priority.MAJOR)
                         .reportedDate(now)
                         .updatedAt(now));

--- a/src/main/java/com/github/marcellokim/issuetracker/technical/IssueIdGenerator.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/technical/IssueIdGenerator.java
@@ -1,0 +1,14 @@
+package com.github.marcellokim.issuetracker.technical;
+
+import com.github.marcellokim.issuetracker.service.IssueIdProvider;
+import java.util.UUID;
+
+public final class IssueIdGenerator implements IssueIdProvider {
+
+    private static final String ISSUE_ID_PREFIX = "ISSUE-";
+
+    @Override
+    public String nextIssueId() {
+        return ISSUE_ID_PREFIX + UUID.randomUUID();
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerFlowTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerFlowTest.java
@@ -33,6 +33,7 @@ import com.github.marcellokim.issuetracker.service.PermissionPolicy;
 import com.github.marcellokim.issuetracker.service.ProjectResult;
 import com.github.marcellokim.issuetracker.service.ProjectService;
 import com.github.marcellokim.issuetracker.service.UserResult;
+import com.github.marcellokim.issuetracker.support.SequentialIssueIdProvider;
 import com.github.marcellokim.issuetracker.support.FakeIssueDependencyRepository;
 import com.github.marcellokim.issuetracker.support.FakeIssueHistoryRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
@@ -163,6 +164,7 @@ class ControllerFlowTest {
                 new FakeIssueHistoryRepository(),
                 users,
                 policy,
+                new SequentialIssueIdProvider(),
                 () -> NOW);
         IssueWorkflowService workflowService = new IssueWorkflowService(
                 issues,

--- a/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerTestSupport.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerTestSupport.java
@@ -34,6 +34,7 @@ import com.github.marcellokim.issuetracker.support.FakeIssueDependencyRepository
 import com.github.marcellokim.issuetracker.support.FakeIssueHistoryRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
+import com.github.marcellokim.issuetracker.support.SequentialIssueIdProvider;
 import com.github.marcellokim.issuetracker.support.StatisticsReportTestFactory;
 import com.github.marcellokim.issuetracker.technical.PasswordHasher;
 import com.github.marcellokim.issuetracker.technical.SessionStore;
@@ -81,6 +82,7 @@ final class ControllerTestSupport {
                 new FakeIssueHistoryRepository(),
                 users,
                 policy,
+                new SequentialIssueIdProvider(),
                 () -> NOW);
         IssueWorkflowService workflowService = new IssueWorkflowService(
                 issueRepository,
@@ -107,6 +109,7 @@ final class ControllerTestSupport {
                 new FakeIssueHistoryRepository(),
                 users,
                 policy,
+                new SequentialIssueIdProvider(),
                 () -> NOW);
         IssueWorkflowService workflowService = new IssueWorkflowService(
                 issueRepository,

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCreationTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCreationTest.java
@@ -80,20 +80,22 @@ class IssueCreationTest {
         @Test
         @DisplayName("saved issue needs its ids")
         void savedIssueNeedsItsIds() {
-                assertThrows(IllegalArgumentException.class, () -> Issue.fromPersistence(
-                                Issue.persistedState(1L, "Bug", "desc", reporter)
-                                                .id(0L)
-                                                .issueId("ISSUE-1")
-                                                .reportedDate(createdAt)
-                                                .updatedAt(createdAt)));
-                assertThrows(IllegalArgumentException.class, () -> Issue.fromPersistence(Issue.persistedState(
+                Issue.PersistedState missingDatabaseId = Issue.persistedState(1L, "Bug", "desc", reporter)
+                                .id(0L)
+                                .issueId("ISSUE-1")
+                                .reportedDate(createdAt)
+                                .updatedAt(createdAt);
+                Issue.PersistedState missingIssueId = Issue.persistedState(
                                 1L,
                                 "Missing issue id",
                                 "Persisted state must carry DB issue_id.",
                                 reporter)
                                 .id(11L)
                                 .reportedDate(createdAt)
-                                .updatedAt(createdAt)));
+                                .updatedAt(createdAt);
+
+                assertThrows(IllegalArgumentException.class, () -> Issue.fromPersistence(missingDatabaseId));
+                assertThrows(IllegalArgumentException.class, () -> Issue.fromPersistence(missingIssueId));
         }
 
         @Test

--- a/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCreationTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/domain/IssueCreationTest.java
@@ -1,7 +1,6 @@
 package com.github.marcellokim.issuetracker.domain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -24,11 +23,12 @@ class IssueCreationTest {
                                 "Login fails",
                                 "Cannot log in",
                                 reporter)
+                                .issueId("ISSUE-NEW-1")
                                 .reportedDate(createdAt)
                                 .updatedAt(createdAt));
 
-                assertEquals(0L, issue.id());
-                assertFalse(issue.getIssueId().isBlank());
+        assertEquals(0L, issue.id());
+        assertEquals("ISSUE-NEW-1", issue.getIssueId());
                 assertEquals("Login fails", issue.getTitle());
                 assertEquals("Cannot log in", issue.getDescription());
                 assertSame(reporter, issue.getReporter());
@@ -50,6 +50,7 @@ class IssueCreationTest {
                                 "Crash",
                                 "App crashes",
                                 reporter)
+                                .issueId("ISSUE-NEW-2")
                                 .priority(Priority.CRITICAL)
                                 .reportedDate(createdAt)
                                 .updatedAt(createdAt));
@@ -100,7 +101,17 @@ class IssueCreationTest {
         void newIssueHasNoDatabaseIdYet() {
                 assertThrows(IllegalArgumentException.class, () -> Issue.create(
                                 Issue.persistedState(1L, "Bug", "desc", reporter)
+                                                .issueId("ISSUE-NEW-3")
                                                 .id(5L)
+                                                .reportedDate(createdAt)
+                                                .updatedAt(createdAt)));
+        }
+
+        @Test
+        @DisplayName("new issue needs an issue id")
+        void newIssueNeedsIssueId() {
+                assertThrows(IllegalArgumentException.class, () -> Issue.create(
+                                Issue.persistedState(1L, "Bug", "desc", reporter)
                                                 .reportedDate(createdAt)
                                                 .updatedAt(createdAt)));
         }

--- a/src/test/java/com/github/marcellokim/issuetracker/persistence/OracleRepositoryIntegrationTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/persistence/OracleRepositoryIntegrationTest.java
@@ -386,6 +386,7 @@ class OracleRepositoryIntegrationTest {
                                 "Temporary deleted issue for repository policy test",
                                 "Deleted issues should stay out of normal browse and statistics.",
                                 admin)
+                                .issueId(uniqueId("ISSUE_deleted_policy"))
                                 .reportedDate(reportedAt)
                                 .priority(Priority.TRIVIAL)
                                 .status(IssueStatus.DELETED)
@@ -700,6 +701,7 @@ class OracleRepositoryIntegrationTest {
                                         uniqueId("crud_project_composition_issue"),
                                         "Issue should be removed when its owning project is deleted.",
                                         user("dev1"))
+                                        .issueId(uniqueId("ISSUE_project_composition"))
                                         .reportedDate(LocalDateTime.now())
                                         .priority(Priority.MINOR)
                                         .status(IssueStatus.NEW)
@@ -740,6 +742,7 @@ class OracleRepositoryIntegrationTest {
                                         title,
                                         "Issue repository CRUD test.",
                                         user("dev1"))
+                                        .issueId(uniqueId("ISSUE_crud_issue"))
                                         .reportedDate(LocalDateTime.now())
                                         .priority(Priority.MINOR)
                                         .status(IssueStatus.NEW)
@@ -838,6 +841,7 @@ class OracleRepositoryIntegrationTest {
                                         title,
                                         "Aggregate root save should persist audit children.",
                                         user("dev1"))
+                                        .issueId(uniqueId("ISSUE_aggregate_audit"))
                                         .reportedDate(LocalDateTime.now())
                                         .priority(Priority.MAJOR)
                                         .status(IssueStatus.NEW)
@@ -1146,6 +1150,7 @@ class OracleRepositoryIntegrationTest {
                                         uniqueId("crud_stats_issue"),
                                         "Resolved issue for statistics and recommendation CRUD test.",
                                         user("tester4"))
+                                        .issueId(uniqueId("ISSUE_stats"))
                                         .reportedDate(LocalDateTime.now())
                                         .priority(Priority.CRITICAL)
                                         .status(IssueStatus.RESOLVED)
@@ -1228,6 +1233,7 @@ class OracleRepositoryIntegrationTest {
                                         uniqueId("participant_guard_issue"),
                                         "Assigned issue for participant removal guard.",
                                         user("tester1"))
+                                        .issueId(uniqueId("ISSUE_participant_guard"))
                                         .reportedDate(LocalDateTime.now())
                                         .priority(Priority.MAJOR)
                                         .status(IssueStatus.ASSIGNED)
@@ -1503,6 +1509,7 @@ class OracleRepositoryIntegrationTest {
                                 repositories.issueHistory(),
                                 repositories.users(),
                                 permissionPolicy(),
+                                OracleRepositoryIntegrationTest::nextIssueId,
                                 LocalDateTime::now);
         }
 
@@ -1528,6 +1535,10 @@ class OracleRepositoryIntegrationTest {
 
         private static String nextCommentId() {
                 return "COMMENT-test-" + UUID.randomUUID();
+        }
+
+        private static String nextIssueId() {
+                return "ISSUE-test-" + UUID.randomUUID();
         }
 
         private static DeletedIssueService deletedIssueService() {
@@ -1610,6 +1621,7 @@ class OracleRepositoryIntegrationTest {
                                 title,
                                 "Repository CRUD support issue.",
                                 user("dev1"))
+                                .issueId(uniqueId("ISSUE_support"))
                                 .reportedDate(LocalDateTime.now())
                                 .priority(Priority.MINOR)
                                 .status(status)

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueServiceTest.java
@@ -23,6 +23,7 @@ import com.github.marcellokim.issuetracker.support.FakeIssueHistoryRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.support.SequentialIssueIdProvider;
 import com.github.marcellokim.issuetracker.domain.IssueDependency;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
@@ -1271,6 +1272,7 @@ class IssueServiceTest {
                                 histories,
                                 users,
                                 new PermissionPolicy(),
+                                new SequentialIssueIdProvider(),
                                 LocalDateTime::now);
         }
 

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/ArchitectureBoundaryTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/ArchitectureBoundaryTest.java
@@ -100,6 +100,56 @@ class ArchitectureBoundaryTest {
     }
 
     @Test
+    @DisplayName("runtime source scan ignores comments")
+    void runtimeSourceScanIgnoresComments() {
+        JavaSource source = new JavaSource(
+                "domain/Sample.java",
+                List.of(
+                        "package com.github.marcellokim.issuetracker.domain;",
+                        "// UUID.randomUUID( is documentation only.",
+                        "/* LocalDateTime.now( belongs in the example text.",
+                        " * System.currentTimeMillis( is not executable here.",
+                        " */",
+                        "final class Sample {",
+                        "    void method() {",
+                        "        String value = \"safe\";",
+                        "    }",
+                        "}"
+                ),
+                List.of()
+        );
+
+        List<Violation> violations = runtimeSourceViolations(
+                source,
+                Set.of("UUID.randomUUID(", "LocalDateTime.now(", "System.currentTimeMillis(")
+        );
+
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    @DisplayName("runtime source scan reports executable calls")
+    void runtimeSourceScanReportsExecutableCalls() {
+        JavaSource source = new JavaSource(
+                "domain/Sample.java",
+                List.of(
+                        "package com.github.marcellokim.issuetracker.domain;",
+                        "final class Sample {",
+                        "    Object id() {",
+                        "        return UUID.randomUUID();",
+                        "    }",
+                        "}"
+                ),
+                List.of()
+        );
+
+        List<Violation> violations = runtimeSourceViolations(source, Set.of("UUID.randomUUID("));
+
+        assertEquals(1, violations.size());
+        assertEquals(4, violations.get(0).lineNumber());
+    }
+
+    @Test
     @DisplayName("jdbc user repository depends on password hashing port")
     void jdbcUserRepositoryDependsOnPasswordHashingPort() throws NoSuchMethodException {
         Constructor<JdbcUserRepository> repositoryConstructor = JdbcUserRepository.class.getConstructor(
@@ -227,19 +277,7 @@ class ArchitectureBoundaryTest {
         List<Violation> violations = new ArrayList<>();
         for (String packageSegment : packageSegments) {
             for (JavaSource source : productionSources(packageSegment)) {
-                for (int index = 0; index < source.lines().size(); index++) {
-                    String line = source.lines().get(index);
-                    for (String forbiddenText : forbiddenTexts) {
-                        if (line.contains(forbiddenText)) {
-                            violations.add(new Violation(
-                                    source.relativePath(),
-                                    index + 1,
-                                    "uses runtime source",
-                                    forbiddenText
-                            ));
-                        }
-                    }
-                }
+                violations.addAll(runtimeSourceViolations(source, forbiddenTexts));
             }
         }
 
@@ -247,6 +285,58 @@ class ArchitectureBoundaryTest {
                 violations.isEmpty(),
                 () -> "Forbidden runtime sources found:%n%s".formatted(formatViolations(violations))
         );
+    }
+
+    private static List<Violation> runtimeSourceViolations(JavaSource source, Set<String> forbiddenTexts) {
+        List<Violation> violations = new ArrayList<>();
+        boolean inBlockComment = false;
+        for (int index = 0; index < source.lines().size(); index++) {
+            CodeLine codeLine = executablePart(source.lines().get(index), inBlockComment);
+            inBlockComment = codeLine.inBlockComment();
+            for (String forbiddenText : forbiddenTexts) {
+                if (codeLine.text().contains(forbiddenText)) {
+                    violations.add(new Violation(
+                            source.relativePath(),
+                            index + 1,
+                            "uses runtime source",
+                            forbiddenText
+                    ));
+                }
+            }
+        }
+        return violations;
+    }
+
+    private static CodeLine executablePart(String line, boolean startsInBlockComment) {
+        StringBuilder code = new StringBuilder();
+        boolean inBlockComment = startsInBlockComment;
+        int cursor = 0;
+        while (cursor < line.length()) {
+            if (inBlockComment) {
+                int commentEnd = line.indexOf("*/", cursor);
+                if (commentEnd < 0) {
+                    return new CodeLine(code.toString(), true);
+                }
+                cursor = commentEnd + 2;
+                inBlockComment = false;
+                continue;
+            }
+
+            int lineCommentStart = line.indexOf("//", cursor);
+            int blockCommentStart = line.indexOf("/*", cursor);
+            if (lineCommentStart < 0 && blockCommentStart < 0) {
+                code.append(line.substring(cursor));
+                break;
+            }
+            if (lineCommentStart >= 0 && (blockCommentStart < 0 || lineCommentStart < blockCommentStart)) {
+                code.append(line, cursor, lineCommentStart);
+                break;
+            }
+            code.append(line, cursor, blockCommentStart);
+            cursor = blockCommentStart + 2;
+            inBlockComment = true;
+        }
+        return new CodeLine(code.toString(), inBlockComment);
     }
 
     private static boolean isForbidden(String importedType, Set<String> forbiddenPrefixes) {
@@ -351,5 +441,8 @@ class ArchitectureBoundaryTest {
     }
 
     record Violation(String relativePath, int lineNumber, String kind, String reference) {
+    }
+
+    record CodeLine(String text, boolean inBlockComment) {
     }
 }

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/ArchitectureBoundaryTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/ArchitectureBoundaryTest.java
@@ -11,8 +11,10 @@ import com.github.marcellokim.issuetracker.repository.DashboardSummaryRepository
 import com.github.marcellokim.issuetracker.service.Clock;
 import com.github.marcellokim.issuetracker.service.CommentIdProvider;
 import com.github.marcellokim.issuetracker.service.CurrentUserSession;
+import com.github.marcellokim.issuetracker.service.IssueIdProvider;
 import com.github.marcellokim.issuetracker.service.PasswordHashing;
 import com.github.marcellokim.issuetracker.technical.CommentIdGenerator;
+import com.github.marcellokim.issuetracker.technical.IssueIdGenerator;
 import com.github.marcellokim.issuetracker.technical.PasswordHasher;
 import com.github.marcellokim.issuetracker.technical.SessionStore;
 import com.github.marcellokim.issuetracker.technical.SystemClock;
@@ -76,8 +78,25 @@ class ArchitectureBoundaryTest {
     void technicalImplementationsSatisfyServicePorts() {
         assertTrue(Clock.class.isAssignableFrom(SystemClock.class));
         assertTrue(CommentIdProvider.class.isAssignableFrom(CommentIdGenerator.class));
+        assertTrue(IssueIdProvider.class.isAssignableFrom(IssueIdGenerator.class));
         assertTrue(CurrentUserSession.class.isAssignableFrom(SessionStore.class));
         assertTrue(PasswordHashing.class.isAssignableFrom(PasswordHasher.class));
+    }
+
+    @Test
+    @DisplayName("domain and service packages keep runtime sources behind ports")
+    void domainAndServicesKeepRuntimeSourcesBehindPorts() throws IOException {
+        assertNoForbiddenSourceText(
+                Set.of("domain", "service"),
+                Set.of(
+                        "LocalDateTime.now(",
+                        "Instant.now(",
+                        "System.currentTimeMillis(",
+                        "UUID.randomUUID(",
+                        "Math.random(",
+                        "new Random("
+                )
+        );
     }
 
     @Test
@@ -201,6 +220,33 @@ class ArchitectureBoundaryTest {
                     () -> sourcePath + " must not contain " + forbiddenText
             );
         }
+    }
+
+    private static void assertNoForbiddenSourceText(Set<String> packageSegments, Set<String> forbiddenTexts)
+            throws IOException {
+        List<Violation> violations = new ArrayList<>();
+        for (String packageSegment : packageSegments) {
+            for (JavaSource source : productionSources(packageSegment)) {
+                for (int index = 0; index < source.lines().size(); index++) {
+                    String line = source.lines().get(index);
+                    for (String forbiddenText : forbiddenTexts) {
+                        if (line.contains(forbiddenText)) {
+                            violations.add(new Violation(
+                                    source.relativePath(),
+                                    index + 1,
+                                    "uses runtime source",
+                                    forbiddenText
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        assertTrue(
+                violations.isEmpty(),
+                () -> "Forbidden runtime sources found:%n%s".formatted(formatViolations(violations))
+        );
     }
 
     private static boolean isForbidden(String importedType, Set<String> forbiddenPrefixes) {

--- a/src/test/java/com/github/marcellokim/issuetracker/support/SequentialIssueIdProvider.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/support/SequentialIssueIdProvider.java
@@ -1,21 +1,22 @@
 package com.github.marcellokim.issuetracker.support;
 
 import com.github.marcellokim.issuetracker.service.IssueIdProvider;
+import java.util.concurrent.atomic.AtomicLong;
 
 public final class SequentialIssueIdProvider implements IssueIdProvider {
 
-    private long next;
+    private final AtomicLong next;
 
     public SequentialIssueIdProvider() {
         this(1L);
     }
 
     public SequentialIssueIdProvider(long first) {
-        this.next = first;
+        this.next = new AtomicLong(first);
     }
 
     @Override
     public String nextIssueId() {
-        return "ISSUE-" + next++;
+        return "ISSUE-" + next.getAndIncrement();
     }
 }

--- a/src/test/java/com/github/marcellokim/issuetracker/support/SequentialIssueIdProvider.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/support/SequentialIssueIdProvider.java
@@ -1,0 +1,21 @@
+package com.github.marcellokim.issuetracker.support;
+
+import com.github.marcellokim.issuetracker.service.IssueIdProvider;
+
+public final class SequentialIssueIdProvider implements IssueIdProvider {
+
+    private long next;
+
+    public SequentialIssueIdProvider() {
+        this(1L);
+    }
+
+    public SequentialIssueIdProvider(long first) {
+        this.next = first;
+    }
+
+    @Override
+    public String nextIssueId() {
+        return "ISSUE-" + next++;
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/support/SequentialIssueIdProviderTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/support/SequentialIssueIdProviderTest.java
@@ -1,0 +1,50 @@
+package com.github.marcellokim.issuetracker.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("sequential issue id provider")
+class SequentialIssueIdProviderTest {
+
+    @Test
+    @DisplayName("generates unique ids under concurrent access")
+    void generatesUniqueIdsUnderConcurrentAccess() throws InterruptedException {
+        SequentialIssueIdProvider provider = new SequentialIssueIdProvider();
+        int threads = 32;
+        int idsPerThread = 500;
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+        Set<String> ids = ConcurrentHashMap.newKeySet();
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+
+        for (int thread = 0; thread < threads; thread++) {
+            executor.execute(() -> {
+                try {
+                    start.await();
+                    IntStream.range(0, idsPerThread)
+                            .mapToObj(ignored -> provider.nextIssueId())
+                            .forEach(ids::add);
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        start.countDown();
+        done.await(10, TimeUnit.SECONDS);
+        executor.shutdownNow();
+
+        assertEquals(threads * idsPerThread, ids.size());
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/technical/IssueIdGeneratorTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/technical/IssueIdGeneratorTest.java
@@ -1,0 +1,24 @@
+package com.github.marcellokim.issuetracker.technical;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("issue id generator")
+class IssueIdGeneratorTest {
+
+    @Test
+    @DisplayName("generates prefixed issue ids")
+    void generatesPrefixedIssueIds() {
+        IssueIdGenerator generator = new IssueIdGenerator();
+
+        String first = generator.nextIssueId();
+        String second = generator.nextIssueId();
+
+        assertTrue(first.startsWith("ISSUE-"));
+        assertTrue(second.startsWith("ISSUE-"));
+        assertNotEquals(first, second);
+    }
+}

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPresenterTest.java
@@ -38,6 +38,7 @@ import com.github.marcellokim.issuetracker.support.InMemoryAssignmentRecommendat
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.support.SequentialIssueIdProvider;
 import com.github.marcellokim.issuetracker.technical.SessionStore;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
@@ -509,6 +510,7 @@ class IssueDetailPresenterTest {
                 new FakeIssueHistoryRepository(),
                 users,
                 permissionPolicy,
+                new SequentialIssueIdProvider(),
                 () -> NOW);
         IssueWorkflowService workflowService = new IssueWorkflowService(
                 issueRepository,

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPresenterTest.java
@@ -25,6 +25,7 @@ import com.github.marcellokim.issuetracker.support.FakeIssueHistoryRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.support.SequentialIssueIdProvider;
 import com.github.marcellokim.issuetracker.technical.SessionStore;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -168,6 +169,7 @@ class IssueListPresenterTest {
                         new FakeIssueHistoryRepository(),
                         users,
                         permissionPolicy,
+                        new SequentialIssueIdProvider(),
                         () -> NOW));
         return new ControllerFixture(projectController, issueController);
     }

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/SwingAppPanelTest.java
@@ -55,6 +55,7 @@ import com.github.marcellokim.issuetracker.support.InMemoryAssignmentRecommendat
 import com.github.marcellokim.issuetracker.support.InMemoryIssueRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryProjectRepository;
 import com.github.marcellokim.issuetracker.support.InMemoryUserRepository;
+import com.github.marcellokim.issuetracker.support.SequentialIssueIdProvider;
 import com.github.marcellokim.issuetracker.technical.SessionStore;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
@@ -1783,6 +1784,7 @@ class SwingAppPanelTest {
                                 historyRepository,
                                 repository,
                                 permissionPolicy,
+                                new SequentialIssueIdProvider(),
                                 () -> NOW),
                         new IssueWorkflowService(
                                 issueRepository,


### PR DESCRIPTION
## purpose
- #171 기준으로 architecture boundary와 testability guard를 실행 테스트로 보강함.
- issue id 생성도 `IssueIdProvider` service port와 `IssueIdGenerator` technical adapter로 분리해 domain/service가 직접 runtime source에 의존하지 않게 정리함.
- Closes #171

## non-goals
- 화면 동작이나 이슈 workflow 정책을 변경하지 않음.
- persistence schema나 seed data를 변경하지 않음.
- 광범위한 grep식 예외 목록을 늘리지 않음.

## diff map
- `ArchitectureBoundaryTest`
  - domain/service package가 시간/랜덤 runtime source를 직접 호출하지 않는 guard 추가
  - `IssueIdProvider`와 `IssueIdGenerator` port-adapter 계약 확인 추가
- `Issue`, `IssueService`, `ApplicationBootstrap`
  - issue id 생성 책임을 domain 내부 random 호출에서 service port 주입으로 이동
- 테스트 지원 코드
  - `SequentialIssueIdProvider` 추가
  - controller/service/swing/oracle 테스트 생성 경로에 deterministic issue id provider 적용

## verification evidence
- RED: `./gradlew test --tests '*ArchitectureBoundaryTest' --console=plain`에서 `domain/Issue.java`의 `UUID.randomUUID(` 직접 호출로 실패 확인
- GREEN: `./gradlew test --tests '*ArchitectureBoundaryTest' --console=plain`
- `./gradlew test --tests '*ArchitectureBoundaryTest' --tests '*RepositoryConventionsSmokeTest' --console=plain`
- `git diff --check`
- `./gradlew verifySubmissionMetadata --console=plain`
- `./gradlew check --console=plain`
- pre-commit: `verifyRepositorySetup`
- pre-push: `test + verifyRepositorySetup`

## reviewer focus areas
- issue id 생성을 domain에서 service port로 이동한 경계가 현재 architecture 문서 방향과 맞는지 확인 필요.
- runtime source guard가 false positive를 만들 만큼 넓지 않은지 확인 필요.

## risk / rollback
- 런타임 동작상 issue id 형식은 `ISSUE-<uuid>`로 유지됨.
- 문제가 있으면 `IssueIdProvider` 주입 변경과 architecture guard 추가를 함께 되돌리면 됨.