### PR TITLE
fix: GitHub Project 항목 로딩 한계 보정

### DIFF
--- a/scripts/lib/project_maintenance.py
+++ b/scripts/lib/project_maintenance.py
@@ -14,6 +14,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 PROJECT_TITLE = "SE 2026-1 텀프로젝트"
 STATUS_FIELD = "Status"
+PROJECT_ITEM_LIST_LIMIT = "1000"
 
 STATUS_BY_LABEL = {
     "status:backlog": "대기",
@@ -208,7 +209,19 @@ def load_project_context(repo: str, owner: str, project_number: int | None, proj
     if not status_field:
         raise SystemExit("프로젝트 Status 필드를 찾을 수 없습니다.")
 
-    project_items = gh_json(["project", "item-list", str(resolved_number), "--owner", owner, "--format", "json", "--limit", "200"])
+    project_items = gh_json(
+        [
+            "project",
+            "item-list",
+            str(resolved_number),
+            "--owner",
+            owner,
+            "--format",
+            "json",
+            "--limit",
+            PROJECT_ITEM_LIST_LIMIT,
+        ]
+    )
     item_by_url = {
         item["content"]["url"]: item
         for item in project_items.get("items", [])

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
@@ -212,7 +212,7 @@ class ProjectMaintenanceScriptTest {
                         }
                     if args[:2] == ["project", "item-list"]:
                         limit = int(args[args.index("--limit") + 1])
-                        assert limit >= 1000, args
+                        assert limit == int(project_maintenance.PROJECT_ITEM_LIST_LIMIT), args
                         return {
                             "items": [{
                                 "id": "PVTI_recent",

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/ProjectMaintenanceScriptTest.java
@@ -187,6 +187,57 @@ class ProjectMaintenanceScriptTest {
         assertTrue(result.output().contains("rate limit exceeded"), result.output());
     }
 
+    @Test
+    @DisplayName("프로젝트 항목 context는 200개를 넘는 보드에서도 기존 항목을 인식한다")
+    void projectContextLoadsMoreThanTwoHundredItems() throws IOException, InterruptedException {
+        String script = """
+                import importlib.util
+                import sys
+
+                spec = importlib.util.spec_from_file_location("project_maintenance", "scripts/lib/project_maintenance.py")
+                project_maintenance = importlib.util.module_from_spec(spec)
+                sys.modules[spec.name] = project_maintenance
+                spec.loader.exec_module(project_maintenance)
+
+                def fake_gh_json(args):
+                    if args[:2] == ["project", "view"]:
+                        return {"id": "PVT_project", "readme": ""}
+                    if args[:2] == ["project", "field-list"]:
+                        return {
+                            "fields": [{
+                                "id": "PVTSSF_status",
+                                "name": "Status",
+                                "options": [{"id": "option_review", "name": "리뷰 중"}]
+                            }]
+                        }
+                    if args[:2] == ["project", "item-list"]:
+                        limit = int(args[args.index("--limit") + 1])
+                        assert limit >= 1000, args
+                        return {
+                            "items": [{
+                                "id": "PVTI_recent",
+                                "content": {"url": "https://github.com/marcellokim/se-issue-tracker/pull/262"}
+                            }]
+                        }
+                    raise AssertionError(args)
+
+                project_maintenance.gh_json = fake_gh_json
+
+                context, _ = project_maintenance.load_project_context(
+                    "marcellokim/se-issue-tracker",
+                    "@me",
+                    1,
+                    "SE 2026-1 텀프로젝트"
+                )
+
+                assert "https://github.com/marcellokim/se-issue-tracker/pull/262" in context.item_by_url
+                """;
+
+        ScriptResult result = runPython(script);
+
+        assertEquals(0, result.exitCode(), result.output());
+    }
+
     private ScriptResult runPython(String script) throws IOException, InterruptedException {
         Path scriptFile = Files.createTempFile("project-maintenance-test-", ".py");
         Files.writeString(scriptFile, script, StandardCharsets.UTF_8);


### PR DESCRIPTION
## purpose
Project 보드 항목 수가 200개를 넘은 뒤 `sync-project-board.sh --dry-run`이 이미 등록된 open issue/PR을 다시 add 대상으로 출력하는 문제를 보정합니다.

## non-goals
- 제출 증빙 캡처 자체나 최종 보고서 내용은 이 PR에서 만들지 않습니다.
- milestone/issue 일정 재조정 정책은 변경하지 않습니다.

## diff map
- `scripts/lib/project_maintenance.py`: Project item-list limit을 1000으로 상향하고 상수화합니다.
- `ProjectMaintenanceScriptTest`: 200개 초과 보드에서도 기존 item URL을 context에서 인식하는 회귀 테스트를 추가합니다.

## verification evidence
- `git diff --check`
- `./gradlew test --tests 'com.github.marcellokim.issuetracker.setup.ProjectMaintenanceScriptTest' verifySubmissionMetadata --console=plain`
- `./gradlew check --console=plain`
- `./scripts/sync-project-board.sh --owner @me --dry-run --quiet`

## reviewer focus areas
- ProjectV2 item 조회 한계값이 현재 보드 규모와 제출 전 증가분을 감당하는지
- 중복 add false-positive만 줄이고 status 정렬 로직은 바꾸지 않았는지

## risk / rollback
위험은 낮습니다. GitHub Project 항목이 1000개를 넘으면 같은 문제가 다시 생길 수 있으므로, 그 시점에는 pagination 방식으로 확장하면 됩니다.

## related issue
- Refs #27