### PR TITLE
refactor: 이슈 검색 중복 API 제거

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/controller/IssueController.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/controller/IssueController.java
@@ -87,12 +87,6 @@ public final class IssueController {
                 user.getLoginId());
     }
 
-    public List<IssueSummary> searchRelatedProjectIssues(long projectId, String keyword, IssueStatus status,
-            Priority priority) {
-        User user = requireCurrentUser();
-        return issueService.searchRelatedProjectIssues(projectId, keyword, status, priority, user.getLoginId());
-    }
-
     public List<IssueSummary> viewRelatedProjectIssues(long projectId) {
         User user = requireCurrentUser();
         return issueService.viewRelatedProjectIssues(projectId, user.getLoginId());

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
@@ -164,35 +164,6 @@ public final class IssueService {
                 .toList();
     }
 
-    public List<IssueSummary> searchRelatedProjectIssues(
-            long projectId,
-            String keyword,
-            IssueStatus status,
-            Priority priority,
-            String currentLoginId) {
-
-        SearchContext context = searchContext(
-                projectId,
-                status,
-                null,
-                null,
-                currentLoginId,
-                "Only project members can search related project issues.");
-        return searchIssuesByCriteria(IssueSearchCriteria.create(
-                context.projectId(),
-                status,
-                priority,
-                null,
-                null,
-                null,
-                optionalText(keyword),
-                null,
-                null,
-                false)).stream()
-                .map(IssueService::toIssueSummary)
-                .toList();
-    }
-
     public List<IssueSummary> viewRelatedProjectIssues(long projectId, String currentLoginId) {
         long requiredProjectId = requirePositive(projectId, FIELD_PROJECT_ID);
         String requiredLoginId = requireText(currentLoginId, FIELD_CURRENT_LOGIN_ID);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPresenter.java
@@ -36,7 +36,7 @@ final class IssueListPresenter {
     void searchIssues(long projectId, IssueSearchRequest request) {
         Objects.requireNonNull(request, "request");
         try {
-            showIssues(issueController.searchRelatedProjectIssues(
+            showIssues(issueController.searchIssues(
                     projectId,
                     request.keyword(),
                     request.status(),

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
@@ -250,6 +250,31 @@ class RepositoryConventionsSmokeTest {
         );
     }
 
+    @Test
+    @DisplayName("이슈 검색은 related 전용 중복 API 없이 표준 검색 경로를 사용한다")
+    void issueSearchUsesStandardSearchPathWithoutRelatedDuplicateApi() throws IOException {
+        try (Stream<Path> paths = Files.walk(Path.of("src/main/java"))) {
+            var offenders = paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .filter(path -> readUnchecked(path).contains("searchRelatedProjectIssues"))
+                    .toList();
+
+            assertTrue(
+                    offenders.isEmpty(),
+                    () -> "삭제 대상 중복 검색 API가 남아 있습니다: " + offenders
+            );
+        }
+    }
+
+    private static String readUnchecked(Path path) {
+        try {
+            return Files.readString(path);
+        } catch (IOException exception) {
+            throw new java.io.UncheckedIOException(exception);
+        }
+    }
+
     record ScriptExpectation(String relativePath, String expectedText) {
     }
 }


### PR DESCRIPTION
## purpose
- Swing 이슈 목록 검색에서 별도 related 검색 API를 사용하던 중복 경로를 제거한다.
- 표준 `IssueController.searchIssues` / `IssueService.searchIssues` 경로로 통일해 검색 정책과 필터 적용 지점을 한 곳으로 모은다.

## non-goals
- `viewRelatedProjectIssues`는 목록 초기 조회와 의존성 선택 등에 쓰이는 조회 API라 이번 PR에서 제거하지 않는다.
- 이슈 열람 권한 정책 자체는 변경하지 않는다.

## diff map
- `IssueController`, `IssueService`: `searchRelatedProjectIssues` 제거
- `IssueListPresenter`: Swing 검색 호출을 표준 `searchIssues`로 변경
- `RepositoryConventionsSmokeTest`: 제거 대상 중복 API가 production 코드에 다시 생기지 않도록 회귀 테스트 추가

## verification evidence
- `git diff --check`
- `./gradlew test --tests 'com.github.marcellokim.issuetracker.setup.RepositoryConventionsSmokeTest.issueSearchUsesStandardSearchPathWithoutRelatedDuplicateApi' --tests 'com.github.marcellokim.issuetracker.controller.IssueControllerTest' --tests 'com.github.marcellokim.issuetracker.ui.swing.IssueListPresenterTest' --tests 'com.github.marcellokim.issuetracker.service.IssueServiceTest' --console=plain`
- `./gradlew check --console=plain`

## reviewer focus areas
- Swing 이슈 검색 결과가 기존과 같이 project/keyword/status/priority 기준으로 유지되는지
- 제거된 중복 API 대신 표준 검색 경로를 타는 것이 권한/DELETED 제외 정책과 충돌하지 않는지

## risk / rollback
- 변경 범위는 검색 호출 경로 정리에 한정된다.
- 문제가 있으면 `IssueListPresenter` 호출부를 이전 전용 메서드 경로로 되돌리면 된다.

## 관련 이슈
- Closes #264