### PR TITLE
refactor: 이슈 열람 정책과 검색 API 정리

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -12,7 +12,7 @@
 - UC/OC/DCD 추적성
 - 구현과 설계 문서 사이의 차이 또는 보강 사항
 
-통계는 전체 시스템이나 이슈 상세가 아니라 선택된 프로젝트 화면에서 조회한다. non-ADMIN 사용자의 프로젝트 이슈 목록은 대시보드가 아니라 프로젝트 진입 후 `IssueController.viewRelatedProjectIssues(projectId)`로 조회한다.
+통계는 전체 시스템이나 이슈 상세가 아니라 선택된 프로젝트 화면에서 조회한다. non-ADMIN 사용자의 프로젝트 이슈 목록은 대시보드가 아니라 프로젝트 진입 후 `IssueController.viewProjectIssues(projectId)`로 조회한다.
 
 ## 컨트롤러 문서
 
@@ -37,7 +37,7 @@
 | `AuthenticationController` | `login`, `logout` |
 | `DashboardController` | `viewProjects`, `viewUsers` |
 | `DeletedIssueController` | `viewDeletedIssues`, `deleteIssue`, `restoreIssue`, `purgeDeletedIssue` |
-| `IssueController` | `registerIssue`, `canRegisterIssue`, `viewIssueDetail`, `searchIssues`, `viewRelatedProjectIssues`, `updateIssue`, `changePriority`, `addComment`, `viewComments`, `addDependency`, `viewProjectDependencies`, `removeDependency`, `deleteComment`, `updateComment`, `viewAvailableActions`, `canUpdateComment`, `canDeleteComment` |
+| `IssueController` | `registerIssue`, `canRegisterIssue`, `viewIssueDetail`, `searchIssues`, `viewProjectIssues`, `updateIssue`, `changePriority`, `addComment`, `viewComments`, `addDependency`, `viewProjectDependencies`, `removeDependency`, `deleteComment`, `updateComment`, `viewAvailableActions`, `canUpdateComment`, `canDeleteComment` |
 | `IssueStateController` | `changeStatus` |
 | `ProjectController` | `viewProjectNonAdminDetail`, `viewProjectAdminDetail`, `viewProjectParticipants`, `createProject`, `renameProject`, `changeProjectDescription`, `deleteProject`, `addProjectParticipant`, `removeProjectParticipant` |
 | `StatisticsController` | `viewStatistics` |
@@ -64,7 +64,7 @@
    - 자신이 참여한 프로젝트 요약만 조회한다.
 3. 프로젝트 선택 시 `ProjectController.viewProjectNonAdminDetail(projectId)`
    - 프로젝트 기본 정보를 조회한다.
-4. 같은 프로젝트 화면에서 `IssueController.viewRelatedProjectIssues(projectId)`
+4. 같은 프로젝트 화면에서 `IssueController.viewProjectIssues(projectId)`
    - PL/DEV/TESTER 프로젝트 멤버는 해당 프로젝트의 일반 이슈를 조회한다.
    - reporter, 현재 assignee, 현재 verifier 조건은 `IssueController.searchIssues(...)` 필터로 좁힌다.
    - 완료 이력인 fixer/resolver는 기본 이슈 목록 범위를 제한하지 않는다.
@@ -79,7 +79,7 @@
 | --- | --- |
 | UC1 / OC-01 Register Issue | `IssueController.registerIssue` |
 | UC2 / OC-02 Add Comment | `IssueController.addComment` |
-| UC3 Browse/Search Issues | `IssueController.searchIssues`, `viewRelatedProjectIssues` |
+| UC3 Browse/Search Issues | `IssueController.searchIssues`, `viewProjectIssues` |
 | UC4 View Issue Detail | `IssueController.viewIssueDetail` |
 | UC5 / OC-03, OC-04, OC-05, OC-12 Assignment | `AssignmentController.assignIssue`, `reassignIssue`, `changeVerifier` |
 | UC6 / OC-06, OC-07, OC-08, OC-09, OC-13 State change | `IssueStateController.changeStatus` |

--- a/docs/api/dashboard-controller.md
+++ b/docs/api/dashboard-controller.md
@@ -2,7 +2,7 @@
 
 ## 범위
 
-`DashboardController`는 로그인 후 첫 화면과 화면 이동에 필요한 읽기 전용 API를 제공한다. 프로젝트와 사용자 요약 데이터는 `DashboardSummaryService`를 통해 조회한다. 프로젝트 이슈 목록 조회는 대시보드 컨트롤러가 아니라 `IssueController.viewRelatedProjectIssues`에서 처리한다.
+`DashboardController`는 로그인 후 첫 화면과 화면 이동에 필요한 읽기 전용 API를 제공한다. 프로젝트와 사용자 요약 데이터는 `DashboardSummaryService`를 통해 조회한다. 프로젝트 이슈 조회는 대시보드 컨트롤러가 아니라 `IssueController.viewProjectIssues`에서 처리한다.
 
 ## 공개 오퍼레이션
 

--- a/docs/api/issue-controller.md
+++ b/docs/api/issue-controller.md
@@ -13,7 +13,7 @@
 | `viewIssueDetail(issueId)` | `IssueService.viewIssueDetail(issueId, currentUserId)`, 필요 시 `IssueWorkflowService.viewAvailableActions` | `IssueDetailResult` |
 | `searchIssues(projectId, keyword, status, priority)` | 추가 필터를 `null`로 채운 전체 `searchIssues` 오버로드 | `List<IssueSummary>` |
 | `searchIssues(projectId, keyword, status, priority, reporterId, assigneeId, verifierId, reportedFrom, reportedTo)` | `IssueService.searchIssues(...)` | `List<IssueSummary>` |
-| `viewRelatedProjectIssues(projectId)` | `IssueService.viewRelatedProjectIssues(projectId, currentUserId)` | `List<IssueSummary>` |
+| `viewProjectIssues(projectId)` | `IssueService.viewProjectIssues(projectId, currentUserId)` | `List<IssueSummary>` |
 | `updateIssue(issueId, title, description)` | `IssueService.updateIssue(issueId, title, description, currentUserId)` | `IssueResult` |
 | `changePriority(issueId, priority)` | `IssueService.changePriority(issueId, priority, currentUserId)` | `IssueResult` |
 | `addComment(issueId, content)` | `IssueService.addComment(issueId, content, currentUserId)` | `CommentResult` |
@@ -39,7 +39,7 @@
 
 `viewIssueDetail`은 이슈 기본 정보, reporter/assignee/verifier/fixer/resolver, 댓글, 히스토리, 현재 이슈를 막고 있는 dependency 정보를 반환한다. 컨트롤러가 `IssueWorkflowService`와 함께 생성된 경우에는 `IssueWorkflowActions`를 계산해 `IssueDetailResult.availableActions` 이름 목록으로 포함한다. `IssueWorkflowService`가 없으면 상세 정보만 반환하고 action 목록은 비어 있다.
 
-`viewRelatedProjectIssues`는 특정 프로젝트 내부의 일반 이슈 목록을 반환한다. PL/DEV/TESTER 프로젝트 멤버는 같은 프로젝트의 일반 이슈를 볼 수 있고, reporter, 현재 assignee, 현재 verifier 조건은 `searchIssues` 필터로 좁힌다. fixer와 resolver는 완료 이력으로 보며 기본 이슈 목록 범위를 제한하지 않는다.
+`viewProjectIssues`는 특정 프로젝트 내부의 일반 이슈 목록을 반환한다. PL/DEV/TESTER 프로젝트 멤버는 같은 프로젝트의 일반 이슈를 볼 수 있고, reporter, 현재 assignee, 현재 verifier 조건은 `searchIssues` 필터로 좁힌다. fixer와 resolver는 완료 이력으로 보며 기본 이슈 목록 범위를 제한하지 않는다.
 
 `updateIssue`는 이슈 reporter만 수행할 수 있고, 이슈 상태가 `NEW` 또는 `REOPENED`일 때만 허용된다. 같은 프로젝트 내 다른 이슈와 title이 중복되면 실패한다.
 
@@ -65,7 +65,7 @@
 | `removeDependency` | UC7, OC-15, SSD-25 | DCD는 `removeDependency(dependencyId)`로 표현하지만, 구현은 `IssueService.removeDependency(blockingIssueId, blockedIssueId)`와 `Issue.removeDependency`를 사용 |
 | `changePriority` | UC16, OC-16, SSD-27 | `Issue.changePriority`, `Issue.verifyPriorityChange`, `IssueHistory(PRIORITY_CHANGED)`; status와 role 연관은 변경되지 않음 |
 | `viewIssueDetail` | UC4, SSD-04 및 UI 지원 | `Issue`, `Comment`, `IssueHistory`, `IssueDependency`, role 연관을 `IssueDetailResult`로 반환 |
-| `searchIssues`, `viewRelatedProjectIssues` | UC3, SSD-03 및 UI 지원 | DCD `Issue`의 status/priority/reporter/assignee/verifier 속성; 구현 `IssueSearchCriteria`, `IssueSummary` |
+| `searchIssues`, `viewProjectIssues` | UC3, SSD-03 및 UI 지원 | DCD `Issue`의 status/priority/reporter/assignee/verifier 속성; 구현 `IssueSearchCriteria`, `IssueSummary` |
 | `updateIssue` | UC15, SSD-23 이슈 수정 지원 | `Issue.updateTitleAndDescription`, `IssueHistory(TITLE_DESCRIPTION_UPDATED)`; priority/status는 별도 UC에서 처리 |
 | `deleteComment`, `updateComment`, `canUpdateComment`, `canDeleteComment`, `viewAvailableActions` | 직접 대응되는 필수 OC가 없는 구현 보조 API | `Comment`, `IssueWorkflowActions`, `PermissionPolicy.assertCan...` 메서드 |
 
@@ -95,7 +95,7 @@
 ## 근거
 
 - `src/main/java/com/github/marcellokim/issuetracker/controller/IssueController.java`: 모든 public `IssueController` 메서드, `requireCurrentUser`, `requireIssueWorkflowService`, `availableActionNames`
-- `src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java`: `IssueService.registerIssue`, `canRegisterIssue`, `viewIssueDetail`, `searchIssues`, `viewRelatedProjectIssues`, `updateIssue`, `changePriority`, `addComment`, `viewComments`, `addDependency`, `viewProjectDependencies`, `removeDependency`, `deleteComment`, `updateComment`
+- `src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java`: `IssueService.registerIssue`, `canRegisterIssue`, `viewIssueDetail`, `searchIssues`, `viewProjectIssues`, `updateIssue`, `changePriority`, `addComment`, `viewComments`, `addDependency`, `viewProjectDependencies`, `removeDependency`, `deleteComment`, `updateComment`
 - `src/main/java/com/github/marcellokim/issuetracker/service/IssueWorkflowService.java`: `IssueWorkflowService.viewAvailableActions`, `canUpdateComment`, `canDeleteComment`
 - `src/main/java/com/github/marcellokim/issuetracker/service/PermissionPolicy.java`: issue/comment/dependency/priority 권한 검사 메서드
 - `src/main/java/com/github/marcellokim/issuetracker/service/IssueResult.java`: `IssueResult`

--- a/docs/api/issue-controller.md
+++ b/docs/api/issue-controller.md
@@ -75,7 +75,7 @@
 | --- | --- |
 | `matches` | 이슈 등록, 댓글 추가, 의존성 추가, priority 변경은 컨트롤러에 연결되어 있고 서비스에서 권한과 정책을 검사한다. |
 | `signature-drift` | OC-15는 `removeDependency(dependencyId)`를 문서화하지만, 현재 구현은 `removeDependency(blockingIssueId, blockedIssueId)`를 노출한다. |
-| `implementation-extra` | 검색, 상세 조회, action 조회, 댓글 수정/삭제, 프로젝트 관련 이슈 조회 API는 필수 OC 목록 밖에 추가로 구현되어 있다. |
+| `implementation-extra` | 검색, 상세 조회, action 조회, 댓글 수정/삭제, 프로젝트 이슈 조회 API는 필수 OC 목록 밖에 추가로 구현되어 있다. |
 
 ## 권한 및 실패 요약
 

--- a/docs/api/project-controller.md
+++ b/docs/api/project-controller.md
@@ -2,7 +2,7 @@
 
 ## 범위
 
-`ProjectController`는 프로젝트 상세 조회와 ADMIN 프로젝트 관리 API를 제공한다. ADMIN은 프로젝트 기본 정보와 참여자 정보를 조회하고 프로젝트를 관리한다. non-ADMIN 사용자는 자신이 참여한 프로젝트의 기본 정보만 조회하며, 해당 프로젝트의 관련 이슈 목록은 `IssueController.viewRelatedProjectIssues`에서 조회한다.
+`ProjectController`는 프로젝트 상세 조회와 ADMIN 프로젝트 관리 API를 제공한다. ADMIN은 프로젝트 기본 정보와 참여자 정보를 조회하고 프로젝트를 관리한다. non-ADMIN 사용자는 자신이 참여한 프로젝트의 기본 정보만 조회하며, 해당 프로젝트의 이슈 목록은 `IssueController.viewProjectIssues`에서 조회한다.
 
 ## 공개 오퍼레이션
 
@@ -53,7 +53,7 @@
 | 분류 | 내용 |
 | --- | --- |
 | `implementation-extra` | 프로젝트 관리는 구현되어 있지만 `required_operation_contracts.md`에는 나열되어 있지 않다. |
-| `ui-scope` | ADMIN 프로젝트 상세는 이슈 목록을 포함하지 않는다. non-ADMIN 프로젝트 화면의 관련 이슈 목록은 `IssueController.viewRelatedProjectIssues`에서 별도로 조회한다. |
+| `ui-scope` | ADMIN 프로젝트 상세는 이슈 목록을 포함하지 않는다. non-ADMIN 프로젝트 화면의 이슈 목록은 `IssueController.viewProjectIssues`에서 별도로 조회한다. |
 
 ## 권한 및 실패 요약
 

--- a/docs/assumptions.md
+++ b/docs/assumptions.md
@@ -75,7 +75,7 @@
 - ADMIN은 계정 관리와 프로젝트 관리의 주체입니다. 일반 이슈 작업 흐름은 PL/DEV/TESTER의 active project membership을 기준으로 합니다.
 - Dashboard에서 ADMIN은 전체 프로젝트 요약과 전체 사용자 목록을 볼 수 있고, non-ADMIN은 자신이 참여한 프로젝트 요약만 볼 수 있습니다.
 - ADMIN 프로젝트 상세 화면은 프로젝트 기본 정보와 참여자 정보를 보여주며, 프로젝트 이슈 목록은 포함하지 않습니다.
-- non-ADMIN 프로젝트 화면은 프로젝트 기본 정보와 해당 프로젝트 내 관련 이슈 목록을 나누어 조회합니다.
+- non-ADMIN 프로젝트 화면은 프로젝트 기본 정보와 해당 프로젝트의 전체 이슈 목록을 나누어 조회합니다.
 - 프로젝트 멤버(PL, DEV, TESTER)는 해당 프로젝트의 전체 이슈를 볼 수 있습니다. 검색 기능을 통해 assignee, reporter, verifier 등 조건별 필터링이 가능합니다.
 - Reporter는 `NEW` 또는 `REOPENED` 상태일때만 자신의 이슈 title/description을 수정할 수 있습니다.
 - assigned 이후 title/description 정정과 추가 정보는 comment로 남깁니다.

--- a/docs/ui/javaFX/API_명세/07-issue-list.md
+++ b/docs/ui/javaFX/API_명세/07-issue-list.md
@@ -27,7 +27,7 @@
 ### 2. 이슈 목록 조회
 
 - **호출 시점**: 화면 진입 시
-- **메서드**: `IssueController.viewRelatedProjectIssues(projectId)`
+- **메서드**: `IssueController.viewProjectIssues(projectId)`
 - **반환**: `List<IssueSummary>`
 
 | 필드 | 타입 | 설명 |

--- a/docs/ui/javaFX/UI_navigation_map/javaFX_navigation_map.md
+++ b/docs/ui/javaFX/UI_navigation_map/javaFX_navigation_map.md
@@ -27,7 +27,7 @@
 | 5 | 삭제 이슈 관리 | PL | 이슈 목록에서 진입 |
 | 6 | 통계 | PL, Dev, Tester | 이슈 목록에서 진입 |
 
-Non-admin 사용자가 프로젝트를 선택하면 이슈 목록 화면은 프로젝트 내부 화면 역할을 한다. 따라서 화면 진입 시 `ProjectController.viewProjectNonAdminDetail(projectId)`로 프로젝트 기본 정보를 조회하고, `IssueController.viewRelatedProjectIssues(projectId)`로 프로젝트 일반 이슈 목록을 조회한다.
+Non-admin 사용자가 프로젝트를 선택하면 이슈 목록 화면은 프로젝트 내부 화면 역할을 한다. 따라서 화면 진입 시 `ProjectController.viewProjectNonAdminDetail(projectId)`로 프로젝트 기본 정보를 조회하고, `IssueController.viewProjectIssues(projectId)`로 프로젝트 일반 이슈 목록을 조회한다.
 
 ## 이슈 상세 화면 — 버튼 활성화 제어
 

--- a/docs/ui/javaFX/UI_navigation_map/javafx-navigation-map.puml
+++ b/docs/ui/javaFX/UI_navigation_map/javafx-navigation-map.puml
@@ -146,7 +146,7 @@ state "이슈 목록" as IssueListScreen <<screen>> {
   IssueListScreen : 표시: 프로젝트 기본 정보 + 이슈 목록 (status, priority, title)
   IssueListScreen : 기능: 검색, 필터, 정렬
   IssueListScreen : 호출: ProjectController.viewProjectNonAdminDetail(projectId)
-  IssueListScreen : 호출: IssueController.viewRelatedProjectIssues()
+  IssueListScreen : 호출: IssueController.viewProjectIssues()
   IssueListScreen : 호출: IssueController.searchIssues()
   IssueListScreen : 등록 가능 확인: IssueController.canRegisterIssue()
 }

--- a/docs/uml/architecture/its_layer_architecture.puml
+++ b/docs/uml/architecture/its_layer_architecture.puml
@@ -95,7 +95,7 @@ package "Controller Layer\n(system operation receivers)" #FFF8E1 {
     +registerIssue(projectId, title, description, priority): IssueResult
     +viewIssueDetail(issueId): IssueDetailResult
     +searchIssues(projectId, keyword, status, priority, reporterId, assigneeId, verifierId, reportedFrom, reportedTo): List<IssueSummary>
-    +viewRelatedProjectIssues(projectId): List<IssueSummary>
+    +viewProjectIssues(projectId): List<IssueSummary>
     +updateIssue(issueId, title, description): IssueResult
     +changePriority(issueId, priority): IssueResult
     +addComment(issueId, content): CommentResult
@@ -167,7 +167,7 @@ package "Service Layer\n(application services, policies, ports, DTO/results)" #F
     +registerIssue(projectId, title, description, priority, currentLoginId): IssueResult
     +viewIssueDetail(issueId, currentLoginId): IssueDetailResult
     +searchIssues(projectId, keyword, status, priority, reporterId, assigneeId, verifierId, reportedFrom, reportedTo, currentLoginId): List<IssueSummary>
-    +viewRelatedProjectIssues(projectId, currentLoginId): List<IssueSummary>
+    +viewProjectIssues(projectId, currentLoginId): List<IssueSummary>
     +updateIssue(issueId, title, description, currentLoginId): IssueResult
     +changePriority(issueId, priority, currentLoginId): IssueResult
     +addComment(issueId, content, currentLoginId): CommentResult

--- a/src/main/java/com/github/marcellokim/issuetracker/controller/IssueController.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/controller/IssueController.java
@@ -87,15 +87,9 @@ public final class IssueController {
                 user.getLoginId());
     }
 
-    public List<IssueSummary> searchRelatedProjectIssues(long projectId, String keyword, IssueStatus status,
-            Priority priority) {
+    public List<IssueSummary> viewProjectIssues(long projectId) {
         User user = requireCurrentUser();
-        return issueService.searchRelatedProjectIssues(projectId, keyword, status, priority, user.getLoginId());
-    }
-
-    public List<IssueSummary> viewRelatedProjectIssues(long projectId) {
-        User user = requireCurrentUser();
-        return issueService.viewRelatedProjectIssues(projectId, user.getLoginId());
+        return issueService.viewProjectIssues(projectId, user.getLoginId());
     }
 
     public IssueResult updateIssue(long issueId, String title, String description) {

--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueService.java
@@ -164,36 +164,7 @@ public final class IssueService {
                 .toList();
     }
 
-    public List<IssueSummary> searchRelatedProjectIssues(
-            long projectId,
-            String keyword,
-            IssueStatus status,
-            Priority priority,
-            String currentLoginId) {
-
-        SearchContext context = searchContext(
-                projectId,
-                status,
-                null,
-                null,
-                currentLoginId,
-                "Only project members can search related project issues.");
-        return searchIssuesByCriteria(IssueSearchCriteria.create(
-                context.projectId(),
-                status,
-                priority,
-                null,
-                null,
-                null,
-                optionalText(keyword),
-                null,
-                null,
-                false)).stream()
-                .map(IssueService::toIssueSummary)
-                .toList();
-    }
-
-    public List<IssueSummary> viewRelatedProjectIssues(long projectId, String currentLoginId) {
+    public List<IssueSummary> viewProjectIssues(long projectId, String currentLoginId) {
         long requiredProjectId = requirePositive(projectId, FIELD_PROJECT_ID);
         String requiredLoginId = requireText(currentLoginId, FIELD_CURRENT_LOGIN_ID);
         findProject(requiredProjectId);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueDetailScreen.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueDetailScreen.java
@@ -270,7 +270,7 @@ final class IssueDetailScreen extends VBox {
     private void handleAddDependency(){
         List<IssueSummary> projectIssues;
         try{
-            projectIssues = issueController.viewRelatedProjectIssues(currentDetail.projectId());
+            projectIssues = issueController.viewProjectIssues(currentDetail.projectId());
         } catch (Exception exception){
             ScreenComponents.showError(messageLabel, exception);
             return;

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueGraphScreen.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueGraphScreen.java
@@ -78,7 +78,7 @@ final class IssueGraphScreen extends VBox {
 
     private void loadData(){
         try{
-            List<IssueSummary> allIssues = issueController.viewRelatedProjectIssues(projectId);
+            List<IssueSummary> allIssues = issueController.viewProjectIssues(projectId);
             List<DependencyResult> allDeps = issueController.viewProjectDependencies(projectId);
             graphDeps = visibleDependencies(allIssues, allDeps);
             graphIssues = dependencyIssues(allIssues, graphDeps);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueListScreen.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueListScreen.java
@@ -5,14 +5,15 @@ import com.github.marcellokim.issuetracker.controller.ProjectController;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.service.IssueSummary;
 import com.github.marcellokim.issuetracker.service.ProjectResult;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
+import javafx.scene.control.DatePicker;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.ComboBox;
-import javafx.scene.control.DatePicker;
 import javafx.scene.control.Dialog;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
@@ -148,7 +149,7 @@ final class IssueListScreen extends VBox {
 
     private void loadIssues(){
         try{
-            List<IssueSummary> issues = issueController.viewRelatedProjectIssues(projectId);
+            List<IssueSummary> issues = issueController.viewProjectIssues(projectId);
             issueList.getItems().setAll(issues);
             ScreenComponents.showInfo(messageLabel, issues.size() + " issues");
         } catch (Exception exception){

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueListScreen.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueListScreen.java
@@ -5,7 +5,6 @@ import com.github.marcellokim.issuetracker.controller.ProjectController;
 import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.service.IssueSummary;
 import com.github.marcellokim.issuetracker.service.ProjectResult;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPresenter.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPresenter.java
@@ -26,7 +26,7 @@ final class IssueListPresenter {
         try {
             view.showProject(projectController.viewProjectNonAdminDetail(projectId));
             view.setRegisterEnabled(issueController.canRegisterIssue(projectId));
-            showIssues(issueController.viewRelatedProjectIssues(projectId));
+            showIssues(issueController.viewProjectIssues(projectId));
         } catch (RuntimeException exception) {
             view.setRegisterEnabled(false);
             view.showMessage(exception.getMessage(), true);
@@ -36,7 +36,7 @@ final class IssueListPresenter {
     void searchIssues(long projectId, IssueSearchRequest request) {
         Objects.requireNonNull(request, "request");
         try {
-            showIssues(issueController.searchRelatedProjectIssues(
+            showIssues(issueController.searchIssues(
                     projectId,
                     request.keyword(),
                     request.status(),
@@ -54,7 +54,7 @@ final class IssueListPresenter {
                     request.title(),
                     request.description(),
                     request.priority());
-            showIssues(issueController.viewRelatedProjectIssues(projectId));
+            showIssues(issueController.viewProjectIssues(projectId));
             view.setRegisterEnabled(issueController.canRegisterIssue(projectId));
             view.showMessage("Issue registered: " + result.title(), false);
         } catch (RuntimeException exception) {

--- a/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerFlowTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/controller/ControllerFlowTest.java
@@ -74,7 +74,7 @@ class ControllerFlowTest {
     }
 
     @Test
-    @DisplayName("dev opens a project and sees related issues")
+    @DisplayName("dev opens a project and sees project issues")
     void devProjectFlow() {
         PasswordHasher hasher = new PasswordHasher();
         User dev = storedUser("dev1", Role.DEV, hasher);
@@ -93,10 +93,10 @@ class ControllerFlowTest {
         IssueController issueController = issueController(auth, projects, issues, users, policy);
 
         ProjectResult detail = projectController.viewProjectNonAdminDetail(PROJECT_ID);
-        List<IssueSummary> relatedIssues = issueController.viewRelatedProjectIssues(PROJECT_ID);
+        List<IssueSummary> projectIssues = issueController.viewProjectIssues(PROJECT_ID);
 
         assertEquals("project-" + PROJECT_ID, detail.name());
-        assertEquals(List.of(issue.id()), relatedIssues.stream().map(IssueSummary::id).toList());
+        assertEquals(List.of(issue.id()), projectIssues.stream().map(IssueSummary::id).toList());
     }
 
     @Test

--- a/src/test/java/com/github/marcellokim/issuetracker/controller/IssueControllerTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/controller/IssueControllerTest.java
@@ -54,8 +54,8 @@ class IssueControllerTest {
         List<IssueSummary> simpleSearch = devController.searchIssues(PROJECT_ID, null, null, null);
         assertEquals(List.of(issue.id(), created.id()), simpleSearch.stream().map(IssueSummary::id).toList());
 
-        List<IssueSummary> relatedIssues = devController.viewRelatedProjectIssues(PROJECT_ID);
-        assertEquals(List.of(issue.id(), created.id()), relatedIssues.stream().map(IssueSummary::id).toList());
+        List<IssueSummary> projectIssues = devController.viewProjectIssues(PROJECT_ID);
+        assertEquals(List.of(issue.id(), created.id()), projectIssues.stream().map(IssueSummary::id).toList());
 
         IssueResult updated = devController.updateIssue(issue.id(), "Updated title", "Updated description");
         assertEquals("Updated title", updated.title());

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueServiceTest.java
@@ -382,9 +382,9 @@ class IssueServiceTest {
                                 new FakeCommentRepository(),
                                 users);
 
-                List<IssueSummary> devResults = service.viewRelatedProjectIssues(PROJECT_ID, dev.getLoginId());
-                List<IssueSummary> testerResults = service.viewRelatedProjectIssues(PROJECT_ID, tester.getLoginId());
-                List<IssueSummary> plResults = service.viewRelatedProjectIssues(PROJECT_ID, pl.getLoginId());
+                List<IssueSummary> devResults = service.viewProjectIssues(PROJECT_ID, dev.getLoginId());
+                List<IssueSummary> testerResults = service.viewProjectIssues(PROJECT_ID, tester.getLoginId());
+                List<IssueSummary> plResults = service.viewProjectIssues(PROJECT_ID, pl.getLoginId());
                 String adminLoginId = admin.getLoginId();
 
                 List<Long> allProjectIssueIds = List.of(reporterOnlyIssue.id(), assignedDevIssue.id(), completedHistoryOnlyIssue.id());
@@ -392,7 +392,7 @@ class IssueServiceTest {
                 assertEquals(allProjectIssueIds, testerResults.stream().map(IssueSummary::id).toList());
                 assertEquals(allProjectIssueIds, plResults.stream().map(IssueSummary::id).toList());
                 assertThrows(SecurityException.class,
-                                () -> service.viewRelatedProjectIssues(PROJECT_ID, adminLoginId));
+                                () -> service.viewProjectIssues(PROJECT_ID, adminLoginId));
         }
 
         @Test
@@ -409,7 +409,7 @@ class IssueServiceTest {
                 String devLoginId = dev.getLoginId();
 
                 assertThrows(SecurityException.class,
-                                () -> service.viewRelatedProjectIssues(PROJECT_ID, devLoginId));
+                                () -> service.viewProjectIssues(PROJECT_ID, devLoginId));
         }
 
         @Test

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
@@ -251,20 +251,32 @@ class RepositoryConventionsSmokeTest {
     }
 
     @Test
-    @DisplayName("이슈 검색은 related 전용 중복 API 없이 표준 검색 경로를 사용한다")
-    void issueSearchUsesStandardSearchPathWithoutRelatedDuplicateApi() throws IOException {
+    @DisplayName("이슈 목록과 검색은 related 전용 API 없이 표준 경로를 사용한다")
+    void issueListAndSearchUseStandardPathWithoutRelatedDuplicateApi() throws IOException {
         try (Stream<Path> paths = Files.walk(Path.of("src/main/java"))) {
             var offenders = paths
                     .filter(Files::isRegularFile)
                     .filter(path -> path.toString().endsWith(".java"))
-                    .filter(path -> readUnchecked(path).contains("searchRelatedProjectIssues"))
+                    .filter(path -> containsAny(
+                            readUnchecked(path),
+                            "searchRelatedProjectIssues",
+                            "viewRelatedProjectIssues"))
                     .toList();
 
             assertTrue(
                     offenders.isEmpty(),
-                    () -> "삭제 대상 중복 검색 API가 남아 있습니다: " + offenders
+                    () -> "삭제 대상 related 이슈 API가 남아 있습니다: " + offenders
             );
         }
+    }
+
+    private static boolean containsAny(String text, String... candidates) {
+        for (String candidate : candidates) {
+            if (text.contains(candidate)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static String readUnchecked(Path path) {

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
@@ -250,6 +250,31 @@ class RepositoryConventionsSmokeTest {
         );
     }
 
+    @Test
+    @DisplayName("이슈 검색은 related 전용 중복 API 없이 표준 검색 경로를 사용한다")
+    void issueSearchUsesStandardSearchPathWithoutRelatedDuplicateApi() throws IOException {
+        try (Stream<Path> paths = Files.walk(Path.of("src/main/java"))) {
+            var offenders = paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .filter(path -> readUnchecked(path).contains("searchRelatedProjectIssues"))
+                    .toList();
+
+            assertTrue(
+                    offenders.isEmpty(),
+                    () -> "삭제 대상 중복 검색 API가 남아 있습니다: " + offenders
+            );
+        }
+    }
+
+    private static String readUnchecked(Path path) {
+        try {
+            return Files.readString(path);
+        } catch (IOException exception) {
+            throw new java.io.UncheckedIOException(exception);
+        }
+    }
+
     record ScriptExpectation(String relativePath, String expectedText) {
     }
 }

--- a/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPresenterTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPresenterTest.java
@@ -39,8 +39,8 @@ class IssueListPresenterTest {
     private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 31, 0, 0);
 
     @Test
-    @DisplayName("loads project info, related issues, and register permission through controllers")
-    void loadsProjectAndRelatedIssues() {
+    @DisplayName("loads project info, project issues, and register permission through controllers")
+    void loadsProjectAndProjectIssues() {
         User dev = user("dev1", Role.DEV);
         ControllerFixture fixture = controllers(
                 dev,


### PR DESCRIPTION
## 요약
- 관련 이슈: Closes #264
- 프로젝트 멤버가 같은 프로젝트의 일반 이슈 전체를 열람하도록 이슈 목록 정책을 정리
- `viewRelatedProjectIssues`를 `viewProjectIssues`로 이름 변경
- `searchRelatedProjectIssues` 중복 API를 제거하고 표준 `searchIssues` 경로로 통합
- API 문서, JavaFX/Swing 호출부, UML/navigation map, 테스트 명칭을 현재 구현 기준으로 갱신

## 변경 분류
- type: refactor
- area: domain, ui, documentation

## purpose
UC3 Search/Browse 흐름에서 프로젝트 멤버 열람 정책과 controller/service API 이름을 실제 역할에 맞게 정리한다.

## non-goals
- 검색 조건 입력 UI를 새로 설계하지 않는다.
- deleted issue 관리 정책이나 상태 전이 정책은 변경하지 않는다.
- DB schema나 repository 계약은 변경하지 않는다.

## diff map
- 핵심 변경: `IssueService.viewProjectIssues`, `IssueController.viewProjectIssues`, 프로젝트 멤버 열람 정책 정리
- 중복 제거: `searchRelatedProjectIssues` 제거, Swing presenter는 `searchIssues` 사용
- UI 호출부: JavaFX issue detail/graph/list, Swing issue list presenter의 API 명칭 반영
- 문서: API 문서, assumption, navigation map, architecture puml의 옛 명칭 갱신
- 테스트: controller/service/presenter 테스트와 중복 API 재도입 방지 convention test 갱신

## verification evidence
- `./gradlew check --console=plain`
- `git diff --check && ./gradlew compileJava test --tests 'com.github.marcellokim.issuetracker.setup.RepositoryConventionsSmokeTest' --tests 'com.github.marcellokim.issuetracker.ui.swing.IssueListPresenterTest' --console=plain`
- pre-push `test + verifyRepositorySetup`

## reviewer focus areas
- DEV/TESTER/PL 프로젝트 멤버가 같은 프로젝트 일반 이슈를 보는 정책이 UC3와 맞는지
- `viewProjectIssues` rename이 문서와 UI 호출부에 일관되게 반영됐는지
- `searchRelatedProjectIssues` 제거 후 검색 호출이 `searchIssues`로 충분히 대체됐는지

## risk / rollback
- 위험: API rename 영향으로 남은 호출부가 있으면 컴파일 또는 convention test에서 잡힘
- rollback: 이 PR만 되돌리면 기존 related API 경로와 문서 명칭으로 복구됨
