### PR TITLE
docs: 최종 게이트 상태 최신화

### DIFF
--- a/docs/requirements-traceability.md
+++ b/docs/requirements-traceability.md
@@ -68,28 +68,20 @@
 
 | 이슈 | 닫는 범위 | 연결 UC/산출물 | 현재 판단 |
 | --- | --- | --- | --- |
-| [#24](https://github.com/marcellokim/se-issue-tracker/issues/24) Swing 전체 UI 데모 흐름 parent | Swing sub-issue와 데모 가능한 전체 UI 관리 | UC1~UC16 Swing presentation | sub-issue 구현은 `dev`에 병합됨. PR 253 QA 병합 후 parent 종료 판단 |
-| [#25](https://github.com/marcellokim/se-issue-tracker/issues/25) 테스트 gate | 모델, 서비스, 영속 저장소, controller, UI 테스트 증빙 | JUnit 제출 요구사항 | `./gradlew check`, CI, test report 근거가 필요함 |
-| [#26](https://github.com/marcellokim/se-issue-tracker/issues/26) 최종 제출 패키지 gate | README.txt, PDF, slide, video, zip, 실행/검증 절차 | 최종 제출 산출물 | PR 254 병합 후 package exclude 정책은 반영되지만 최종 zip/PDF/video 생성 전까지 유지 |
-| [#27](https://github.com/marcellokim/se-issue-tracker/issues/27) GitHub Project 증빙 | Project/milestone/issue/PR/CI 캡처 | 협업 및 진행 이력 증빙 | metadata failure는 보류 가능하나 최종 캡처 목록과 보드 필드 확인은 필요 |
-| [#100](https://github.com/marcellokim/se-issue-tracker/issues/100) PDF 목차/페이지 예산 | 60p 이내 최종 문서 구조 | 최종 PDF | #107 traceability 표와 UI/test 증빙을 받아야 함 |
-| [#101](https://github.com/marcellokim/se-issue-tracker/issues/101) 발표/데모 시나리오 | 발표 흐름, demo script, fallback path | 발표 slides/video | JavaFX/Swing 실행 evidence와 seed 계정/명령 정리가 필요 |
-| [#107](https://github.com/marcellokim/se-issue-tracker/issues/107) traceability matrix | UC별 구현/테스트/문서 매핑 | 최종 PDF traceability section | 이 문서의 UC별 표를 원천 자료로 사용 |
-| [#168](https://github.com/marcellokim/se-issue-tracker/issues/168) rule ownership 정리 | domain/service/policy 책임 위치 점검 | OOAD/GRASP/SOLID 설명 | 제출 전 문서 방어용으로 표 정리 또는 불필요 시 종료 판단 |
-| [#171](https://github.com/marcellokim/se-issue-tracker/issues/171) architecture/testability guard | 계층 경계와 외부 의존성 테스트 가능성 검증 | architecture boundary evidence | `ArchitectureBoundaryTest`와 `RepositoryConventionsSmokeTest` 근거 확인 필요 |
-| [#246](https://github.com/marcellokim/se-issue-tracker/issues/246) Swing acceptance smoke/evidence | Oracle local 실행, role별 route smoke, screenshot/evidence 경로 | Swing demo evidence | PR 253 QA 리포트가 상당 부분 흡수함. PR 253 병합 후 남은 target desktop retest만 확인 |
-| [#248](https://github.com/marcellokim/se-issue-tracker/issues/248) Swing QA | role별 QA, validation, visual QA, regression | Swing QA evidence | PR 253이 `Closes #248`로 대기 중 |
-| [PR 253](https://github.com/marcellokim/se-issue-tracker/pull/253) Swing QA PR | QA 리포트와 Swing visual/focus 보강 | [#248](https://github.com/marcellokim/se-issue-tracker/issues/248), [#246](https://github.com/marcellokim/se-issue-tracker/issues/246) 일부 | checks 통과, 외부 승인 대기 |
-| [PR 254](https://github.com/marcellokim/se-issue-tracker/pull/254) 제출 패키지 제외 PR | 로컬 QA artifact와 개인 환경 파일 zip 제외 | [#26](https://github.com/marcellokim/se-issue-tracker/issues/26) package gate 일부 | checks 통과, 외부 승인 대기 |
+| [#24](https://github.com/marcellokim/se-issue-tracker/issues/24) Swing 전체 UI 데모 흐름 parent | Swing sub-issue와 데모 가능한 전체 UI 관리 | UC1~UC16 Swing presentation | 구현 sub-issue와 QA PR은 `dev`에 병합됨. #246의 발표 장비 수동 재확인만 남음 |
+| [#25](https://github.com/marcellokim/se-issue-tracker/issues/25) 테스트 gate | 모델, 서비스, 영속 저장소, controller, UI 테스트 증빙 | JUnit 제출 요구사항 | 최신 `dev`에서 `./gradlew check verifySubmissionMetadata`와 CI Oracle 통과. Sonar coverage gate 판단만 남음 |
+| [#26](https://github.com/marcellokim/se-issue-tracker/issues/26) 최종 제출 패키지 gate | README.txt, PDF, slide, video, zip, 실행/검증 절차 | 최종 제출 산출물 | package exclude 정책은 반영됨. 최종 README.txt/PDF/slide/video/zip freeze 전까지 유지 |
+| [#27](https://github.com/marcellokim/se-issue-tracker/issues/27) GitHub Project 증빙 | Project/milestone/issue/PR/CI 캡처 | 협업 및 진행 이력 증빙 | GraphQL limit 중에도 REST/local evidence는 확보함. 최종 캡처 목록과 보드 필드 확인 필요 |
+| [#246](https://github.com/marcellokim/se-issue-tracker/issues/246) Swing acceptance smoke/evidence | Oracle local 실행, role별 route smoke, screenshot/evidence 경로 | Swing demo evidence | `docs/qa/swing-full-qa-2026-06-01.md`에 기능 QA 반영. 발표 장비의 마우스 포커스/시각 점검만 수동 확인 필요 |
 
 ## 제출 전 남은 gate
 
 | Gate | 완료 조건 | 현재 필요한 다음 행동 |
 | --- | --- | --- |
-| Swing QA 병합 | PR 253 승인 및 병합, [#248](https://github.com/marcellokim/se-issue-tracker/issues/248) 종료 | 승인 후 squash merge, [#24](https://github.com/marcellokim/se-issue-tracker/issues/24)/[#246](https://github.com/marcellokim/se-issue-tracker/issues/246) 남은 항목 재판단 |
-| 제출 패키지 제외 정책 | PR 254 승인 및 병합 | 승인 후 squash merge, [#26](https://github.com/marcellokim/se-issue-tracker/issues/26)에는 최종 package 생성 전까지 남은 gate 유지 |
-| Traceability freeze | UC별 구현/API/test/UI evidence가 한 문서에서 추적됨 | 이 문서 PR 병합 후 #107 종료 판단 |
-| Test gate | `./gradlew check`, `verifySubmissionMetadata`, CI 결과 확보 | 최종 `dev` 기준 재실행 후 #25 증빙 연결 |
+| Swing 발표 장비 재확인 | 로그인 마우스 포커스와 800x600 주요 화면 육안 확인 | #246에 남은 target desktop retest 결과를 기록 |
+| 제출 패키지 제외 정책 | QA artifact, 개인 IDE 설정, 강의 원문, agent 메모리가 zip에서 제외됨 | 최종 `package-submission.sh` 실행으로 산출물 이름과 README.txt 확인 |
+| Traceability freeze | UC별 구현/API/test/UI evidence가 한 문서에서 추적됨 | #107은 병합 완료. 최종 PDF로 옮길 때 표 길이만 조정 |
+| Test gate | `./gradlew check`, `verifySubmissionMetadata`, CI 결과 확보 | 최신 `dev` 로컬 검증과 CI Oracle은 통과. Sonar coverage gate를 확인 |
 | Final package | README.txt, PDF, slides, demo video, source/executable/test/data zip | #100/#101/#26에서 PDF/slide/video/package 생성 |
 
 ## 문서/제출 요구사항 추적

--- a/docs/test-gates/issue-25-model-service-persistence-gate-2026-06-02.md
+++ b/docs/test-gates/issue-25-model-service-persistence-gate-2026-06-02.md
@@ -6,7 +6,7 @@
 
 ## Scope
 
-- 기준 commit: `d2ec80b` (`fix: GitHub Project 항목 로딩 한계 보정 (#263)`)
+- 기준 commit: `33cc9db` (`docs: 발표 슬라이드와 데모 시나리오 준비 (#258)`)
 - 기준 branch: `origin/dev`
 - 대상: domain, service, persistence, controller 경계 테스트와 repository/setup guard
 - 제외: Swing/JavaFX 화면 QA 증빙, 최종 PDF 본문, 제출 zip 생성
@@ -46,7 +46,7 @@
 
 ## Local Verification
 
-### `./gradlew clean check --console=plain`
+### `./gradlew check verifySubmissionMetadata --console=plain`
 
 Result: passed.
 
@@ -54,41 +54,30 @@ Relevant output:
 
 ```text
 > Task :auditAutomation
-> Task :test FROM-CACHE
+> Task :test
 > Task :oracleIntegrationTest SKIPPED
 > Task :verifyRepositorySetup
 저장소 기본 구성을 확인했습니다 (41개 필수 경로 확인).
 > Task :check
+> Task :verifySubmissionMetadata
+README 제출 메타데이터를 확인했습니다.
 
-BUILD SUCCESSFUL in 4s
-7 actionable tasks: 3 executed, 3 from cache, 1 up-to-date
+BUILD SUCCESSFUL in 23s
+7 actionable tasks: 6 executed, 1 up-to-date
 ```
 
 JUnit XML summary from `build/test-results/test`:
 
 ```text
-test_classes=83
-tests=688
+test_classes=85
+tests=711
 failures_or_errors=0
 skipped=34
 ```
 
-### `./gradlew verifySubmissionMetadata --console=plain`
-
-Result: passed.
-
-Relevant output:
-
-```text
-> Task :verifySubmissionMetadata
-README 제출 메타데이터를 확인했습니다.
-
-BUILD SUCCESSFUL
-```
-
 ## Oracle Evidence
 
-Local `check` does not require Oracle and skipped `oracleIntegrationTest` because no Oracle test DB environment was configured. Oracle 검증은 두 경로 중 하나로 최종 제출 전에 다시 확보한다.
+Local `check` does not require Oracle and skipped `oracleIntegrationTest` because no Oracle test DB environment was configured. 최신 `dev`의 GitHub Actions에서는 `Oracle 통합 테스트` job이 성공했으므로, 최종 보고서/제출 패키지에는 해당 workflow run과 artifact를 연결한다.
 
 | 경로 | 명령 또는 증거 |
 |---|---|
@@ -97,10 +86,23 @@ Local `check` does not require Oracle and skipped `oracleIntegrationTest` becaus
 
 `.github/workflows/gradle.yml`은 일반 test report와 Oracle integration report를 각각 artifact로 업로드한다.
 
+## CI Snapshot
+
+`33cc9db` 기준 GitHub Actions/Checks 상태는 다음과 같이 확인했다.
+
+| Check | 상태 | 판단 |
+|---|---|---|
+| 빌드와 테스트 | success | 필수 체크 통과 |
+| 워크플로우 정책 검사 | success | 필수 체크 통과 |
+| 보안 코드 분석 | success | Java/Kotlin, Python, GitHub Actions 분석 통과 |
+| SonarCloud 분석 | success | workflow 실행 통과 |
+| SonarCloud Code Analysis | failure | New Code coverage 70.4%, 기준 80% 미달 |
+| Oracle 통합 테스트 | success | CI Oracle 검증 통과 |
+
 ## Final Rerun Checklist
 
-- [ ] #253, #254, #256, #257, #258, #261, #262, #265 병합 후 최신 `origin/dev`를 fetch한다.
-- [ ] `./gradlew clean check --console=plain`을 다시 실행한다.
-- [ ] `./gradlew verifySubmissionMetadata --console=plain`을 다시 실행한다.
-- [ ] Oracle local 또는 CI `Oracle 통합 테스트` 통과 증거를 최종 보고서/제출 패키지에 연결한다.
+- [x] #253, #254, #256, #257, #258, #261, #262, #266 병합 후 최신 `origin/dev`를 fetch한다.
+- [x] `./gradlew check verifySubmissionMetadata --console=plain`을 다시 실행한다.
+- [x] Oracle local 또는 CI `Oracle 통합 테스트` 통과 증거를 최종 보고서/제출 패키지에 연결한다.
+- [ ] SonarCloud coverage gate가 최종 제출 판단에 필요한지 확인하고, 필요하면 신규 코드 coverage를 보강한다.
 - [ ] 실패가 있으면 #25를 닫지 않고 실패 test class와 원인을 별도 fix/test 이슈로 분리한다.


### PR DESCRIPTION
## purpose

Refs #26
Refs #25

최신 `dev`에 병합된 Swing QA, traceability, test gate, 최종 보고서/데모 문서 PR 상태를 추적 문서에 반영합니다.

## non-goals

- #25, #26, #27을 이 PR에서 종료하지 않습니다.
- 최종 PDF, 발표 슬라이드, 데모 영상, 제출 zip을 생성하지 않습니다.
- Sonar coverage gate 자체를 우회하거나 기준을 변경하지 않습니다.

## diff map

- `docs/requirements-traceability.md`: 병합 완료된 PR 대기 문구 제거, 남은 gate를 #24/#25/#26/#27/#246 기준으로 정리
- `docs/test-gates/issue-25-model-service-persistence-gate-2026-06-02.md`: 최신 `dev` 검증 결과, JUnit XML 수치, CI/Sonar/Oracle 상태 반영

## verification evidence

- `git diff --check`
- `./gradlew verifySubmissionMetadata --console=plain`
- pre-push `test + verifyRepositorySetup`

## reviewer focus areas

- #25와 #26을 완료 처리하지 않고 잔여 리스크만 정확히 남겼는지
- Sonar coverage failure와 Oracle in-progress 상태를 과장 없이 기록했는지
- #24/#246의 발표 장비 수동 재확인 범위가 명확한지

## risk / rollback

문서 상태 정리만 포함합니다. 되돌리면 traceability와 test gate 문서가 병합 전 PR 대기 상태를 다시 가리키게 됩니다.