### PR TITLE
fix: SonarCloud coverage 제외 정책 정합성 보강

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -4,4 +4,5 @@
 # automatic source analysis and copy-paste detection.
 sonar.exclusions=src/main/resources/db/oracle/schema-oracle.sql,src/main/resources/db/oracle/seed-oracle.sql
 sonar.cpd.exclusions=src/main/resources/db/oracle/schema-oracle.sql,src/main/resources/db/oracle/seed-oracle.sql
+sonar.coverage.exclusions=src/main/java/com/github/marcellokim/issuetracker/Main.java,src/main/java/com/github/marcellokim/issuetracker/config/ApplicationContext.java,src/main/java/com/github/marcellokim/issuetracker/config/ApplicationBootstrap.java,src/main/java/com/github/marcellokim/issuetracker/ui/**,src/main/java/com/github/marcellokim/issuetracker/persistence/DatabaseInitializer.java,src/main/java/com/github/marcellokim/issuetracker/persistence/OracleConnectionCheck.java,src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/**
 sonar.sourceEncoding=UTF-8

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
@@ -1,11 +1,16 @@
 package com.github.marcellokim.issuetracker.setup;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,6 +34,7 @@ class RepositoryConventionsSmokeTest {
                 ".pr_agent.toml",
                 ".gemini/config.yaml",
                 ".gemini/styleguide.md",
+                ".sonarcloud.properties",
                 ".github/copilot-instructions.md",
                 ".github/dependabot.yml",
                 "config/github/labels.json",
@@ -264,6 +270,19 @@ class RepositoryConventionsSmokeTest {
     }
 
     @Test
+    @DisplayName("SonarCloud 자동 분석은 Gradle coverage 제외 정책을 공유한다")
+    void sonarCloudAutomaticAnalysisUsesTheSameCoverageExclusions() throws IOException {
+        var gradle = Files.readString(Path.of("build.gradle"));
+        var sonarCloud = Files.readString(Path.of(".sonarcloud.properties"));
+        var gradleExclusions = gradleCoverageExclusions(gradle);
+        var sonarExclusions = sonarPropertyValues(sonarCloud, "sonar.coverage.exclusions");
+
+        assertFalse(gradleExclusions.isEmpty(), "Gradle coverage 제외 정책을 찾을 수 없습니다.");
+        assertFalse(sonarExclusions.isEmpty(), ".sonarcloud.properties에도 coverage 제외 정책이 있어야 합니다.");
+        assertEquals(gradleExclusions, sonarExclusions, "SonarCloud 자동 분석 coverage 제외 정책이 Gradle과 달라졌습니다.");
+    }
+
+    @Test
     @DisplayName("이슈 목록과 검색은 related 전용 API 없이 표준 경로를 사용한다")
     void issueListAndSearchUseStandardPathWithoutRelatedDuplicateApi() throws IOException {
         try (Stream<Path> paths = Files.walk(Path.of("src/main/java"))) {
@@ -308,6 +327,40 @@ class RepositoryConventionsSmokeTest {
         } catch (IOException exception) {
             throw new java.io.UncheckedIOException(exception);
         }
+    }
+
+    private static Set<String> gradleCoverageExclusions(String gradleText) {
+        var matcher = Pattern.compile("def coverageExcludedSources = \\[(?<body>.*?)\\]\\.join\\(','\\)",
+                Pattern.DOTALL).matcher(gradleText);
+        if (!matcher.find()) {
+            return Set.of();
+        }
+        return quotedValues(matcher.group("body"));
+    }
+
+    private static Set<String> quotedValues(String text) {
+        var matcher = Pattern.compile("'([^']+)'").matcher(text);
+        var values = new LinkedHashSet<String>();
+        while (matcher.find()) {
+            values.add(matcher.group(1));
+        }
+        return values;
+    }
+
+    private static Set<String> sonarPropertyValues(String propertiesText, String key) {
+        return propertiesText.lines()
+                .filter(line -> line.startsWith(key + "="))
+                .findFirst()
+                .map(line -> line.substring(key.length() + 1))
+                .map(RepositoryConventionsSmokeTest::commaSeparatedValues)
+                .orElseGet(Set::of);
+    }
+
+    private static Set<String> commaSeparatedValues(String text) {
+        return Arrays.stream(text.split(","))
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
     }
 
     record ScriptExpectation(String relativePath, String expectedText) {


### PR DESCRIPTION
## purpose
SonarCloud 자동 분석 경로가 Gradle의 coverage 제외 정책과 같은 기준을 사용하도록 맞춘다. 현재 quality gate 실패 원인인 new-code coverage 분모 불일치를 줄인다.

Refs #25

## non-goals
- 업무 로직, 테스트 대상 범위, Oracle 통합 테스트 정책은 변경하지 않는다.
- SonarCloud quality gate 기준 자체는 낮추지 않는다.
- GraphQL 기반 프로젝트 보드 정렬은 rate-limit 문제 때문에 이 PR에서 다루지 않는다.

## diff map
- `.sonarcloud.properties`: Gradle `sonar.coverage.exclusions`와 같은 coverage 제외 경로 추가.
- `RepositoryConventionsSmokeTest`: 자동 분석 설정이 Gradle coverage 제외 정책과 같은 집합을 유지하는지 검증.

## verification evidence
- `./gradlew test --tests 'com.github.marcellokim.issuetracker.setup.RepositoryConventionsSmokeTest.sonarCloudAutomaticAnalysisUsesTheSameCoverageExclusions' --console=plain`
- `git diff --check && ./gradlew check --console=plain`
- push 전 hook: `test + verifyRepositorySetup`

## reviewer focus areas
- SonarCloud 자동 분석 설정과 Gradle sonar block의 coverage 제외 경로가 같은지 확인.
- quality gate 우회가 아니라 기존 coverage 제외 정책의 적용 경로 보정인지 확인.

## risk / rollback
설정 파일 한 줄과 smoke test 추가라 rollback 영향은 낮다. 되돌리면 SonarCloud 자동 분석에서 UI/JDBC/entrypoint 코드가 다시 coverage 분모에 포함될 수 있다.