### PR TITLE
fix: SonarCloud coverage 제외 패턴 보정

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -4,5 +4,5 @@
 # automatic source analysis and copy-paste detection.
 sonar.exclusions=src/main/resources/db/oracle/schema-oracle.sql,src/main/resources/db/oracle/seed-oracle.sql
 sonar.cpd.exclusions=src/main/resources/db/oracle/schema-oracle.sql,src/main/resources/db/oracle/seed-oracle.sql
-sonar.coverage.exclusions=src/main/java/com/github/marcellokim/issuetracker/Main.java,src/main/java/com/github/marcellokim/issuetracker/config/ApplicationContext.java,src/main/java/com/github/marcellokim/issuetracker/config/ApplicationBootstrap.java,src/main/java/com/github/marcellokim/issuetracker/ui/**,src/main/java/com/github/marcellokim/issuetracker/persistence/DatabaseInitializer.java,src/main/java/com/github/marcellokim/issuetracker/persistence/OracleConnectionCheck.java,src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/**
+sonar.coverage.exclusions=**/Main.java,**/config/ApplicationContext.java,**/config/ApplicationBootstrap.java,**/ui/**,**/persistence/DatabaseInitializer.java,**/persistence/OracleConnectionCheck.java,**/persistence/jdbc/**
 sonar.sourceEncoding=UTF-8

--- a/build.gradle
+++ b/build.gradle
@@ -46,13 +46,13 @@ sonar {
         ].join(',')
         // Oracle JDBC classes are covered by oracleIntegrationTest, which needs an Oracle test schema.
         def coverageExcludedSources = [
-            'src/main/java/com/github/marcellokim/issuetracker/Main.java',
-            'src/main/java/com/github/marcellokim/issuetracker/config/ApplicationContext.java',
-            'src/main/java/com/github/marcellokim/issuetracker/config/ApplicationBootstrap.java',
-            'src/main/java/com/github/marcellokim/issuetracker/ui/**',
-            'src/main/java/com/github/marcellokim/issuetracker/persistence/DatabaseInitializer.java',
-            'src/main/java/com/github/marcellokim/issuetracker/persistence/OracleConnectionCheck.java',
-            'src/main/java/com/github/marcellokim/issuetracker/persistence/jdbc/**'
+            '**/Main.java',
+            '**/config/ApplicationContext.java',
+            '**/config/ApplicationBootstrap.java',
+            '**/ui/**',
+            '**/persistence/DatabaseInitializer.java',
+            '**/persistence/OracleConnectionCheck.java',
+            '**/persistence/jdbc/**'
         ].join(',')
         property 'sonar.host.url', 'https://sonarcloud.io'
         property 'sonar.projectKey', providers.environmentVariable('SONAR_PROJECT_KEY').orElse('marcellokim_se-issue-tracker').get()

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
@@ -280,6 +280,10 @@ class RepositoryConventionsSmokeTest {
         assertFalse(gradleExclusions.isEmpty(), "Gradle coverage 제외 정책을 찾을 수 없습니다.");
         assertFalse(sonarExclusions.isEmpty(), ".sonarcloud.properties에도 coverage 제외 정책이 있어야 합니다.");
         assertEquals(gradleExclusions, sonarExclusions, "SonarCloud 자동 분석 coverage 제외 정책이 Gradle과 달라졌습니다.");
+        assertFalse(
+                gradleExclusions.stream().anyMatch(value -> value.startsWith("src/main/java/")),
+                "Coverage 제외 정책은 SonarCloud 파일 키와 안정적으로 맞도록 source-root 고정 경로 대신 glob 패턴을 사용해야 합니다."
+        );
     }
 
     @Test


### PR DESCRIPTION
## purpose
PR #268 merge 후 dev 브랜치에서 `SonarCloud Code Analysis`가 여전히 `70.4% Coverage on New Code`로 실패했다. Coverage 제외 경로를 SonarCloud 파일 키와 더 안정적으로 맞는 glob 패턴으로 보정한다.

Refs #25

## non-goals
- SonarCloud quality gate 기준을 낮추지 않는다.
- 업무 로직, 테스트 대상, Oracle 통합 테스트 흐름은 변경하지 않는다.
- UI/JDBC source 분석 자체를 제외하지 않는다. coverage 분모 제외 정책만 보정한다.

## diff map
- `build.gradle`: `sonar.coverage.exclusions` 값을 source-root 고정 경로에서 glob 패턴으로 변경.
- `.sonarcloud.properties`: 자동 분석 설정도 Gradle과 같은 glob 패턴으로 변경.
- `RepositoryConventionsSmokeTest`: Gradle과 SonarCloud 설정이 같은 집합인지 검증하고, `src/main/java/` 고정 경로 재도입을 막음.

## verification evidence
- `./gradlew test --tests 'com.github.marcellokim.issuetracker.setup.RepositoryConventionsSmokeTest.sonarCloudAutomaticAnalysisUsesTheSameCoverageExclusions' --console=plain`
- `git diff --check && ./gradlew check --console=plain`
- 로컬 JaCoCo 기준 `origin/main..HEAD` new coverable line 98개, uncovered 0개
- push 전 hook: `test + verifyRepositorySetup`

## reviewer focus areas
- coverage exclusion이 `sonar.exclusions`가 아니라 `sonar.coverage.exclusions`에만 적용되어 source analysis 범위를 줄이지 않는지 확인.
- Gradle sonar 설정과 `.sonarcloud.properties`가 같은 coverage 제외 집합을 유지하는지 확인.

## risk / rollback
패턴이 과하게 넓어질 경우 coverage 분모에서 의도보다 많은 파일이 빠질 수 있다. rollback은 직전 source-root 고정 경로로 되돌리면 되지만, dev quality gate가 다시 실패할 수 있다.