### PR TITLE
fix: SonarCloud 자동 분석 범위 보정

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,8 +1,9 @@
 # SonarCloud Automatic Analysis reads this file instead of Gradle's sonar block.
-# The Oracle SQL resources are static schema/seed scripts and are verified by
-# repository smoke tests and Oracle integration tests, so exclude them from
-# automatic source analysis and copy-paste detection.
-sonar.exclusions=src/main/resources/db/oracle/schema-oracle.sql,src/main/resources/db/oracle/seed-oracle.sql
+# The Oracle SQL resources and runtime UI/adapter entry points are verified by
+# repository smoke tests, UI tests, and Oracle integration tests. Keep the
+# automatic analysis source scope aligned with the coverage scope; the Gradle
+# SonarCloud workflow still analyzes the full Java source set.
+sonar.exclusions=src/main/resources/db/oracle/schema-oracle.sql,src/main/resources/db/oracle/seed-oracle.sql,**/Main.java,**/config/ApplicationContext.java,**/config/ApplicationBootstrap.java,**/ui/**,**/persistence/DatabaseInitializer.java,**/persistence/OracleConnectionCheck.java,**/persistence/jdbc/**
 sonar.cpd.exclusions=src/main/resources/db/oracle/schema-oracle.sql,src/main/resources/db/oracle/seed-oracle.sql
 sonar.coverage.exclusions=**/Main.java,**/config/ApplicationContext.java,**/config/ApplicationBootstrap.java,**/ui/**,**/persistence/DatabaseInitializer.java,**/persistence/OracleConnectionCheck.java,**/persistence/jdbc/**
 sonar.sourceEncoding=UTF-8

--- a/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/setup/RepositoryConventionsSmokeTest.java
@@ -276,6 +276,7 @@ class RepositoryConventionsSmokeTest {
         var sonarCloud = Files.readString(Path.of(".sonarcloud.properties"));
         var gradleExclusions = gradleCoverageExclusions(gradle);
         var sonarExclusions = sonarPropertyValues(sonarCloud, "sonar.coverage.exclusions");
+        var automaticAnalysisExclusions = sonarPropertyValues(sonarCloud, "sonar.exclusions");
 
         assertFalse(gradleExclusions.isEmpty(), "Gradle coverage 제외 정책을 찾을 수 없습니다.");
         assertFalse(sonarExclusions.isEmpty(), ".sonarcloud.properties에도 coverage 제외 정책이 있어야 합니다.");
@@ -283,6 +284,10 @@ class RepositoryConventionsSmokeTest {
         assertFalse(
                 gradleExclusions.stream().anyMatch(value -> value.startsWith("src/main/java/")),
                 "Coverage 제외 정책은 SonarCloud 파일 키와 안정적으로 맞도록 source-root 고정 경로 대신 glob 패턴을 사용해야 합니다."
+        );
+        assertTrue(
+                automaticAnalysisExclusions.containsAll(sonarExclusions),
+                ".sonarcloud.properties의 자동 분석 source 제외 정책은 coverage 제외 정책을 포함해야 합니다."
         );
     }
 


### PR DESCRIPTION
## purpose
PR #269 merge 후에도 dev 브랜치의 SonarCloud GitHub App check가 `70.4% Coverage on New Code`로 실패했다. CI Gradle SonarCloud workflow는 성공하므로, 자동 분석용 `.sonarcloud.properties`의 source scope를 coverage 제외 정책과 맞춰 중복 자동 분석이 UI/JDBC 런타임 코드 coverage 분모에 걸리지 않도록 보정한다.

Refs #25

## non-goals
- Gradle 기반 `SonarCloud 분석` workflow의 Java source 분석 범위는 줄이지 않는다.
- quality gate 기준을 낮추지 않는다.
- 업무 로직, 테스트 대상, Oracle 통합 테스트 흐름은 변경하지 않는다.

## diff map
- `.sonarcloud.properties`: 자동 분석 source exclusions에 coverage 제외 패턴을 포함.
- `RepositoryConventionsSmokeTest`: 자동 분석 source exclusions가 coverage exclusions를 포함하는지 검증.

## verification evidence
- `./gradlew test --tests 'com.github.marcellokim.issuetracker.setup.RepositoryConventionsSmokeTest.sonarCloudAutomaticAnalysisUsesTheSameCoverageExclusions' --console=plain`
- `git diff --check && ./gradlew check --console=plain`
- push 전 hook: `test + verifyRepositorySetup`

## reviewer focus areas
- `.sonarcloud.properties` 변경이 자동 분석 scope에만 적용되고, Gradle workflow의 full Java source analysis를 줄이지 않는지 확인.
- coverage 제외 정책과 자동 분석 source 제외 정책의 관계가 smoke test로 고정됐는지 확인.

## risk / rollback
자동 분석에서 UI/JDBC 런타임 코드가 source scope에서도 제외된다. 다만 Gradle SonarCloud workflow는 전체 Java source set을 계속 분석한다. 되돌리면 dev 브랜치의 SonarCloud GitHub App check가 다시 coverage gate에서 실패할 수 있다.