### PR TITLE
fix: 이슈 필수 필드 UI 표시 보완

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueDetailScreen.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueDetailScreen.java
@@ -10,9 +10,11 @@ import com.github.marcellokim.issuetracker.service.AssignmentCandidateResult;
 import com.github.marcellokim.issuetracker.service.AssignmentOptionsResult;
 import com.github.marcellokim.issuetracker.service.CommentResult;
 import com.github.marcellokim.issuetracker.service.DependencyResult;
+import com.github.marcellokim.issuetracker.service.HistoryResult;
 import com.github.marcellokim.issuetracker.service.IssueDetailResult;
 import com.github.marcellokim.issuetracker.service.IssueSummary;
 import com.github.marcellokim.issuetracker.service.UserResult;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -37,6 +39,7 @@ import javafx.util.StringConverter;
 
 final class IssueDetailScreen extends VBox {
 
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
     private final IssueController issueController;
     private final IssueStateController issueStateController;
     private final AssignmentController assignmentController;
@@ -77,6 +80,9 @@ final class IssueDetailScreen extends VBox {
 
             Label statusLabel = new Label(String.format("Status: %s | Priority: %s", detail.status(), detail.priority()));
             statusLabel.setStyle("-fx-font-size: 13px; -fx-text-fill: #444;");
+
+            Label reportedLabel = new Label("Reported: " + DATE_TIME_FORMATTER.format(detail.reportedDate()));
+            reportedLabel.setStyle("-fx-font-size: 13px; -fx-text-fill: #444;");
 
             Label descriptionLabel = new Label(detail.description());
             descriptionLabel.setWrapText(true);
@@ -129,15 +135,22 @@ final class IssueDetailScreen extends VBox {
 
             Label historyTitle = new Label("History (" + detail.histories().size() + " entries)");
             historyTitle.setStyle("-fx-font-size: 12px; -fx-text-fill: #888;");
+            ListView<String> historyListView = new ListView<>();
+            for (HistoryResult h : detail.histories()){
+                String entry = String.format("%s | %s | by %s", DATE_TIME_FORMATTER.format(h.changedDate()), h.actionType(), h.changedById());
+                if (h.previousValue() != null && h.newValue() != null) entry += String.format(" (%s → %s)", h.previousValue(), h.newValue());
+                historyListView.getItems().add(entry);
+            }
+            historyListView.setPrefHeight(Math.min(120, detail.histories().size() * 26 + 4));
 
-            VBox content = new VBox(8, titleLabel, statusLabel, new Separator(),
+            VBox content = new VBox(8, titleLabel, statusLabel, reportedLabel, new Separator(),
                     descriptionLabel, new Separator(),
                     peopleBox, new Separator(),
                     new Label("Available Actions:"), actionButtons, new Separator(),
                     commentsTitle, commentList,
                     blockedByTitle, blockedByListView,
                     blockingTitle, blockingListView,
-                    historyTitle, messageLabel);
+                    historyTitle, historyListView, messageLabel);
             javafx.scene.control.ScrollPane scrollPane = new javafx.scene.control.ScrollPane(content);
             scrollPane.setFitToWidth(true);
             VBox.setVgrow(scrollPane, javafx.scene.layout.Priority.ALWAYS);
@@ -489,7 +502,10 @@ final class IssueDetailScreen extends VBox {
             super.updateItem(comment, empty);
             if (empty || comment == null){ setText(null); setGraphic(null); return; }
             setText(null);
-            Label text = new Label(String.format("[%s] %s: %s", comment.purpose(), comment.writerLoginId(), comment.content()));
+            String commentDate = comment.createdDate().equals(comment.updatedDate())
+                    ? DATE_TIME_FORMATTER.format(comment.createdDate())
+                    : DATE_TIME_FORMATTER.format(comment.updatedDate()) + " (수정됨)";
+            Label text = new Label(String.format("[%s] %s (%s): %s", comment.purpose(), comment.writerLoginId(), commentDate, comment.content()));
             text.setWrapText(true);
             FlowPane buttons = new FlowPane(4, 0);
             if (editable.contains(comment.commentId())){

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueDetailScreen.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueDetailScreen.java
@@ -504,7 +504,7 @@ final class IssueDetailScreen extends VBox {
             setText(null);
             String commentDate = comment.createdDate().equals(comment.updatedDate())
                     ? DATE_TIME_FORMATTER.format(comment.createdDate())
-                    : DATE_TIME_FORMATTER.format(comment.updatedDate()) + " (수정됨)";
+                    : DATE_TIME_FORMATTER.format(comment.updatedDate()) + " (Edited)";
             Label text = new Label(String.format("[%s] %s (%s): %s", comment.purpose(), comment.writerLoginId(), commentDate, comment.content()));
             text.setWrapText(true);
             FlowPane buttons = new FlowPane(4, 0);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueListScreen.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/javafx/IssueListScreen.java
@@ -6,6 +6,7 @@ import com.github.marcellokim.issuetracker.domain.IssueStatus;
 import com.github.marcellokim.issuetracker.service.IssueSummary;
 import com.github.marcellokim.issuetracker.service.ProjectResult;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -25,6 +26,7 @@ import javafx.scene.layout.VBox;
 
 final class IssueListScreen extends VBox {
 
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
     private final IssueController issueController;
     private final long projectId;
     private final ListView<IssueSummary> issueList = new ListView<>();
@@ -227,8 +229,9 @@ final class IssueListScreen extends VBox {
             VBox box = new VBox(2);
             Label title = new Label(String.format("[%s] %s", ScreenComponents.shortIssueId(issue.issueId()), issue.title()));
             title.setStyle("-fx-font-size: 13px; -fx-font-weight: bold;");
-            Label info = new Label(String.format("%s | %s | reporter: %s",
-                    issue.status(), issue.priority(), issue.reporterId()));
+            Label info = new Label(String.format("%s | %s | reporter: %s | reported: %s",
+                    issue.status(), issue.priority(), issue.reporterId(),
+                    DATE_TIME_FORMATTER.format(issue.reportedDate())));
             info.setStyle("-fx-text-fill: #666; -fx-font-size: 11px;");
             box.getChildren().addAll(title, info);
             setGraphic(box);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
@@ -48,7 +48,7 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
     private static final int HISTORY_SECTION_HEIGHT = 170;
     private static final int DEPENDENCY_SECTION_HEIGHT = 180;
     private static final String[] COMMENT_COLUMNS = {
-            "ID", "Purpose", "Writer", "Content", "Updated", "Edit", "Delete"
+            "ID", "Purpose", "Writer", "Content", "Date", "Edit", "Delete"
     };
     private static final String[] HISTORY_COLUMNS = {
             "ID", "Action", "By", "Previous", "New", "Message", "Changed"
@@ -79,6 +79,7 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
     private final JLabel stateLabel = new JLabel(" ");
     private final JLabel userLabel;
     private final JLabel descriptionLabel = new JLabel(" ");
+    private final JLabel reportedDateLabel = new JLabel("Reported: -");
     private final JLabel reporterLabel = new JLabel("Reporter: -");
     private final JLabel assigneeLabel = new JLabel("Assignee: -");
     private final JLabel verifierLabel = new JLabel("Verifier: -");
@@ -145,6 +146,7 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
             currentTitle = detail.title();
             currentDescription = detail.description();
             currentPriority = detail.priority();
+            reportedDateLabel.setText("Reported: " + DATE_TIME_FORMATTER.format(detail.reportedDate()));
             reporterLabel.setText("Reporter: " + formatUser(detail.reporter()));
             assigneeLabel.setText("Assignee: " + formatUser(detail.assignee()));
             verifierLabel.setText("Verifier: " + formatUser(detail.verifier()));
@@ -247,7 +249,7 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
         section.add(descriptionLabel);
         section.add(Box.createVerticalStrut(SwingStyles.ROW_GAP));
 
-        for (JLabel label : List.of(reporterLabel, assigneeLabel, verifierLabel, fixerLabel, resolverLabel)) {
+        for (JLabel label : List.of(reportedDateLabel, reporterLabel, assigneeLabel, verifierLabel, fixerLabel, resolverLabel)) {
             label.setAlignmentX(Component.LEFT_ALIGNMENT);
             SwingStyles.applyMuted(label);
             section.add(label);
@@ -498,7 +500,9 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
                             comment.purpose(),
                             comment.writerLoginId(),
                             comment.content(),
-                            DATE_TIME_FORMATTER.format(comment.updatedDate()),
+                            comment.createdDate().equals(comment.updatedDate())
+                                    ? DATE_TIME_FORMATTER.format(comment.createdDate())
+                                    : DATE_TIME_FORMATTER.format(comment.updatedDate()) + " (수정됨)",
                             yesNo(state != null && state.canUpdate()),
                             yesNo(state != null && state.canDelete())
                     };

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueDetailPanel.java
@@ -502,7 +502,7 @@ final class IssueDetailPanel extends JPanel implements IssueDetailView {
                             comment.content(),
                             comment.createdDate().equals(comment.updatedDate())
                                     ? DATE_TIME_FORMATTER.format(comment.createdDate())
-                                    : DATE_TIME_FORMATTER.format(comment.updatedDate()) + " (수정됨)",
+                                    : DATE_TIME_FORMATTER.format(comment.updatedDate()) + " (Edited)",
                             yesNo(state != null && state.canUpdate()),
                             yesNo(state != null && state.canDelete())
                     };

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanel.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueListPanel.java
@@ -35,7 +35,7 @@ final class IssueListPanel extends JPanel implements IssueListView {
 
     private static final long serialVersionUID = 1L;
     private static final String[] ISSUE_COLUMNS = {
-            "ID", "Issue", "Status", "Priority", "Title", "Reporter", "Assignee", "Verifier", "Updated"
+            "ID", "Issue", "Status", "Priority", "Title", "Reporter", "Assignee", "Verifier", "Reported"
     };
     private static final int[] ISSUE_COLUMN_WIDTHS = {64, 96, 100, 92, 240, 112, 112, 112, 144};
     private static final Color SELECTION_BACKGROUND = new Color(219, 234, 254);

--- a/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueTableRows.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/ui/swing/IssueTableRows.java
@@ -33,7 +33,7 @@ final class IssueTableRows {
                 issue.reporterId(),
                 valueOrDash(issue.assigneeId()),
                 valueOrDash(issue.verifierId()),
-                DATE_TIME_FORMATTER.format(issue.updatedAt())
+                DATE_TIME_FORMATTER.format(issue.reportedDate())
         }));
         selectedIssueId.ifPresent(issueId -> restoreSelection(table, issueId));
     }


### PR DESCRIPTION
## 변경 내용

과제 명세의 필수 이슈 필드 중 화면에 노출되지 않던 항목을 UI에 표시합니다. 해당 데이터는 결과 DTO에 이미 존재하므로, 도메인·서비스·컨트롤러는 변경하지 않고 UI 렌더링만 추가했습니다.

- **Reported Date**: JavaFX/Swing 이슈 상세 및 목록에 표시
- **댓글 날짜**: 작성일을 표시하고, 수정된 댓글은 수정일과 함께 표시
- **변경 이력(History)**: JavaFX 이슈 상세에 이력 항목 표시 (Swing과 동일 범위)

## 변경 범위

UI 5개 파일 (BE 변경 없음)

- `ui/javafx/IssueDetailScreen.java`
- `ui/javafx/IssueListScreen.java`
- `ui/swing/IssueDetailPanel.java`
- `ui/swing/IssueListPanel.java`
- `ui/swing/IssueTableRows.java`

## 검증

- `./gradlew compileJava` 성공
- `./gradlew test` 전체 통과 (회귀 없음)

Closes #277