### PR TITLE
fix: RESOLVED/CLOSED 이슈에 의존성 추가 버튼이 비활성화되는 정책 위반

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/service/IssueWorkflowService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/IssueWorkflowService.java
@@ -56,7 +56,7 @@ public final class IssueWorkflowService {
                 canResolve(actor, issue, access),
                 canClose(actor, issue, access),
                 canReopen(actor, issue, access),
-                canAddDependency(issue, access),
+                canAddDependency(access),
                 canRemoveDependency(access),
                 canAddComment(actor, issue, access),
                 canSoftDelete(actor, issue, access));
@@ -188,10 +188,8 @@ public final class IssueWorkflowService {
                 && allows(() -> permissionPolicy.assertCanChangeStatus(actor, issue, IssueStatus.REOPENED));
     }
 
-    private static boolean canAddDependency(Issue issue, WorkflowAccess access) {
-        return access.canManageDependency()
-                && issue.status() != IssueStatus.RESOLVED
-                && issue.status() != IssueStatus.CLOSED;
+    private static boolean canAddDependency(WorkflowAccess access) {
+        return access.canManageDependency();
     }
 
     private static boolean canRemoveDependency(WorkflowAccess access) {

--- a/src/test/java/com/github/marcellokim/issuetracker/service/IssueWorkflowServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/IssueWorkflowServiceTest.java
@@ -115,10 +115,10 @@ class IssueWorkflowServiceTest {
         assertTrue(resolvedActions.canClose());
         assertTrue(resolvedActions.canReopen());
         assertFalse(resolvedActions.canSoftDelete());
-        assertFalse(resolvedActions.canAddDependency());
+        assertTrue(resolvedActions.canAddDependency());
         assertTrue(closedActions.canReopen());
         assertTrue(closedActions.canSoftDelete());
-        assertFalse(closedActions.canAddDependency());
+        assertTrue(closedActions.canAddDependency());
     }
 
     @Test


### PR DESCRIPTION
## 요약
- 작업 브랜치: `fix/282-add-dependency-closed-resolved`
- 관련 이슈: #282

## 검증
- `./gradlew check`

## 관련 이슈
- Closes #282