### PR TITLE
fix: keep previous resolver in reopened recommendations

### DIFF
--- a/src/main/java/com/github/marcellokim/issuetracker/service/AssignmentRecommendationService.java
+++ b/src/main/java/com/github/marcellokim/issuetracker/service/AssignmentRecommendationService.java
@@ -9,7 +9,6 @@ import com.github.marcellokim.issuetracker.domain.User;
 import com.github.marcellokim.issuetracker.repository.AssignmentRecommendationRepository;
 import com.github.marcellokim.issuetracker.repository.AssignmentRecommendationRepository.IssueRecommendationData;
 
-
 public final class AssignmentRecommendationService {
 
     private static final int MAX_CANDIDATES = 3;
@@ -17,60 +16,80 @@ public final class AssignmentRecommendationService {
     private final AssignmentRecommendationRepository recmmendationRepository;
     private final KNNAssignmentRecommendation knnEngine;
 
-    public AssignmentRecommendationService(AssignmentRecommendationRepository recmmendationRepository, KNNAssignmentRecommendation knnEngine) {
+    public AssignmentRecommendationService(AssignmentRecommendationRepository recmmendationRepository,
+            KNNAssignmentRecommendation knnEngine) {
         this.recmmendationRepository = Objects.requireNonNull(recmmendationRepository, "recmmendationRepository");
         this.knnEngine = Objects.requireNonNull(knnEngine, "knnEngine");
     }
 
-    public AssignmentOptionsResult recommendAssignmentCandidates(Issue issue){
+    public AssignmentOptionsResult recommendAssignmentCandidates(Issue issue) {
         Issue targetIssue = Objects.requireNonNull(issue, "issue");
         List<User> activeDevUsers = recmmendationRepository.findActiveDevCandidates(targetIssue.projectId());
         List<User> activeTesterUsers = recmmendationRepository.findActiveTesterCandidates(targetIssue.projectId());
         List<AssignmentCandidateResult> allActiveDevs = toActiveResults(activeDevUsers);
         List<AssignmentCandidateResult> allActiveTesters = toActiveResults(activeTesterUsers);
-        return switch(targetIssue.status()) {
+        return switch (targetIssue.status()) {
             case NEW -> options(
-                findAllDevAssigneeCandidateDetails(targetIssue, activeDevUsers),
-                findAllTesterVerifierCandidateDetails(targetIssue, activeTesterUsers),
-                allActiveDevs, allActiveTesters);
+                    findAllDevAssigneeCandidateDetails(targetIssue, activeDevUsers),
+                    findAllTesterVerifierCandidateDetails(targetIssue, activeTesterUsers),
+                    allActiveDevs, allActiveTesters);
             case REOPENED -> {
                 List<AssignmentCandidateResult> devCandidates = new ArrayList<>();
                 User fixer = findActiveUser(activeDevUsers, targetIssue.fixerId());
-                if (fixer != null){
+                if (fixer != null) {
                     devCandidates.add(new AssignmentCandidateResult(fixer.getLoginId(),
-                    fixer.getName(), fixer.getRole(), 0, "fixed lastly"));
+                            fixer.getName(), fixer.getRole(), 0, "fixed lastly"));
                 }
-                for (AssignmentCandidateResult c : findAllDevAssigneeCandidateDetails(targetIssue, activeDevUsers)){
-                    if (c.loginId().equals(targetIssue.fixerId()) == false){ devCandidates.add(c); }
+                for (AssignmentCandidateResult c : findAllDevAssigneeCandidateDetails(targetIssue, activeDevUsers)) {
+                    if (c.loginId().equals(targetIssue.fixerId()) == false) {
+                        devCandidates.add(c);
+                    }
                 }
-                yield options(devCandidates, findAllTesterVerifierCandidateDetails(targetIssue, activeTesterUsers),
-                    allActiveDevs, allActiveTesters);
+                List<AssignmentCandidateResult> testerCandidates = new ArrayList<>();
+                User resolver = findActiveUser(activeTesterUsers, targetIssue.resolverId());
+                if (resolver != null) {
+                    testerCandidates.add(new AssignmentCandidateResult(resolver.getLoginId(),
+                            resolver.getName(), resolver.getRole(), 0, "resolved lastly"));
+                }
+                for (AssignmentCandidateResult c : findAllTesterVerifierCandidateDetails(targetIssue,
+                        activeTesterUsers)) {
+                    if (c.loginId().equals(targetIssue.resolverId()) == false) {
+                        testerCandidates.add(c);
+                    }
+                }
+                yield options(devCandidates, testerCandidates,
+                        allActiveDevs, allActiveTesters);
             }
             case ASSIGNED -> {
                 List<AssignmentCandidateResult> devCandidates = new ArrayList<>();
                 User assignee = findActiveUser(activeDevUsers, targetIssue.assigneeId());
-                if (assignee != null){
+                if (assignee != null) {
                     devCandidates.add(new AssignmentCandidateResult(assignee.getLoginId(),
-                    assignee.getName(), assignee.getRole(), 0, "current assignee"));
+                            assignee.getName(), assignee.getRole(), 0, "current assignee"));
                 }
-                for (AssignmentCandidateResult c : findAllDevAssigneeCandidateDetails(targetIssue, activeDevUsers)){
-                    if (c.loginId().equals(targetIssue.assigneeId()) == false){ devCandidates.add(c); }
+                for (AssignmentCandidateResult c : findAllDevAssigneeCandidateDetails(targetIssue, activeDevUsers)) {
+                    if (c.loginId().equals(targetIssue.assigneeId()) == false) {
+                        devCandidates.add(c);
+                    }
                 }
                 yield options(devCandidates, List.of(),
-                    allActiveDevs, allActiveTesters);
+                        allActiveDevs, allActiveTesters);
             }
             case FIXED -> {
                 List<AssignmentCandidateResult> testerCandidates = new ArrayList<>();
                 User verifier = findActiveUser(activeTesterUsers, targetIssue.verifierId());
-                if (verifier != null){
+                if (verifier != null) {
                     testerCandidates.add(new AssignmentCandidateResult(verifier.getLoginId(),
-                    verifier.getName(), verifier.getRole(), 0, "current verifier"));
+                            verifier.getName(), verifier.getRole(), 0, "current verifier"));
                 }
-                for (AssignmentCandidateResult c : findAllTesterVerifierCandidateDetails(targetIssue, activeTesterUsers)){
-                    if (c.loginId().equals(targetIssue.verifierId()) == false){ testerCandidates.add(c); }
+                for (AssignmentCandidateResult c : findAllTesterVerifierCandidateDetails(targetIssue,
+                        activeTesterUsers)) {
+                    if (c.loginId().equals(targetIssue.verifierId()) == false) {
+                        testerCandidates.add(c);
+                    }
                 }
                 yield options(List.of(), testerCandidates,
-                    allActiveDevs, allActiveTesters);
+                        allActiveDevs, allActiveTesters);
             }
             default -> throw new IllegalStateException("Unsupported issue status");
         };
@@ -88,49 +107,58 @@ public final class AssignmentRecommendationService {
                 allActiveTesters);
     }
 
-    private List<AssignmentCandidateResult> findAllDevAssigneeCandidateDetails(Issue issue, List<User> activeDevUsers){
+    private List<AssignmentCandidateResult> findAllDevAssigneeCandidateDetails(Issue issue, List<User> activeDevUsers) {
         Objects.requireNonNull(issue, "issue");
-        List<IssueRecommendationData> searchedField = recmmendationRepository.findResolvedIssuesForRecommendation(issue.projectId());
-        List<KNNAssignmentRecommendation.UserRecord> recommendationRecordForCalculation =
-        searchedField.stream()
-        .filter(i -> i.fixerLoginId() != null)
-        .map(j -> new KNNAssignmentRecommendation.UserRecord(j.title(), j.description(), j.fixerLoginId())).toList();
-        List<String> recommendedAssignees = knnEngine.calculateRecomendation(issue.title(), issue.description(), recommendationRecordForCalculation);
-        return toCandidateResults(recommendedAssignees, recommendationRecordForCalculation, activeDevUsers, "recommended by similarity");
+        List<IssueRecommendationData> searchedField = recmmendationRepository
+                .findResolvedIssuesForRecommendation(issue.projectId());
+        List<KNNAssignmentRecommendation.UserRecord> recommendationRecordForCalculation = searchedField.stream()
+                .filter(i -> i.fixerLoginId() != null)
+                .map(j -> new KNNAssignmentRecommendation.UserRecord(j.title(), j.description(), j.fixerLoginId()))
+                .toList();
+        List<String> recommendedAssignees = knnEngine.calculateRecomendation(issue.title(), issue.description(),
+                recommendationRecordForCalculation);
+        return toCandidateResults(recommendedAssignees, recommendationRecordForCalculation, activeDevUsers,
+                "recommended by similarity");
     }
 
-    private List<AssignmentCandidateResult> findAllTesterVerifierCandidateDetails(Issue issue, List<User> activeTesterUsers){
+    private List<AssignmentCandidateResult> findAllTesterVerifierCandidateDetails(Issue issue,
+            List<User> activeTesterUsers) {
         Objects.requireNonNull(issue, "issue");
-        List<IssueRecommendationData> searchedField = recmmendationRepository.findResolvedIssuesForRecommendation(issue.projectId());
-        List<KNNAssignmentRecommendation.UserRecord> recommendationRecordForCalculation =
-        searchedField.stream()
-        .filter(i -> i.resolverLoginId() != null)
-        .map(j -> new KNNAssignmentRecommendation.UserRecord(j.title(), j.description(), j.resolverLoginId())).toList();
-        List<String> recommendedVerifiers = knnEngine.calculateRecomendation(issue.title(), issue.description(), recommendationRecordForCalculation);
-        return toCandidateResults(recommendedVerifiers, recommendationRecordForCalculation, activeTesterUsers, "recommended by similarity");
+        List<IssueRecommendationData> searchedField = recmmendationRepository
+                .findResolvedIssuesForRecommendation(issue.projectId());
+        List<KNNAssignmentRecommendation.UserRecord> recommendationRecordForCalculation = searchedField.stream()
+                .filter(i -> i.resolverLoginId() != null)
+                .map(j -> new KNNAssignmentRecommendation.UserRecord(j.title(), j.description(), j.resolverLoginId()))
+                .toList();
+        List<String> recommendedVerifiers = knnEngine.calculateRecomendation(issue.title(), issue.description(),
+                recommendationRecordForCalculation);
+        return toCandidateResults(recommendedVerifiers, recommendationRecordForCalculation, activeTesterUsers,
+                "recommended by similarity");
     }
 
     private static List<AssignmentCandidateResult> toCandidateResults(
             List<String> userIds,
             List<KNNAssignmentRecommendation.UserRecord> records,
             List<User> activeCandidateUsers,
-            String reason){
+            String reason) {
         List<AssignmentCandidateResult> results = new ArrayList<>();
-        for (String userId : userIds){
+        for (String userId : userIds) {
             User user = findActiveUser(activeCandidateUsers, userId);
-            if (user != null){
+            if (user != null) {
                 int count = (int) records.stream().filter(r -> r.userId().equals(userId)).count();
                 results.add(new AssignmentCandidateResult(
-                    userId, user.getName(), user.getRole(), count, reason));
+                        userId, user.getName(), user.getRole(), count, reason));
             }
         }
         return results;
     }
 
-    private static User findActiveUser(List<User> activeUsers, String loginId){
-        if (loginId == null) return null;
-        for (User user : activeUsers){
-            if (user.getLoginId().equals(loginId)) return user;
+    private static User findActiveUser(List<User> activeUsers, String loginId) {
+        if (loginId == null)
+            return null;
+        for (User user : activeUsers) {
+            if (user.getLoginId().equals(loginId))
+                return user;
         }
         return null;
     }
@@ -139,7 +167,7 @@ public final class AssignmentRecommendationService {
         List<AssignmentCandidateResult> results = new ArrayList<>();
         for (User user : activeUsers) {
             results.add(new AssignmentCandidateResult(
-                user.getLoginId(), user.getName(), user.getRole(), 0, ""));
+                    user.getLoginId(), user.getName(), user.getRole(), 0, ""));
         }
         return results;
     }

--- a/src/test/java/com/github/marcellokim/issuetracker/service/AssignmentRecommendationServiceTest.java
+++ b/src/test/java/com/github/marcellokim/issuetracker/service/AssignmentRecommendationServiceTest.java
@@ -49,6 +49,52 @@ class AssignmentRecommendationServiceTest {
         }
 
         @Test
+        @DisplayName("reopened issue puts old resolver first")
+        void oldResolverComesFirst() {
+                User dev2 = user("dev2", Role.DEV);
+                User tester2 = user("tester2", Role.TESTER);
+                InMemoryAssignmentRecommendationRepository repo = new InMemoryAssignmentRecommendationRepository(dev1,
+                                dev2, tester1, tester2)
+                                .withResolvedIssues(
+                                                recommendationData("login error", "login page crash", "dev2",
+                                                                "tester1"),
+                                                recommendationData("login timeout", "login page timeout", "dev1",
+                                                                "tester2"));
+                AssignmentRecommendationService svc = new AssignmentRecommendationService(repo,
+                                new KNNAssignmentRecommendation());
+
+                AssignmentOptionsResult options = svc.recommendAssignmentCandidates(reopenedLoginIssue());
+
+                assertEquals("tester1", options.testerVerifierCandidates().get(0).loginId());
+                assertEquals("resolved lastly", options.testerVerifierCandidates().get(0).reason());
+                assertEquals("tester2", options.testerVerifierCandidates().get(1).loginId());
+                assertEquals(2, options.testerVerifierCandidates().size());
+                assertEquals(2, options.testerVerifierCandidates().stream()
+                                .map(AssignmentCandidateResult::loginId)
+                                .distinct()
+                                .count());
+        }
+
+        @Test
+        @DisplayName("reopened issue skips inactive old resolver")
+        void inactiveOldResolverIsSkipped() {
+                User inactiveResolver = User.fromPersistence("tester1", "tester1", "hash", Role.TESTER, false, null,
+                                null);
+                User tester2 = user("tester2", Role.TESTER);
+                InMemoryAssignmentRecommendationRepository repo = new InMemoryAssignmentRecommendationRepository(dev1,
+                                inactiveResolver, tester2)
+                                .withResolvedIssues(recommendationData("login timeout", "login page timeout", "dev1",
+                                                "tester2"));
+                AssignmentRecommendationService svc = new AssignmentRecommendationService(repo,
+                                new KNNAssignmentRecommendation());
+
+                AssignmentOptionsResult options = svc.recommendAssignmentCandidates(reopenedLoginIssue());
+
+                assertEquals("tester2", options.testerVerifierCandidates().get(0).loginId());
+                assertTrue(options.testerVerifierCandidates().stream().noneMatch(c -> c.loginId().equals("tester1")));
+        }
+
+        @Test
         @DisplayName("assigned issue only needs a dev")
         void assignedIssueNeedsDev() {
                 AssignmentOptionsResult options = service.recommendAssignmentCandidates(issue(IssueStatus.ASSIGNED));
@@ -145,6 +191,19 @@ class AssignmentRecommendationServiceTest {
                                                 .reportedDate(NOW)
                                                 .priority(Priority.MAJOR)
                                                 .status(IssueStatus.NEW)
+                                                .updatedAt(NOW));
+        }
+
+        private static Issue reopenedLoginIssue() {
+                return Issue.fromPersistence(
+                                Issue.persistedState(1L, "login error page", "login crash", user("tester1", Role.TESTER))
+                                                .id(3L)
+                                                .issueId("ISSUE-3")
+                                                .reportedDate(NOW)
+                                                .priority(Priority.MAJOR)
+                                                .status(IssueStatus.REOPENED)
+                                                .fixer(user("dev1", Role.DEV))
+                                                .resolver(user("tester1", Role.TESTER))
                                                 .updatedAt(NOW));
         }
 


### PR DESCRIPTION
Summary: Keep the previous resolver as the first tester candidate when a REOPENED issue is assigned again, while preserving the existing fixer-first Dev recommendation behavior and KNN fallback candidates. Verification: targeted assignment recommendation tests passed; .\gradlew.bat check --console=plain passed. Closes #289